### PR TITLE
Remove servicename path for consultemplate config dir

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -14,7 +14,7 @@ import (
 	"github.com/trento-project/trento/agent"
 )
 
-const METADATAFILE string = "trento-config.json"
+const metaDataFile string = "trento-config.json"
 
 var TTL time.Duration
 var serviceName string
@@ -89,7 +89,7 @@ func start(cmd *cobra.Command, args []string) {
 	cfg.WebPort = port
 	cfg.TTL = TTL
 	cfg.TemplateSource = templatePath
-	cfg.TemplateDestination = path.Join(configDir, serviceName, METADATAFILE)
+	cfg.TemplateDestination = path.Join(configDir, metaDataFile)
 
 	a, err := agent.NewWithConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
Before this, the trento configuration file used to populate the metadata was created at `consul.d/service/trento-config.json` when `consul.d` is the value given to `config-dir` flag (this is the default value actually). 

This doesn't match with the consul agent if we set `consul.d` as config-dir, being counter intuitive. 

With this change the config file goes directly to `consul.d/trento-config.json` matching the same config dir with the consul agent.

So now, the agent and the trento agent will receive the same config-dir value without any issue.

PD: I have renamed the template name constant to use camel case