### PR TITLE
Clusters view

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ As an example, check the [meta-data file][./examples/trento-config.json] file. T
 located in the folder set as `-config-dir` during the agent execution.
 
 The next items are reserved:
+- `trento-ha-cluster`: Cluster which the system belongs to
 - `trento-sap-environment`: Environment in which the system is running
 - `trento-sap-landscape`: Landscape in which the system is running
 - `trento-sap-environment`: SAP system (composed by database and application) in which the system is running
@@ -83,6 +84,7 @@ These reserved tags can be automatically set and updated using the [consul-templ
 To achieve this, the tags information will come from the KV storage.
 
 Set the metadata in the next paths:
+- `trento/nodename/metadata/ha-cluster`
 - `trento/nodename/metadata/sap-environment`
 - `trento/nodename/metadata/sap-landscape`
 - `trento/nodename/metadata/sap-system`

--- a/examples/trento-config.json
+++ b/examples/trento-config.json
@@ -1,5 +1,6 @@
 {
   "metadata": {
+    "trento-ha-cluster": "cluster1",
     "trento-sap-environment": "env1",
     "trento-sap-landscape": "land1",
     "trento-sap-system": "sys1"

--- a/web/app.go
+++ b/web/app.go
@@ -55,6 +55,9 @@ func NewAppWithDeps(host string, port int, deps Dependencies) (*App, error) {
 	engine.GET("/environments", NewEnvironmentsListHandler(deps.consul))
 	engine.GET("/environments/:name", NewEnvironmentHandler(deps.consul))
 	engine.GET("/environments/:name/checks/:checkid", NewCheckHandler(deps.consul))
+	engine.GET("/clusters", NewClustersListHandler(deps.consul))
+	engine.GET("/clusters/:name", NewClusterHandler(deps.consul))
+
 	apiGroup := engine.Group("/api")
 	{
 		apiGroup.GET("/ping", ApiPingHandler)

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -1,0 +1,111 @@
+package web
+
+import (
+	"fmt"
+	//"log"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	//consulApi "github.com/hashicorp/consul/api"
+	"github.com/pkg/errors"
+
+	"github.com/trento-project/trento/internal/consul"
+)
+
+const KV_CLUSTERS_PATH string = "trento/clusters"
+
+type Cluster struct {
+	Name string
+}
+
+type ClusterList map[string]*Cluster
+
+func NewClustersListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clusters, err := loadClusters(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "clusters.html.tmpl", gin.H{
+			"Clusters": clusters,
+		})
+	}
+}
+
+func loadClusters(client consul.Client) (ClusterList, error) {
+	var clusters = ClusterList{}
+
+	entries, _, err := client.KV().List(KV_CLUSTERS_PATH, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not query Consul for Cluster KV values")
+	}
+
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Key, "clusters/") {
+			continue
+		}
+
+		key_values := strings.Split(entry.Key, "/")
+
+		if strings.HasSuffix(entry.Key, "/") {
+			// 2 is used as Split creates a last empty entry
+			last_key := key_values[len(key_values)-2]
+			clusters[last_key] = &Cluster{}
+			continue
+		}
+
+		cluster_id := key_values[len(key_values)-2]
+		key := key_values[len(key_values)-1]
+		// This could be done with a more automatic way in the future when we define the
+		// Cluster and KV structure
+		switch key {
+		case "name":
+			clusters[cluster_id].Name = string(entry.Value)
+		}
+
+	}
+	return clusters, nil
+}
+
+func NewClusterHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var cluster = Cluster{}
+
+		cluster_name := c.Param("name")
+
+		cluster_data, _, err := client.KV().List(fmt.Sprintf("%s/%s", KV_CLUSTERS_PATH, cluster_name), nil)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		for _, entry := range cluster_data {
+			if strings.HasSuffix(entry.Key, "/") {
+				continue
+			}
+
+			key_values := strings.Split(entry.Key, "/")
+			key := key_values[len(key_values)-1]
+			// This could be done with a more automatic way in the future when we define the
+			// Cluster and KV structure
+			switch key {
+			case "name":
+				cluster.Name = string(entry.Value)
+			}
+		}
+
+		environments, err := loadEnvironments(client, fmt.Sprintf("Meta[\"trento-ha-cluster\"] == \"%s\"", cluster_name), nil)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "cluster.html.tmpl", gin.H{
+			"Cluster":      cluster,
+			"Environments": environments,
+		})
+	}
+}

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -78,17 +78,17 @@ func loadClusters(client consul.Client, cluster_name string) (ClusterList, error
 		cluster_id := key_values[len(key_values)-2]
 
 		if strings.HasSuffix(entry.Key, "/") {
-			clusters[cluster_id] = &Cluster{}
+			clusters[cluster_id] = &Cluster{Name: cluster_id}
 			continue
 		}
 
-		value := key_values[len(key_values)-1]
+		//value := key_values[len(key_values)-1]
 		// This could be done with a more automatic way in the future when we define the
 		// Cluster and KV structure
-		switch value {
-		case "name":
-			clusters[cluster_id].Name = string(entry.Value)
-		}
+		//switch value {
+		//case "name":
+		//	clusters[cluster_id].Name = string(entry.Value)
+		//}
 
 	}
 	return clusters, nil

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -1,0 +1,71 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	consulApi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/tdewolff/minify/v2"
+	"github.com/tdewolff/minify/v2/html"
+	"github.com/trento-project/trento/internal/consul/mocks"
+)
+
+func TestClustersListHandler(t *testing.T) {
+	clusters := consulApi.KVPairs{
+		&consulApi.KVPair{
+			Key: "trento/clusters/",
+		},
+		&consulApi.KVPair{
+			Key: "trento/clusters/cluster1/",
+		},
+		&consulApi.KVPair{
+			Key: "trento/clusters/cluster2/",
+		},
+	}
+
+	consul := new(mocks.Client)
+	kv := new(mocks.KV)
+
+	consul.On("KV").Return(kv)
+
+	kv.On("List", "trento/clusters/", (*consulApi.QueryOptions)(nil)).Return(clusters, nil, nil)
+
+	deps := DefaultDependencies()
+	deps.consul = consul
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/clusters", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app.ServeHTTP(resp, req)
+
+	consul.AssertExpectations(t)
+	kv.AssertExpectations(t)
+
+	m := minify.New()
+	m.AddFunc("text/html", html.Minify)
+	m.Add("text/html", &html.Minifier{
+		KeepDefaultAttrVals: true,
+		KeepEndTags:         true,
+	})
+	minified, err := m.String("text/html", resp.Body.String())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, 200, resp.Code)
+	assert.Contains(t, minified, "Clusters")
+	assert.Regexp(t, regexp.MustCompile("<td>cluster1</td><td>2</td><td>4</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td>cluster2</td><td>2</td><td>4</td><td>.*passing.*</td>"), minified)
+}

--- a/web/environments.go
+++ b/web/environments.go
@@ -211,13 +211,19 @@ func loadHealthChecks(client consul.Client, node string) ([]*consulApi.HealthChe
 func NewEnvironmentHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
+		catalogNode, _, err := client.Catalog().Node(name, nil)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
 		checks, err := loadHealthChecks(client, name)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
 		c.HTML(http.StatusOK, "environment.html.tmpl", gin.H{
-			"NodeName":     name,
+			"Node":         &Node{*catalogNode.Node, client},
 			"HealthChecks": checks,
 		})
 	}

--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -21,3 +21,16 @@ tr.clickable {
 .show-white-space {
     white-space: pre-wrap;
 }
+
+dl.inline dd {
+  display: inline;
+  margin: 0;
+}
+dl.inline dd:after{
+  display: block;
+  content: '';
+}
+dl.inline dt{
+  display: inline-block;
+  min-width: 100px;
+}

--- a/web/templates/blocks/nodes_table.html.tmpl
+++ b/web/templates/blocks/nodes_table.html.tmpl
@@ -1,0 +1,41 @@
+{{ define "nodes_table" }}
+<div class='table-responsive'>
+    <table class='table eos-table'>
+        <thead>
+            <tr>
+                <th scope='col'>Name</th>
+                <th scope='col'>Datacenter</th>
+                <th scope='col'>Address</th>
+                <th scope='col'>Cluster</th>
+                <th scope='col'>Tags</th>
+                <th scope='col'>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{- range .Environments }}
+            {{- $Datacenter := .Name }}
+            {{- range .Nodes }}
+            <tr class='clickable' onclick="window.location='/environments/{{ .Name }}'">
+                <td>{{ .Name }}</td>
+                <td>{{ $Datacenter }}</td>
+                <td>{{ .Address }}</td>
+                <td><a href="/clusters/{{ index .TrentoMeta "trento-ha-cluster" }}">{{ index .TrentoMeta "trento-ha-cluster" }}</a></td>
+                <td>
+                    {{- range $Key, $Value := .TrentoMeta }}
+                    {{- if eq $Key "trento-ha-cluster" }}
+                    {{- else }}
+                    <span class='badge badge-pill badge-info'>{{ $Value }}</span>
+                    {{- end }}
+                    {{- end }}
+                </td>
+                <td>
+                    {{- $Health := .Health }}
+                    <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }}</span>
+                </td>
+            </tr>
+            {{- end }}
+            {{- end }}
+        </tbody>
+    </table>
+</div>
+{{ end }}

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -23,6 +23,10 @@
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Environments</span>
           </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/clusters">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">Clusters</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/web/templates/cluster.html.tmpl
+++ b/web/templates/cluster.html.tmpl
@@ -6,11 +6,42 @@
       <dt class="inline">Name</dt>
       <dd class="inline">{{ .Cluster.Name }}</dd>
       <dt class="inline">Nodes number</dt>
-      <dd class="inline">2</a></dd>
+      <dd class="inline">{{ len .Environments  }}</a></dd>
       <dt class="inline">Resource number</dt>
       <dd class="inline">4</a></dd>
     </dl>
     <h2>Nodes</h2>
     {{ template "nodes_table" . }}
+    <hr/>
+    <p class='clearfix'/>
+    <h2>Resources</h2>
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+                <tr>
+                    <th scope='col'>test</th>
+                    <th scope='col'>test2</th>
+                </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td><span class='badge badge-pill badge-primary'>rsc_ip_PRD_HDB00</span></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><span class='badge badge-pill badge-primary'>rsc_SAPHana_PRD_HDB00</span></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td><span class='badge badge-pill badge-primary'>rsc_SAPHanaTopology_PRD_HDB00</span></td>
+                <td></td>
+              </tr>
+              <tr>
+                <td></td>
+                <td><span class='badge badge-pill badge-primary'>rsc_SAPHanaTopology_PRD_HDB00</span></td>
+              </tr>
+            </tbody>
+        </table>
+    </div>
 </div>
 {{- end }}

--- a/web/templates/cluster.html.tmpl
+++ b/web/templates/cluster.html.tmpl
@@ -1,0 +1,16 @@
+{{ define "content" }}
+<div class="col">
+    <h1><a href="/clusters">Clusters</a> > {{ .Cluster.Name }}</h1>
+    <h2>Cluster details</h2>
+    <dl class="inline">
+      <dt class="inline">Name</dt>
+      <dd class="inline">{{ .Cluster.Name }}</dd>
+      <dt class="inline">Nodes number</dt>
+      <dd class="inline">2</a></dd>
+      <dt class="inline">Resource number</dt>
+      <dd class="inline">4</a></dd>
+    </dl>
+    <h2>Nodes</h2>
+    {{ template "nodes_table" . }}
+</div>
+{{- end }}

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -1,0 +1,29 @@
+{{ define "content" }}
+<div class="col">
+    <h1>Clusters</h1>
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+                <tr>
+                    <th scope='col'>Name</th>
+                    <th scope='col'>Nodes number</th>
+                    <th scope='col'>Resource number</th>
+                    <th scope='col'>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .Clusters }}
+                <tr class='clickable' onclick="window.location='/clusters/{{ .Name }}'">
+                    <td>{{ .Name }}</td>
+                    <td>2</td>
+                    <td>4</td>
+                    <td>
+                        <span class='badge badge-pill badge-primary'>passing</span>
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{ end }}

--- a/web/templates/environment.html.tmpl
+++ b/web/templates/environment.html.tmpl
@@ -1,6 +1,16 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/environments">Environments</a> > {{ .NodeName }}</h1>
+    <h1><a href="/environments">Environments</a> > {{ .Node.Name }}</h1>
+    <h2>Node details</h2>
+    <dl class="inline">
+      <dt class="inline">Name</dt>
+      <dd class="inline">{{ .Node.Name }}</dd>
+      <dt class="inline">Cluster</dt>
+      <dd class="inline"><a href="/clusters/{{ index .Node.TrentoMeta "trento-ha-cluster" }}">{{ index .Node.TrentoMeta "trento-ha-cluster" }}</a></dd>
+    </dl>
+    <hr/>
+    <p class='clearfix'/>
+    <h2>Checks</h2>
     <div class='table-responsive'>
         <table class='table eos-table'>
             <thead>

--- a/web/templates/environments.html.tmpl
+++ b/web/templates/environments.html.tmpl
@@ -45,39 +45,6 @@
     </div>
     <hr/>
     <p class='clearfix'/>
-    <div class='table-responsive'>
-        <table class='table eos-table'>
-            <thead>
-                <tr>
-                    <th scope='col'>Name</th>
-                    <th scope='col'>Datacenter</th>
-                    <th scope='col'>Address</th>
-                    <th scope='col'>Tags</th>
-                    <th scope='col'>Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{- range .Environments }}
-                {{- $Datacenter := .Name }}
-                {{- range .Nodes }}
-                <tr class='clickable' onclick="window.location='/environments/{{ .Name }}'">
-                    <td>{{ .Name }}</td>
-                    <td>{{ $Datacenter }}</td>
-                    <td>{{ .Address }}</td>
-                    <td>
-                        {{- range $Key, $Value := .TrentoMeta }}
-                        <span class='badge badge-pill badge-info'>{{ $Value }}</span>
-                        {{- end }}
-                    </td>
-                    <td>
-                        {{- $Health := .Health }}
-                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }}</span>
-                    </td>
-                </tr>
-                {{- end }}
-                {{- end }}
-            </tbody>
-        </table>
-    </div>
+    {{ template "nodes_table" . }}
 </div>
 {{ end }}


### PR DESCRIPTION
New `clusters` views. This views show the information about existing clusters and the nodes on them. Some data is hardcoded to make it more realistic (Nodes number, resources number, some resources in the cluster level).

In order to get this the value comes from the `kv` storage. This are the paths
`trento/clusters/${clusterName}/` (**clusterName is still a folder. It will store the cluster information when it is available).

Besides this, the node metadata stores the cluster which this nodes belongs to (`trento-ha-cluster`). The nodes of the cluster are obtained using this metadata filter. This metadata is obtained from the `kv` value storage (`trento/nodes/$node/metadata/ha-cluster`)

Pics:
![image](https://user-images.githubusercontent.com/36370954/115197996-e2595580-a0f1-11eb-9b96-db36a1b4b7c5.png)
![image](https://user-images.githubusercontent.com/36370954/115198033-eb4a2700-a0f1-11eb-8380-56065e9d8d84.png)
![image](https://user-images.githubusercontent.com/36370954/115198080-f7ce7f80-a0f1-11eb-8265-ffee64ffb301.png)
![image](https://user-images.githubusercontent.com/36370954/115198109-fef58d80-a0f1-11eb-8876-c070aa58b5a4.png)
