### PR TITLE
feature: agent: several yaml files can be specified

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -35,7 +35,7 @@ type Config struct {
 	WebPort             int
 	ServiceName         string
 	InstanceName        string
-	DefinitionsPath     string
+	DefinitionsPaths    []string
 	DiscoverInterval    time.Duration
 	TemplateSource      string
 	TemplateDestination string
@@ -57,7 +57,7 @@ func NewWithConfig(cfg Config) (*Agent, error) {
 		return nil, errors.Wrap(err, "could not create a Consul client")
 	}
 
-	checker, err := NewChecker(cfg.DefinitionsPath)
+	checker, err := NewChecker(cfg.DefinitionsPaths)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not create a Checker instance")
 	}

--- a/agent/checker.go
+++ b/agent/checker.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"strconv"
+	"strings"
 
 	"github.com/aquasecurity/bench-common/check"
 	"github.com/pkg/errors"
@@ -12,15 +14,46 @@ import (
 
 type Checker func() (CheckResult, error)
 
-func NewChecker(definitionsPath string) (Checker, error) {
-	data, err := ioutil.ReadFile(definitionsPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not read definitions file")
+/* Remove
+  '---
+   controls:
+	version: ...
+	id: ...
+	description: ...
+	type: ...
+	groups:
+'
+that comes before '    - id:...'
+You need to do it to append the yaml to another yaml file
+*/
+func trim_yaml_header(yaml_text string) string {
+	pattern := "\ngroups:"
+	index := strings.Index(yaml_text, pattern)
+	if index == -1 {
+		log.Fatal("the yaml file doesn't contain the 'id:' field and is possibly broken")
 	}
+	index += len(pattern)
+	return yaml_text[index:]
+}
 
+func NewChecker(definitionsPaths []string) (Checker, error) {
+	var data [][]byte
+	for _, path := range definitionsPaths {
+		datum, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not read definitions file")
+		}
+		data = append(data, datum)
+	}
 	return func() (CheckResult, error) {
-		result := CheckResult{}
-		controls, err := check.NewControls(data, nil)
+		var result CheckResult
+		first_yaml_file := string(data[0])
+		// Appent all next files to the first
+		for _, datum := range data[1:] {
+			first_yaml_file += trim_yaml_header(string(datum))
+		}
+
+		controls, err := check.NewControls([]byte(first_yaml_file), nil)
 		if err != nil {
 			return result, errors.Wrap(err, "could not parse definitions file")
 		}
@@ -38,11 +71,28 @@ type CheckResult struct {
 }
 
 func (cr *CheckResult) CheckPrettyPrint(sw io.StringWriter) {
-	sw.WriteString("== Summary ==\n")
-	sw.WriteString(strconv.Itoa(cr.controls.Summary.Pass) + " checks PASS\n")
-	sw.WriteString(strconv.Itoa(cr.controls.Summary.Fail) + " checks FAIL\n")
-	sw.WriteString(strconv.Itoa(cr.controls.Summary.Warn) + " checks WARN\n")
-	sw.WriteString(strconv.Itoa(cr.controls.Summary.Info) + " checks INFO\n")
+	// 1) Print descriptions
+	controls := cr.controls
+	remedations := ""
+	sw.WriteString("[INFO] " + controls.ID + " " + controls.Description + "\n")
+	for _, group := range controls.Groups {
+		sw.WriteString("[INFO] " + group.ID + " " + group.Description + "\n")
+		for _, check := range group.Checks {
+			sw.WriteString("[" + string(check.State) + "] " + check.ID + " " + check.Description + "\n")
+			if string(check.State) == "FAIL" {
+				remedations += check.ID + " " + check.Remediation + "\n"
+			}
+		}
+	}
+	// 2) Print remedations
+	sw.WriteString("\n== Remedations ==\n" + remedations)
+
+	// 3) Print the summary
+	sw.WriteString("\n== Summary ==\n")
+	sw.WriteString(strconv.Itoa(controls.Summary.Pass) + " checks PASS\n")
+	sw.WriteString(strconv.Itoa(controls.Summary.Fail) + " checks FAIL\n")
+	sw.WriteString(strconv.Itoa(controls.Summary.Warn) + " checks WARN\n")
+	sw.WriteString(strconv.Itoa(controls.Summary.Info) + " checks INFO\n")
 }
 
 func (r CheckResult) Summary() check.Summary {

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -60,7 +60,7 @@ func NewAgentCmd() *cobra.Command {
 func runOnce(cmd *cobra.Command, args []string) {
 	var err error
 
-	checker, err := agent.NewChecker(args[0])
+	checker, err := agent.NewChecker(args)
 	if err != nil {
 		log.Fatal("Failed to create a Checker instance: ", err)
 	}
@@ -84,7 +84,7 @@ func start(cmd *cobra.Command, args []string) {
 		log.Fatal("Failed to create the agent configuration: ", err)
 	}
 
-	cfg.DefinitionsPath = args[0]
+	cfg.DefinitionsPaths = args
 	cfg.ServiceName = serviceName
 	cfg.WebPort = port
 	cfg.CheckerTTL = TTL
@@ -112,21 +112,21 @@ func start(cmd *cobra.Command, args []string) {
 }
 
 func startArgsValidator(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("accepts exactly 1 argument, received %d", len(args))
+	if len(args) == 0 {
+		return fmt.Errorf("please specify at least one configuration yaml file")
 	}
 
-	definitionsPath := args[0]
-
-	info, err := os.Lstat(definitionsPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("unable to find file %q", definitionsPath)
+	for _, definitionsPath := range args {
+		info, err := os.Lstat(definitionsPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("unable to find file %q", definitionsPath)
+			}
+			return fmt.Errorf("error when running os.Lstat(%q): %s", definitionsPath, err)
 		}
-		return fmt.Errorf("error when running os.Lstat(%q): %s", definitionsPath, err)
-	}
-	if info.IsDir() {
-		return fmt.Errorf("%q is a directory", definitionsPath)
+		if info.IsDir() {
+			return fmt.Errorf("%q is a directory", definitionsPath)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Previously there must have been exactly one yaml file. Now it should be
at least one.

The question to duscuss is how to update the consul check (see agent/agent.go:195).
It's current implementation is that it's been sequentially updated for each yaml file.