### PR TITLE
Add Dockerfile and docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM opensuse/leap:15.2
+MAINTAINER Rubén Torrero Marijnissen <rtorreromarijnissen@suse.com>
+
+COPY . /app
+
+RUN zypper -n in go1.16 nodejs14 make
+RUN cd /app && make build
+
+EXPOSE 8080/tcp
+
+ENTRYPOINT ["/app/trento"]

--- a/README.md
+++ b/README.md
@@ -230,6 +230,39 @@ You can install it with `go install github.com/vektra/mockery/v2@latest`.
 > **Note**  
 > Be sure to add the `mockery` binary to your `$PATH` environment variable so that `make` can find it.
 
+
+## Docker
+
+To assist in testing & developing `trento`, we have added a [Dockerfile](Dockerfile) 
+that will automatically fetch all the required compile-time dependencies to build
+the binary and finally a container image with the fresh binary in it.
+
+We also provide a [docker-compose.yml](docker-compose.yml) file that allows to
+deploy other required services to run alongside `trento` by fetching 
+the images from the [dockerhub](https://hub.docker.com/) registry and running 
+the containers in your `docker` instance.
+
+To only build the docker image:
+```shell
+git clone https://github.com/trento-project/trento.git
+cd trento
+docker build -t trento ./
+```
+
+If you want to build & start `trento` and it's dependencies, you only need `docker-compose`:
+```shell
+docker-compose up
+```
+
+The application should be reachable on the port that is defined in the 
+`docker-compose.yml` file (8080 by default).
+
+> **Note**
+> Take into account that `trento` requires an agent instance that is running on
+> the OS (*not* inside a container) so while it is possible to hack the `docker-compose.yml`
+> file to also run a `trento` agent, it makes little sense as most of the checks
+> require direct access to host files.
+
 # Support
 
 As the project is currently in its early stages, we suggest that any question or

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+
+services:
+
+  consul-server-1:
+    image: consul:latest
+    networks:
+      - trento
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+      - "8600:8600/udp"
+    command: "agent -server -bootstrap-expect 3 -ui -client 0.0.0.0"
+
+  consul-server-2:
+    image: consul:latest
+    networks:
+      - trento
+    command: "agent -server -retry-join consul-server-1 -client 0.0.0.0"
+
+  consul-server-3:
+    image: consul:latest
+    networks:
+      - trento
+    command: "agent -server -retry-join consul-server-1 -client 0.0.0.0"
+
+  trento-web:
+    build: .
+    image: trento:latest
+    networks:
+      - trento
+    ports:
+      - "8080:8080"
+    environment:
+      - CONSUL_HTTP_ADDR=consul-server-1:8500
+    command: "web serve -p 8080"
+
+networks:
+  trento:


### PR DESCRIPTION
This PR should make it easier during development to quickly set up a simple docker-based cluster with `consul` & `trento` and also ensure that all developers are making use of the same versions of our dependencies.

~~**Note that it is using the environment variable from https://github.com/trento-project/trento/pull/48**, so that PR is a requirement for the docker-compose.yml.~~
Update: not needed anymore