### PR TITLE
Add CONSUL_ADDR to override default lo addr

### DIFF
--- a/internal/consul/consul.go
+++ b/internal/consul/consul.go
@@ -1,6 +1,8 @@
 package consul
 
 import (
+	"os"
+
 	consulApi "github.com/hashicorp/consul/api"
 )
 
@@ -39,7 +41,15 @@ type Health interface {
 }
 
 func DefaultClient() (Client, error) {
-	w, err := consulApi.NewClient(consulApi.DefaultConfig())
+	config := consulApi.DefaultConfig()
+	addrVal, addrPresent := os.LookupEnv("CONSUL_ADDR")
+	if addrPresent {
+		config.Address = addrVal
+	} else {
+		config.Address = "127.0.0.1:8500"
+	}
+
+	w, err := consulApi.NewClient(config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR allows to use an environment variable to override the default `127.0.0.1` address that is used to connect to the consult HTTP API. The `127.0.0.1` default assumes that the `consul` agent is running on the same machine, which is not necessarily true.