### PR TITLE
New environments view

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,16 +96,17 @@ Notice that a new entry must exists for every node.
 - `config-dir`: Consul agent configuration files directory. It must be the same used by the consul agent. The `trento` agent creates a new folder with the node name where the trento meta-data configuration file is stored (e.g. `consul.d/node1/trento-config.json`).
 - `consul-template`: Template used to populate the trento meta-data configuration file (by default [meta-data file][./examples/trento-config.json] is used).
 
-### Filtering the nodes in the wep app
+### Grouping and filtering the nodes in the wep app
 
-The web app provides the option to filter the systems using the previously commented reserved tags. To achieve this, the tags must be stored in the KV storage.
+The app provides the option to see the environment composed by the nodes and filter the systems using the previously commented reserved tags. To achieve this, the tags must be stored in the KV storage.
 Use the next path:
-- `trento/filters/sap-environments`
-- `trento/filters/sap-landscapes`
-- `trento/filters/sap-systems`
+- `trento/environments/$yourenv/`
+- `trento/environments/$yourenv/landscapes/$yourland/`
+- `trento/environments/$yourenv/landscapes/$yourland/sapsystems/$yoursapsy`
 
-Each of them must have a json list format. As example: `["land1", "land2"]`.
-These entries will be available in the filters on the `/environments` page.
+Keep in mind that the created environments, landscapes and sap systems are directories themselves, and there can be multiple of them.
+The possibility to have multiple landscapes with the same name in different environments (and the same for SAP systems) is possible.
+Be aware that the nodes meta-data tags are not strictly linked to these names, they are soft relations (this means that only the string matches, there is no any real relationship between them).
 
 ## Development
 

--- a/internal/consul/consul.go
+++ b/internal/consul/consul.go
@@ -21,6 +21,7 @@ type Catalog interface {
 type KV interface {
 	Get(key string, q *consulApi.QueryOptions) (*consulApi.KVPair, *consulApi.QueryMeta, error)
 	List(prefix string, q *consulApi.QueryOptions) (consulApi.KVPairs, *consulApi.QueryMeta, error)
+	Keys(prefix, separator string, q *consulApi.QueryOptions) ([]string, *consulApi.QueryMeta, error)
 }
 
 type Health interface {

--- a/internal/consul/mocks/KV.go
+++ b/internal/consul/mocks/KV.go
@@ -45,6 +45,38 @@ func (_m *KV) Get(key string, q *api.QueryOptions) (*api.KVPair, *api.QueryMeta,
 	return r0, r1, r2
 }
 
+// Keys provides a mock function with given fields: prefix, separator, q
+func (_m *KV) Keys(prefix string, separator string, q *api.QueryOptions) ([]string, *api.QueryMeta, error) {
+	ret := _m.Called(prefix, separator, q)
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func(string, string, *api.QueryOptions) []string); ok {
+		r0 = rf(prefix, separator, q)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 *api.QueryMeta
+	if rf, ok := ret.Get(1).(func(string, string, *api.QueryOptions) *api.QueryMeta); ok {
+		r1 = rf(prefix, separator, q)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*api.QueryMeta)
+		}
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(string, string, *api.QueryOptions) error); ok {
+		r2 = rf(prefix, separator, q)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // List provides a mock function with given fields: prefix, q
 func (_m *KV) List(prefix string, q *api.QueryOptions) (api.KVPairs, *api.QueryMeta, error) {
 	ret := _m.Called(prefix, q)

--- a/web/app.go
+++ b/web/app.go
@@ -57,6 +57,10 @@ func NewAppWithDeps(host string, port int, deps Dependencies) (*App, error) {
 	engine.GET("/hosts/:name/checks/:checkid", NewCheckHandler(deps.consul))
 	engine.GET("/clusters", NewClustersListHandler(deps.consul))
 	engine.GET("/clusters/:name", NewClusterHandler(deps.consul))
+	engine.GET("/environments", NewEnvironmentsListHandler(deps.consul))
+	engine.GET("/environments/:env", NewLandscapesListHandler(deps.consul))
+	engine.GET("/environments/:env/landscapes/:land", NewSAPSystemsListHandler(deps.consul))
+	engine.GET("/environments/:env/landscapes/:land/sapsystems/:sys", NewSAPSystemHostsListHandler(deps.consul))
 
 	apiGroup := engine.Group("/api")
 	{

--- a/web/app.go
+++ b/web/app.go
@@ -58,9 +58,11 @@ func NewAppWithDeps(host string, port int, deps Dependencies) (*App, error) {
 	engine.GET("/clusters", NewClustersListHandler(deps.consul))
 	engine.GET("/clusters/:name", NewClusterHandler(deps.consul))
 	engine.GET("/environments", NewEnvironmentsListHandler(deps.consul))
-	engine.GET("/environments/:env", NewLandscapesListHandler(deps.consul))
-	engine.GET("/environments/:env/landscapes/:land", NewSAPSystemsListHandler(deps.consul))
-	engine.GET("/environments/:env/landscapes/:land/sapsystems/:sys", NewSAPSystemHostsListHandler(deps.consul))
+	engine.GET("/environments/:env", NewEnvironmentListHandler(deps.consul))
+	engine.GET("/landscapes", NewLandscapesListHandler(deps.consul))
+	engine.GET("/landscapes/:land", NewLandscapeListHandler(deps.consul))
+	engine.GET("/sapsystems", NewSAPSystemsListHandler(deps.consul))
+	engine.GET("/sapsystems/:sys", NewSAPSystemHostsListHandler(deps.consul))
 
 	apiGroup := engine.Group("/api")
 	{

--- a/web/environments.go
+++ b/web/environments.go
@@ -128,6 +128,11 @@ func loadEnvironments(client consul.Client) (EnvironmentList, error) {
 	}
 
 	for _, entry := range entries {
+		// Remove individual values, even though there is not any defined by now.
+		if !strings.HasSuffix(entry, "/") {
+			continue
+		}
+
 		keyValues := strings.Split(strings.TrimSuffix(entry, "/"), "/")
 		lastKey := keyValues[len(keyValues)-1]
 		lastKeyParent := keyValues[len(keyValues)-2]

--- a/web/environments.go
+++ b/web/environments.go
@@ -1,7 +1,7 @@
 package web
 
 import (
-	//"log"
+	"log"
 	"net/http"
 	"strings"
 
@@ -98,6 +98,24 @@ func NewSAPSystemHostsListHandler(client consul.Client) gin.HandlerFunc {
 	}
 }
 
+/* loadEnvironments needs a fixed kv structure to work. Here an example
+trento/environments/
+trento/environments/env1/
+trento/environments/env1/landscapes/
+trento/environments/env1/landscapes/land1/
+trento/environments/env1/landscapes/land1/sapsystems/
+trento/environments/env1/landscapes/land1/sapsystems/sys1/
+trento/environments/env1/landscapes/land1/sapsystems/sys2/
+trento/environments/env1/landscapes/land2/
+trento/environments/env1/landscapes/land2/sapsystems/
+trento/environments/env1/landscapes/land2/sapsystems/sys3/
+trento/environments/env1/landscapes/land2/sapsystems/sys4/
+trento/environments/env2/
+trento/environments/env2/landscapes/
+trento/environments/env2/landscapes/land3/
+trento/environments/env2/landscapes/land3/sapsystems/
+trento/environments/env2/landscapes/land3/sapsystems/sys5/
+*/
 func loadEnvironments(client consul.Client) (EnvironmentList, error) {
 	var (
 		environments = EnvironmentList{}
@@ -160,6 +178,7 @@ func loadSAPSystems(client consul.Client, environments EnvironmentList, values [
 	if lastKeyParent == "sapsystems" && !sysFound {
 		envName := values[envIndex]
 		landName := values[landIndex]
+		// Get the nodes with these meta-data entries
 		query := CreateFilterMetaQuery(map[string][]string{
 			"trento-sap-environment": []string{envName},
 			"trento-sap-landscape":   []string{landName},

--- a/web/environments.go
+++ b/web/environments.go
@@ -1,0 +1,178 @@
+package web
+
+import (
+	//"log"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+
+	"github.com/trento-project/trento/internal/consul"
+)
+
+const KVEnvironmentsPath string = "trento/environments"
+const envIndex int = 2
+const landIndex int = 4
+
+type SAPSystem struct {
+	Name  string
+	Hosts HostList
+}
+
+type SAPSystemList map[string]*SAPSystem
+
+type Landscape struct {
+	Name       string
+	SAPSystems SAPSystemList
+}
+
+type LandscapeList map[string]*Landscape
+
+type Environment struct {
+	Name       string
+	Landscapes LandscapeList
+}
+
+type EnvironmentList map[string]*Environment
+
+func NewEnvironmentsListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "environments.html.tmpl", gin.H{
+			"Environments": environments,
+		})
+	}
+}
+
+func NewLandscapesListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "landscapes.html.tmpl", gin.H{
+			"Environments": environments,
+			"EnvName":      c.Param("env"),
+		})
+	}
+}
+
+func NewSAPSystemsListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "sapsystems.html.tmpl", gin.H{
+			"Environments": environments,
+			"EnvName":      c.Param("env"),
+			"LandName":     c.Param("land"),
+		})
+	}
+}
+
+func NewSAPSystemHostsListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "sapsystem.html.tmpl", gin.H{
+			"Environments": environments,
+			"EnvName":      c.Param("env"),
+			"LandName":     c.Param("land"),
+			"SAPSysName":   c.Param("sys"),
+		})
+	}
+}
+
+func loadEnvironments(client consul.Client) (EnvironmentList, error) {
+	var (
+		environments = EnvironmentList{}
+		reserveKeys  = []string{"environments", "landscapes", "sapsystems"}
+	)
+
+	entries, _, err := client.KV().Keys(KVEnvironmentsPath, "", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not query Consul for Environments KV values")
+	}
+
+	for _, entry := range entries {
+		keyValues := strings.Split(strings.TrimSuffix(entry, "/"), "/")
+		lastKey := keyValues[len(keyValues)-1]
+		lastKeyParent := keyValues[len(keyValues)-2]
+
+		if contains(reserveKeys, lastKey) {
+			continue
+		}
+
+		_, envFound := environments[lastKeyParent]
+		if lastKeyParent == "environments" && !envFound {
+			env := &Environment{Name: lastKey, Landscapes: make(LandscapeList)}
+			environments[lastKey] = env
+		}
+
+		environments, err = loadLandscapes(client, environments, keyValues)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not get the SAP landscapes")
+		}
+	}
+
+	return environments, nil
+}
+
+func loadLandscapes(client consul.Client, environments EnvironmentList, values []string) (EnvironmentList, error) {
+	lastKey := values[len(values)-1]
+	lastKeyParent := values[len(values)-2]
+
+	_, landFound := environments[lastKeyParent]
+	if lastKeyParent == "landscapes" && !landFound {
+		land := &Landscape{Name: lastKey, SAPSystems: make(SAPSystemList)}
+		envName := values[envIndex]
+		environments[envName].Landscapes[lastKey] = land
+	}
+
+	environments, err := loadSAPSystems(client, environments, values)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not get the SAP systems")
+	}
+
+	return environments, nil
+}
+
+func loadSAPSystems(client consul.Client, environments EnvironmentList, values []string) (EnvironmentList, error) {
+	lastKey := values[len(values)-1]
+	lastKeyParent := values[len(values)-2]
+
+	_, sysFound := environments[lastKeyParent]
+	if lastKeyParent == "sapsystems" && !sysFound {
+		envName := values[envIndex]
+		landName := values[landIndex]
+		query := CreateFilterMetaQuery(map[string][]string{
+			"trento-sap-environment": []string{envName},
+			"trento-sap-landscape":   []string{landName},
+			"trento-sap-system":      []string{lastKey},
+		})
+		hosts, err := loadHosts(client, query, []string{})
+		if err != nil {
+			return nil, errors.Wrap(err, "could not query Consul for hosts")
+		}
+		sapsystem := &SAPSystem{Name: lastKey, Hosts: hosts}
+
+		environments[envName].Landscapes[landName].SAPSystems[lastKey] = sapsystem
+	}
+
+	return environments, nil
+}

--- a/web/environments.go
+++ b/web/environments.go
@@ -109,8 +109,30 @@ func NewEnvironmentsListHandler(client consul.Client) gin.HandlerFunc {
 	}
 }
 
+func NewEnvironmentListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "environment.html.tmpl", gin.H{
+			"Environments": environments,
+			"EnvName":      c.Param("env"),
+		})
+	}
+}
+
 func NewLandscapesListHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var env string = ""
+
+		query := c.Request.URL.Query()
+		if len(query["environment"]) > 0 {
+			env = query["environment"][0]
+		}
+
 		environments, err := loadEnvironments(client)
 		if err != nil {
 			_ = c.Error(err)
@@ -119,13 +141,48 @@ func NewLandscapesListHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "landscapes.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      c.Param("env"),
+			"EnvName":      env,
+		})
+	}
+}
+
+func NewLandscapeListHandler(client consul.Client) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var env string = ""
+
+		query := c.Request.URL.Query()
+		if len(query["environment"]) > 0 {
+			env = query["environment"][0]
+		}
+
+		environments, err := loadEnvironments(client)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.HTML(http.StatusOK, "landscape.html.tmpl", gin.H{
+			"Environments": environments,
+			"EnvName":      env,
+			"LandName":     c.Param("land"),
 		})
 	}
 }
 
 func NewSAPSystemsListHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var env string = ""
+		var land string = ""
+
+		query := c.Request.URL.Query()
+		if len(query["environment"]) > 0 {
+			env = query["environment"][0]
+		}
+
+		if len(query["landscape"]) > 0 {
+			land = query["landscape"][0]
+		}
+
 		environments, err := loadEnvironments(client)
 		if err != nil {
 			_ = c.Error(err)
@@ -134,14 +191,26 @@ func NewSAPSystemsListHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "sapsystems.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      c.Param("env"),
-			"LandName":     c.Param("land"),
+			"EnvName":      env,
+			"LandName":     land,
 		})
 	}
 }
 
 func NewSAPSystemHostsListHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		var env string = ""
+		var land string = ""
+
+		query := c.Request.URL.Query()
+		if len(query["environment"]) > 0 {
+			env = query["environment"][0]
+		}
+
+		if len(query["landscape"]) > 0 {
+			land = query["landscape"][0]
+		}
+
 		environments, err := loadEnvironments(client)
 		if err != nil {
 			_ = c.Error(err)
@@ -150,8 +219,8 @@ func NewSAPSystemHostsListHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "sapsystem.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      c.Param("env"),
-			"LandName":     c.Param("land"),
+			"EnvName":      env,
+			"LandName":     land,
 			"SAPSysName":   c.Param("sys"),
 		})
 	}

--- a/web/environments.go
+++ b/web/environments.go
@@ -1,7 +1,7 @@
 package web
 
 import (
-	"log"
+	//"log"
 	"net/http"
 	"strings"
 

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -60,15 +60,15 @@ func setupTest() (*mocks.Client, *mocks.Catalog) {
 	kv.On("Keys", "trento/environments", "", (*consulApi.QueryOptions)(nil)).Return(filters, nil, nil)
 
 	filterSys1 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land1\" and Meta[\"trento-sap-system\"] == \"sys1\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-system\"] == \"sys1\")"}
 	catalog.On("Nodes", (filterSys1)).Return(nodes, nil, nil)
 
 	filterSys2 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land2\" and Meta[\"trento-sap-system\"] == \"sys2\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land2\") and (Meta[\"trento-sap-system\"] == \"sys2\")"}
 	catalog.On("Nodes", (filterSys2)).Return(nodes, nil, nil)
 
 	filterSys3 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env2\" and Meta[\"trento-sap-landscape\"] == \"land3\" and Meta[\"trento-sap-system\"] == \"sys3\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env2\") and (Meta[\"trento-sap-landscape\"] == \"land3\") and (Meta[\"trento-sap-system\"] == \"sys3\")"}
 	catalog.On("Nodes", (filterSys3)).Return(nodes, nil, nil)
 
 	return consul, catalog

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -1,0 +1,192 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	consulApi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/tdewolff/minify/v2"
+	"github.com/tdewolff/minify/v2/html"
+	"github.com/trento-project/trento/internal/consul/mocks"
+)
+
+func setupTest() (*mocks.Client, *mocks.Catalog) {
+	nodes := []*consulApi.Node{
+		{
+			Node:       "foo",
+			Datacenter: "dc1",
+			Address:    "192.168.1.1",
+			Meta: map[string]string{
+				"trento-sap-environments": "land1",
+			},
+		},
+		{
+			Node:       "bar",
+			Datacenter: "dc",
+			Address:    "192.168.1.2",
+			Meta: map[string]string{
+				"trento-sap-environments": "land2",
+			},
+		},
+	}
+
+	filters := []string{
+		"trento/environments/",
+		"trento/environments/env1/",
+		"trento/environments/env1/landscapes/",
+		"trento/environments/env1/landscapes/land1/",
+		"trento/environments/env1/landscapes/land1/sapsystems/",
+		"trento/environments/env1/landscapes/land1/sapsystems/sys1/",
+		"trento/environments/env1/landscapes/land2/",
+		"trento/environments/env1/landscapes/land2/sapsystems/",
+		"trento/environments/env1/landscapes/land2/sapsystems/sys2/",
+		"trento/environments/env2/",
+		"trento/environments/env2/landscapes/",
+		"trento/environments/env2/landscapes/land3/",
+		"trento/environments/env2/landscapes/land3/sapsystems/",
+		"trento/environments/env2/landscapes/land3/sapsystems/sys3/",
+	}
+
+	consul := new(mocks.Client)
+	catalog := new(mocks.Catalog)
+	kv := new(mocks.KV)
+
+	consul.On("Catalog").Return(catalog)
+	consul.On("KV").Return(kv)
+
+	kv.On("Keys", "trento/environments", "", (*consulApi.QueryOptions)(nil)).Return(filters, nil, nil)
+
+	filterSys1 := &consulApi.QueryOptions{
+		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land1\" and Meta[\"trento-sap-system\"] == \"sys1\""}
+	catalog.On("Nodes", (filterSys1)).Return(nodes, nil, nil)
+
+	filterSys2 := &consulApi.QueryOptions{
+		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land2\" and Meta[\"trento-sap-system\"] == \"sys2\""}
+	catalog.On("Nodes", (filterSys2)).Return(nodes, nil, nil)
+
+	filterSys3 := &consulApi.QueryOptions{
+		Filter: "Meta[\"trento-sap-environment\"] == \"env2\" and Meta[\"trento-sap-landscape\"] == \"land3\" and Meta[\"trento-sap-system\"] == \"sys3\""}
+	catalog.On("Nodes", (filterSys3)).Return(nodes, nil, nil)
+
+	return consul, catalog
+}
+
+func TestEnvironmentsListHandler(t *testing.T) {
+	consul, catalog := setupTest()
+
+	deps := DefaultDependencies()
+	deps.consul = consul
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/environments", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app.ServeHTTP(resp, req)
+
+	consul.AssertExpectations(t)
+	catalog.AssertExpectations(t)
+
+	m := minify.New()
+	m.AddFunc("text/html", html.Minify)
+	m.Add("text/html", &html.Minifier{
+		KeepDefaultAttrVals: true,
+		KeepEndTags:         true,
+	})
+	minified, err := m.String("text/html", resp.Body.String())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, 200, resp.Code)
+	assert.Contains(t, minified, "Environments")
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1'\".*<td>env1</td><td>2</td><td>2</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env2'\".*<td>env2</td><td>1</td><td>1</td>"), minified)
+}
+
+func TestLandscapesListHandler(t *testing.T) {
+	consul, catalog := setupTest()
+
+	deps := DefaultDependencies()
+	deps.consul = consul
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/environments/env1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app.ServeHTTP(resp, req)
+
+	consul.AssertExpectations(t)
+	catalog.AssertExpectations(t)
+
+	m := minify.New()
+	m.AddFunc("text/html", html.Minify)
+	m.Add("text/html", &html.Minifier{
+		KeepDefaultAttrVals: true,
+		KeepEndTags:         true,
+	})
+	minified, err := m.String("text/html", resp.Body.String())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, 200, resp.Code)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land1'\".*<td>land1</td><td>1</td><td>2</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land2'\".*<td>land2</td><td>1</td><td>2</td>"), minified)
+}
+
+func TestSAPSystemsListHandler(t *testing.T) {
+	consul, catalog := setupTest()
+
+	deps := DefaultDependencies()
+	deps.consul = consul
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/environments/env1/landscapes/land1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app.ServeHTTP(resp, req)
+
+	consul.AssertExpectations(t)
+	catalog.AssertExpectations(t)
+
+	m := minify.New()
+	m.AddFunc("text/html", html.Minify)
+	m.Add("text/html", &html.Minifier{
+		KeepDefaultAttrVals: true,
+		KeepEndTags:         true,
+	})
+	minified, err := m.String("text/html", resp.Body.String())
+	if err != nil {
+		panic(err)
+	}
+
+	assert.Equal(t, 200, resp.Code)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land1/sapsystems/sys1'\".*<td>sys1</td>"), minified)
+}

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -161,7 +161,7 @@ func TestEnvironmentsListHandler(t *testing.T) {
 	assert.Equal(t, 200, resp.Code)
 	assert.Contains(t, minified, "Environments")
 	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1'\".*<td>env1</td><td>2</td><td>2</td><td>.*passing.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env2'\".*<td>env2</td><td>1</td><td>1</td><td>.*critical.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1'\".*<td>env2</td><td>1</td><td>1</td><td>.*critical.*</td>"), minified)
 }
 
 func TestLandscapesListHandler(t *testing.T) {
@@ -177,7 +177,7 @@ func TestLandscapesListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/environments/env1", nil)
+	req, err := http.NewRequest("GET", "/landscapes", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,8 +199,9 @@ func TestLandscapesListHandler(t *testing.T) {
 	}
 
 	assert.Equal(t, 200, resp.Code)
-	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land1'\".*<td>land1</td><td>1</td><td>2</td><td>.*passing.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land2'\".*<td>land2</td><td>1</td><td>2</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/landscapes/land1\\?environment=env1'\"><td>land1</td><td>.*env1.*</td><td>1</td><td>2</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/landscapes/land2\\?environment=env1'\".*<td>land2</td><td>.*env1.*<td>1</td><td>2</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/landscapes/land3\\?environment=env2'\".*<td>land3</td><td>.*env2.*<td>1</td><td>2</td><td>.*critical.*</td>"), minified)
 }
 
 func TestSAPSystemsListHandler(t *testing.T) {
@@ -216,7 +217,7 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/environments/env1/landscapes/land1", nil)
+	req, err := http.NewRequest("GET", "/sapsystems", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,5 +239,7 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	}
 
 	assert.Equal(t, 200, resp.Code)
-	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/environments/env1/landscapes/land1/sapsystems/sys1'\".*<td>sys1</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/sapsystems/sys1\\?environment=env1&landscape=land1'\".*<td>sys1</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/sapsystems/sys2\\?environment=env1&landscape=land2'\".*<td>sys2</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/sapsystems/sys3\\?environment=env2&landscape=land3'\".*<td>sys3</td><td>.*critical.*</td>"), minified)
 }

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -100,7 +100,7 @@ func CreateFilterMetaQuery(query map[string][]string) string {
 						filter = fmt.Sprintf("%s or ", filter)
 					}
 				}
-				filters = append(filters, filter)
+				filters = append(filters, fmt.Sprintf("(%s)", filter))
 			}
 		}
 	}

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -170,6 +170,10 @@ func loadFilters(client consul.Client) (map[string][]string, error) {
 		}
 	}
 
+	sort.Strings(filter_data["environments"])
+	sort.Strings(filter_data["landscapes"])
+	sort.Strings(filter_data["sapsystems"])
+
 	return filter_data, nil
 }
 

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -125,16 +125,6 @@ func NewHostsListHandler(client consul.Client) gin.HandlerFunc {
 	}
 }
 
-func contains(s []string, str string) bool {
-	for _, v := range s {
-		if v == str {
-			return true
-		}
-	}
-
-	return false
-}
-
 func loadHosts(client consul.Client, query_filter string, health_filter []string) (HostList, error) {
 	var hosts = HostList{}
 

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -77,15 +77,15 @@ func TestHostsListHandler(t *testing.T) {
 	catalog.On("Nodes", (*consulApi.QueryOptions)(query)).Return(nodes, nil, nil)
 
 	filterSys1 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land1\" and Meta[\"trento-sap-system\"] == \"sys1\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-system\"] == \"sys1\")"}
 	catalog.On("Nodes", (filterSys1)).Return(nodes, nil, nil)
 
 	filterSys2 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env1\" and Meta[\"trento-sap-landscape\"] == \"land2\" and Meta[\"trento-sap-system\"] == \"sys2\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land2\") and (Meta[\"trento-sap-system\"] == \"sys2\")"}
 	catalog.On("Nodes", (filterSys2)).Return(nodes, nil, nil)
 
 	filterSys3 := &consulApi.QueryOptions{
-		Filter: "Meta[\"trento-sap-environment\"] == \"env2\" and Meta[\"trento-sap-landscape\"] == \"land3\" and Meta[\"trento-sap-system\"] == \"sys3\""}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env2\") and (Meta[\"trento-sap-landscape\"] == \"land3\") and (Meta[\"trento-sap-system\"] == \"sys3\")"}
 	catalog.On("Nodes", (filterSys3)).Return(nodes, nil, nil)
 
 	health.On("Node", "foo", (*consulApi.QueryOptions)(nil)).Return(fooHealthChecks, nil, nil)

--- a/web/layout.go
+++ b/web/layout.go
@@ -90,6 +90,9 @@ func (r *LayoutRender) addFileFromFS(templatesFS fs.FS, file string) {
 			_ = tmpl.ExecuteTemplate(&out, name, data)
 			return out.String()
 		},
+		"sum": func(a int, b int) int {
+			return a + b
+		},
 	})
 	patterns := append([]string{r.root, file}, r.blocks...)
 	tmpl = template.Must(tmpl.ParseFS(templatesFS, patterns...))

--- a/web/templates/blocks/landscapes_row.html.tmpl
+++ b/web/templates/blocks/landscapes_row.html.tmpl
@@ -1,0 +1,22 @@
+{{ define "landscapes_row" }}
+{{- $EnvName := .Name }}
+{{- range .Landscapes }}
+<tr class='clickable' onclick="window.location='/landscapes/{{ .Name }}?environment={{ $EnvName }}'">
+    <td>{{ .Name }}</td>
+    <td><a href="/environment/{{ $EnvName }}">{{ $EnvName }}</a></td>
+    {{- $SAPSystemNumber := 0 }}
+    {{- $HostsNumber := 0 }}
+    {{- $SAPSystemNumber = sum $SAPSystemNumber (len .SAPSystems) }}
+    {{- range .SAPSystems }}
+    {{- $HostsNumber = sum $HostsNumber (len .Hosts) }}
+    {{- end }}
+    <td>{{ $SAPSystemNumber }}</td>
+    <td>{{ $HostsNumber }}</td>
+    <td>
+        {{- $Health := .Health }}
+        {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
+    </td>
+</tr>
+{{- end }}
+{{ end }}

--- a/web/templates/blocks/landscapes_table.html.tmpl
+++ b/web/templates/blocks/landscapes_table.html.tmpl
@@ -1,0 +1,24 @@
+{{ define "landscapes_table" }}
+<table class='table eos-table'>
+    <thead>
+        <tr>
+            <th scope='col'>Landscape</th>
+            <th scope='col'>Environment</th>
+            <th scope='col'>SAP systems number</th>
+            <th scope='col'>Hosts number</th>
+            <th scope='col'>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{- if .EnvName }}
+        {{ $EnvName := .EnvName }}
+        {{ $Env := index .Environments .EnvName }}
+        {{ template "landscapes_row" $Env }}
+        {{- else }}
+        {{- range .Environments }}
+        {{ template "landscapes_row" . }}
+        {{- end }}
+        {{- end }}
+    </tbody>
+</table>
+{{ end }}

--- a/web/templates/blocks/sapsystems_table.html.tmpl
+++ b/web/templates/blocks/sapsystems_table.html.tmpl
@@ -1,0 +1,56 @@
+{{ define "sapsystems_table" }}
+<div class='table-responsive'>
+    <table class='table eos-table'>
+        <thead>
+            <tr>
+                <th scope='col'>SAP System</th>
+                <th scope='col'>Environment</th>
+                <th scope='col'>Landscape</th>
+                <th scope='col'>Hosts number</th>
+                <th scope='col'>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{- if .EnvName }}
+            {{ $EnvName := .EnvName }}
+            {{ $LandName := .LandName }}
+            {{ $Env := index .Environments .EnvName }}
+            {{ $Land := index $Env.Landscapes .LandName }}
+            {{- range $Land.SAPSystems }}
+            <tr class='clickable' onclick="window.location='/sapsystems/{{ .Name }}?environment={{ $EnvName }}&landscape={{ $LandName }}'">
+                <td>{{ .Name }}</td>
+                <td><a href="/landscapes?/environment={{ $EnvName }}">{{ $EnvName }}</a></td>
+                <td><a href="/sapsystems?landscape={{ $LandName }}">{{ $EnvName }}</a></td>
+                <td>{{ len .Hosts }}</td>
+                <td>
+                    {{- $Health := .Health }}
+                    {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+                    <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
+                </td>
+            </tr>
+            {{- end }}
+            {{- else }}
+            {{- range .Environments }}
+            {{- $EnvName := .Name }}
+            {{- range .Landscapes }}
+            {{- $LandName := .Name }}
+            {{- range .SAPSystems }}
+            <tr class='clickable' onclick="window.location='/sapsystems/{{ .Name }}?environment={{ $EnvName }}&landscape={{ $LandName }}'">
+                <td>{{ .Name }}</td>
+                <td><a href="/landscapes?/environment={{ $EnvName }}">{{ $EnvName }}</a></td>
+                <td><a href="/sapsystems?landscape={{ $LandName }}">{{ $LandName }}</a></td>
+                <td>{{ len .Hosts }}</td>
+                <td>
+                    {{- $Health := .Health }}
+                    {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+                    <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
+                </td>
+            </tr>
+            {{- end }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
+        </tbody>
+    </table>
+</div>
+{{ end }}

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -31,6 +31,14 @@
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Environments</span>
           </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/landscapes">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">Landscapes</span>
+          </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">SAP Systems</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -27,6 +27,10 @@
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Clusters</span>
           </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">Environments</span>
+          </a>
         </li>
       </ul>
     </div>

--- a/web/templates/cluster.html.tmpl
+++ b/web/templates/cluster.html.tmpl
@@ -1,7 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/clusters">Clusters</a> > {{ .Cluster.Name }}</h1>
-    <h2>Cluster details</h2>
+    <h6><a href="/clusters">Clusters</a> > {{ .Cluster.Name }}</h6>
+    <h1>Cluster details</h1>
     <dl class="inline">
       <dt class="inline">Name</dt>
       <dd class="inline">{{ .Cluster.Name }}</dd>

--- a/web/templates/environment.html.tmpl
+++ b/web/templates/environment.html.tmpl
@@ -1,0 +1,15 @@
+{{ define "content" }}
+<div class="col">
+    <h6><a href="/environments">Environments</a><h6>
+    <h1>Environment details</h1>
+    <dl class="inline">
+      <dt class="inline">Name</dt>
+      <dd class="inline">{{ .EnvName }}</dd>
+    </dl>
+    <hr/>
+    <p class='clearfix'/>
+    <h1>Landscapes</h1>
+    {{ template "landscapes_table" . }}
+    </div>
+</div>
+{{ end }}

--- a/web/templates/environments.html.tmpl
+++ b/web/templates/environments.html.tmpl
@@ -1,0 +1,40 @@
+{{ define "content" }}
+<div class="col">
+    <h1>Environments</h1>
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+                <tr>
+                    <th scope='col'>Environmemt</th>
+                    <th scope='col'>Landscapes number</th>
+                    <th scope='col'>SAP systems number</th>
+                    <th scope='col'>Hosts number</th>
+                    <th scope='col'>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{- range .Environments }}
+                <tr class='clickable' onclick="window.location='/environments/{{ .Name }}'">
+                    <td>{{ .Name }}</td>
+                    <td>{{ len .Landscapes }}</td>
+                    {{- $SAPSystemNumber := 0 }}
+                    {{- $HostsNumber := 0 }}
+                    {{- range .Landscapes }}
+                    {{- $SAPSystemNumber = sum $SAPSystemNumber (len .SAPSystems) }}
+                    {{- range .SAPSystems }}
+                    {{- $HostsNumber = sum $HostsNumber (len .Hosts) }}
+                    {{- end }}
+                    {{- end }}
+                    <td>{{ $SAPSystemNumber }}</td>
+                    <td>{{ $HostsNumber }}</td>
+                    <td>
+                        {{- $Health := "passing" }}
+                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{ end }}

--- a/web/templates/environments.html.tmpl
+++ b/web/templates/environments.html.tmpl
@@ -5,7 +5,7 @@
         <table class='table eos-table'>
             <thead>
                 <tr>
-                    <th scope='col'>Environmemt</th>
+                    <th scope='col'>Environment</th>
                     <th scope='col'>Landscapes number</th>
                     <th scope='col'>SAP systems number</th>
                     <th scope='col'>Hosts number</th>

--- a/web/templates/environments.html.tmpl
+++ b/web/templates/environments.html.tmpl
@@ -28,8 +28,9 @@
                     <td>{{ $SAPSystemNumber }}</td>
                     <td>{{ $HostsNumber }}</td>
                     <td>
-                        {{- $Health := "passing" }}
-                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                        {{- $Health := .Health }}
+                        {{- /* I`t would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+                        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
                     </td>
                 </tr>
                 {{- end }}

--- a/web/templates/ha_checks.html.tmpl
+++ b/web/templates/ha_checks.html.tmpl
@@ -1,8 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/hosts">Hosts</a> > <a href="/hosts/{{ .HostName }}">{{ .HostName }}</a> > {{ .CheckID }}</h1>
-
-    <h4>{{ .CheckContent.Description  }}</h4>
+    <h6><a href="/hosts">Hosts</a> > <a href="/hosts/{{ .HostName }}">{{ .HostName }}</a> > {{ .CheckID }}</h6>
+    <h1>{{ .CheckContent.Description  }}</h1>
     <div class='table-responsive'>
         <table class='table eos-table'>
             <thead>

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -11,9 +11,9 @@
       <dt class="inline">Environment</dt>
       <dd class="inline"><a href="/environments/{{ $Env }}">{{ $Env }}</a></dd>
       <dt class="inline">Landscape</dt>
-      <dd class="inline"><a href="/environments/{{ $Env }}/landscapes/{{ $Land }}">{{ $Land }}</a></dd>
+      <dd class="inline"><a href="/landscapes/{{ $Land }}?environment={{ $Env }}">{{ $Land }}</a></dd>
       <dt class="inline">SAP System</dt>
-      <dd class="inline"><a href="/environments/{{ $Env }}/landscapes/{{ $Land }}/sapsystems/{{ $SAPSys }}">{{ $SAPSys }}</a></dd>
+      <dd class="inline"><a href="/sapsystems/{{ $SAPSys }}?environment={{ $Env }}&landscape={{ $Land }}">{{ $SAPSys }}</a></dd>
       <dt class="inline">Cluster</dt>
       <dd class="inline"><a href="/clusters/{{ index .Host.TrentoMeta "trento-ha-cluster" }}">{{ index .Host.TrentoMeta "trento-ha-cluster" }}</a></dd>
     </dl>

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -1,7 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/hosts">Hosts</a> > {{ .Host.Name }}</h1>
-    <h2>Host details</h2>
+    <h6><a href="/hosts">Hosts</a> > {{ .Host.Name }}</h6>
+    <h1>Host details</h1>
     <dl class="inline">
       <dt class="inline">Name</dt>
       <dd class="inline">{{ .Host.Name }}</dd>

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -5,6 +5,15 @@
     <dl class="inline">
       <dt class="inline">Name</dt>
       <dd class="inline">{{ .Host.Name }}</dd>
+      {{ $Env := index .Host.TrentoMeta "trento-sap-environment" }}
+      {{ $Land := index .Host.TrentoMeta "trento-sap-landscape" }}
+      {{ $SAPSys := index .Host.TrentoMeta "trento-sap-system" }}
+      <dt class="inline">Environment</dt>
+      <dd class="inline"><a href="/environments/{{ $Env }}">{{ $Env }}</a></dd>
+      <dt class="inline">Landscape</dt>
+      <dd class="inline"><a href="/environments/{{ $Env }}/landscapes/{{ $Land }}">{{ $Land }}</a></dd>
+      <dt class="inline">SAP System</dt>
+      <dd class="inline"><a href="/environments/{{ $Env }}/landscapes/{{ $Land }}/sapsystems/{{ $SAPSys }}">{{ $SAPSys }}</a></dd>
       <dt class="inline">Cluster</dt>
       <dd class="inline"><a href="/clusters/{{ index .Host.TrentoMeta "trento-ha-cluster" }}">{{ index .Host.TrentoMeta "trento-ha-cluster" }}</a></dd>
     </dl>

--- a/web/templates/hosts.html.tmpl
+++ b/web/templates/hosts.html.tmpl
@@ -14,18 +14,18 @@
       </script>
       <form method="GET" action="/hosts">
         <select name="trento-sap-environment" id="trento-sap-environment" class="selectpicker" multiple data-selected-text-format="count > 3" data-actions-box="true" title="SAP environment...">
-          {{- range index .Filters "sap-environments" }}
+          {{- range index .Filters "environments" }}
           <option value="{{ . }}">{{ . }}</option>
           {{- end }}
         </select>
         <select name="trento-sap-landscape" id="trento-sap-landscape" class="selectpicker" multiple data-selected-text-format="count > 3" data-actions-box="true" title="SAP landscape...">
-          {{- range index .Filters "sap-landscapes" }}
+          {{- range index .Filters "landscapes" }}
           <option value="{{ . }}">{{ . }}</option>
           {{- end }}
         </select>
 
         <select name="trento-sap-system" id="trento-sap-system" class="selectpicker" multiple data-selected-text-format="count > 3" data-actions-box="true" title="SAP system...">
-          {{- range index .Filters "sap-systems" }}
+          {{- range index .Filters "sapsystems" }}
           <option value="{{ . }}">{{ . }}</option>
           {{- end }}
         </select>

--- a/web/templates/landscape.html.tmpl
+++ b/web/templates/landscape.html.tmpl
@@ -1,0 +1,13 @@
+{{ define "content" }}
+<div class="col">
+    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a><h6>
+    <h1>Landscape details</h1>
+    <dl class="inline">
+      <dt class="inline">Name</dt>
+      <dd class="inline">{{ .LandName }}</dd>
+    </dl>
+    <hr/>
+    <h1>SAP Systems</h1>
+    {{ template "sapsystems_table" . }}
+</div>
+{{ end }}

--- a/web/templates/landscapes.html.tmpl
+++ b/web/templates/landscapes.html.tmpl
@@ -1,6 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/environments">Environments</a> > {{ .EnvName }}</h1>
+    <h6><a href="/environments">Environments</a> > {{ .EnvName }}</h6>
+    <h1>Landscapes</h1>
     <div class='table-responsive'>
         <table class='table eos-table'>
             <thead>

--- a/web/templates/landscapes.html.tmpl
+++ b/web/templates/landscapes.html.tmpl
@@ -27,8 +27,9 @@
                     <td>{{ $SAPSystemNumber }}</td>
                     <td>{{ $HostsNumber }}</td>
                     <td>
-                        {{- $Health := "passing" }}
-                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                        {{- $Health := .Health }}
+                        {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+                        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
                     </td>
                 </tr>
                 {{- end }}

--- a/web/templates/landscapes.html.tmpl
+++ b/web/templates/landscapes.html.tmpl
@@ -1,0 +1,38 @@
+{{ define "content" }}
+<div class="col">
+    <h1><a href="/environments">Environments</a> > {{ .EnvName }}</h1>
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+                <tr>
+                    <th scope='col'>Landscape</th>
+                    <th scope='col'>SAP systems number</th>
+                    <th scope='col'>Hosts number</th>
+                    <th scope='col'>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ $EnvName := .EnvName }}
+                {{ $Env := index .Environments .EnvName }}
+                {{- range $Env.Landscapes }}
+                <tr class='clickable' onclick="window.location='/environments/{{ $EnvName }}/landscapes/{{ .Name }}'">
+                    <td>{{ .Name }}</td>
+                    {{- $SAPSystemNumber := 0 }}
+                    {{- $HostsNumber := 0 }}
+                    {{- $SAPSystemNumber = sum $SAPSystemNumber (len .SAPSystems) }}
+                    {{- range .SAPSystems }}
+                    {{- $HostsNumber = sum $HostsNumber (len .Hosts) }}
+                    {{- end }}
+                    <td>{{ $SAPSystemNumber }}</td>
+                    <td>{{ $HostsNumber }}</td>
+                    <td>
+                        {{- $Health := "passing" }}
+                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{ end }}

--- a/web/templates/landscapes.html.tmpl
+++ b/web/templates/landscapes.html.tmpl
@@ -1,40 +1,6 @@
 {{ define "content" }}
 <div class="col">
-    <h6><a href="/environments">Environments</a> > {{ .EnvName }}</h6>
     <h1>Landscapes</h1>
-    <div class='table-responsive'>
-        <table class='table eos-table'>
-            <thead>
-                <tr>
-                    <th scope='col'>Landscape</th>
-                    <th scope='col'>SAP systems number</th>
-                    <th scope='col'>Hosts number</th>
-                    <th scope='col'>Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{ $EnvName := .EnvName }}
-                {{ $Env := index .Environments .EnvName }}
-                {{- range $Env.Landscapes }}
-                <tr class='clickable' onclick="window.location='/environments/{{ $EnvName }}/landscapes/{{ .Name }}'">
-                    <td>{{ .Name }}</td>
-                    {{- $SAPSystemNumber := 0 }}
-                    {{- $HostsNumber := 0 }}
-                    {{- $SAPSystemNumber = sum $SAPSystemNumber (len .SAPSystems) }}
-                    {{- range .SAPSystems }}
-                    {{- $HostsNumber = sum $HostsNumber (len .Hosts) }}
-                    {{- end }}
-                    <td>{{ $SAPSystemNumber }}</td>
-                    <td>{{ $HostsNumber }}</td>
-                    <td>
-                        {{- $Health := .Health }}
-                        {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
-                        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
-                    </td>
-                </tr>
-                {{- end }}
-            </tbody>
-        </table>
-    </div>
+    {{ template "landscapes_table" . }}
 </div>
 {{ end }}

--- a/web/templates/sapsystem.html.tmpl
+++ b/web/templates/sapsystem.html.tmpl
@@ -1,6 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > <a href="/environments/{{ .EnvName }}/landscapes/{{ .LandName }}">{{ .LandName }}</a> > {{ .SAPSysName}}</h1>
+    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > <a href="/environments/{{ .EnvName }}/landscapes/{{ .LandName }}">{{ .LandName }}</a> > {{ .SAPSysName}}</h6>
+    <h1>Nodes</h1>
     {{ $EnvName := .EnvName }}
     {{ $LandName := .LandName }}
     {{ $Env := index .Environments .EnvName }}

--- a/web/templates/sapsystem.html.tmpl
+++ b/web/templates/sapsystem.html.tmpl
@@ -1,6 +1,12 @@
 {{ define "content" }}
 <div class="col">
-    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > <a href="/environments/{{ .EnvName }}/landscapes/{{ .LandName }}">{{ .LandName }}</a> > {{ .SAPSysName}}</h6>
+    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > <a href="/landscapes/{{ .LandName }}?environment={{ .EnvName }}">{{ .LandName }}</a> > {{ .SAPSysName}}</h6>
+    <h1>SAP System details</h1>
+    <dl class="inline">
+      <dt class="inline">Name</dt>
+      <dd class="inline">{{ .SAPSysName }}</dd>
+    </dl>
+    <hr/>
     <h1>Nodes</h1>
     {{ $EnvName := .EnvName }}
     {{ $LandName := .LandName }}

--- a/web/templates/sapsystem.html.tmpl
+++ b/web/templates/sapsystem.html.tmpl
@@ -1,0 +1,10 @@
+{{ define "content" }}
+<div class="col">
+    <h1><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > <a href="/environments/{{ .EnvName }}/landscapes/{{ .LandName }}">{{ .LandName }}</a> > {{ .SAPSysName}}</h1>
+    {{ $EnvName := .EnvName }}
+    {{ $LandName := .LandName }}
+    {{ $Env := index .Environments .EnvName }}
+    {{ $Land := index $Env.Landscapes .LandName }}
+    {{ $SAPSystem := index $Land.SAPSystems .SAPSysName }}
+    {{ template "hosts_table" $SAPSystem }}
+{{ end }}

--- a/web/templates/sapsystems.html.tmpl
+++ b/web/templates/sapsystems.html.tmpl
@@ -1,6 +1,7 @@
 {{ define "content" }}
 <div class="col">
-    <h1><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > {{ .LandName }} </h1>
+    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > {{ .LandName }} </h6>
+    <h1>SAP Systems</h1>
     <div class='table-responsive'>
         <table class='table eos-table'>
             <thead>

--- a/web/templates/sapsystems.html.tmpl
+++ b/web/templates/sapsystems.html.tmpl
@@ -1,34 +1,9 @@
 {{ define "content" }}
 <div class="col">
-    <h6><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > {{ .LandName }} </h6>
+    {{- if .EnvName }}
+    <h6><a href="/environments">Environments</a> > <a href="/landscapes?environment={{ .EnvName }}">{{ .EnvName }}</a> > {{ .LandName }} </h6>
+    {{- end }}
     <h1>SAP Systems</h1>
-    <div class='table-responsive'>
-        <table class='table eos-table'>
-            <thead>
-                <tr>
-                    <th scope='col'>SAP System</th>
-                    <th scope='col'>Hosts number</th>
-                    <th scope='col'>Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                {{ $EnvName := .EnvName }}
-                {{ $LandName := .LandName }}
-                {{ $Env := index .Environments .EnvName }}
-                {{ $Land := index $Env.Landscapes .LandName }}
-                {{- range $Land.SAPSystems }}
-                <tr class='clickable' onclick="window.location='/environments/{{ $EnvName }}/landscapes/{{ $LandName }}/sapsystems/{{ .Name }}'">
-                    <td>{{ .Name }}</td>
-                    <td>{{ len .Hosts }}</td>
-                    <td>
-                        {{- $Health := .Health }}
-                        {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
-                        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
-                    </td>
-                </tr>
-                {{- end }}
-            </tbody>
-        </table>
-    </div>
+    {{ template "sapsystems_table" . }}
 </div>
 {{ end }}

--- a/web/templates/sapsystems.html.tmpl
+++ b/web/templates/sapsystems.html.tmpl
@@ -1,0 +1,32 @@
+{{ define "content" }}
+<div class="col">
+    <h1><a href="/environments">Environments</a> > <a href="/environments/{{ .EnvName }}">{{ .EnvName }}</a> > {{ .LandName }} </h1>
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+                <tr>
+                    <th scope='col'>SAP System</th>
+                    <th scope='col'>Hosts number</th>
+                    <th scope='col'>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{ $EnvName := .EnvName }}
+                {{ $LandName := .LandName }}
+                {{ $Env := index .Environments .EnvName }}
+                {{ $Land := index $Env.Landscapes .LandName }}
+                {{- range $Land.SAPSystems }}
+                <tr class='clickable' onclick="window.location='/environments/{{ $EnvName }}/landscapes/{{ $LandName }}/sapsystems/{{ .Name }}'">
+                    <td>{{ .Name }}</td>
+                    <td>{{ len .Hosts }}</td>
+                    <td>
+                        {{- $Health := "passing" }}
+                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                    </td>
+                </tr>
+                {{- end }}
+            </tbody>
+        </table>
+    </div>
+</div>
+{{ end }}

--- a/web/templates/sapsystems.html.tmpl
+++ b/web/templates/sapsystems.html.tmpl
@@ -21,8 +21,9 @@
                     <td>{{ .Name }}</td>
                     <td>{{ len .Hosts }}</td>
                     <td>
-                        {{- $Health := "passing" }}
-                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }} (hardcoded)</span>
+                        {{- $Health := .Health }}
+                        {{- /* It would be nice to show the summary of the the health as tooltip. How many passing, critical and warning in a nice an visual way */ -}}
+                        <span class='badge badge-pill badge-{{ if eq $Health.Health "passing" }}primary{{ else if eq $Health.Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health.Health }}</span>
                     </td>
                 </tr>
                 {{- end }}

--- a/web/utils.go
+++ b/web/utils.go
@@ -1,0 +1,11 @@
+package web
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Implementation of the new `Environments` entry point. This adds a new element in the sidebar that gives the option to move along the environments/landscapes/sap systems in hierarchy mode. Each of the elements summarizes the status of the whole entity.
Besides that, the individual elements show the group they belong too.

The usage of the KV storage is explained in the `README` file

Some pics:
![image](https://user-images.githubusercontent.com/36370954/116055062-9e7bc880-a67c-11eb-9926-9d451c43416c.png)
![image](https://user-images.githubusercontent.com/36370954/116055089-a76c9a00-a67c-11eb-8b7b-f885138ca9a6.png)
![image](https://user-images.githubusercontent.com/36370954/116055116-adfb1180-a67c-11eb-8516-05ba2af39b0b.png)
![image](https://user-images.githubusercontent.com/36370954/116055154-b6534c80-a67c-11eb-98d7-893fe728654a.png)
![image](https://user-images.githubusercontent.com/36370954/116055188-bd7a5a80-a67c-11eb-8769-31a870a8e9f2.png)

FYI: @lee-martin