### PR TITLE
warn if there are not 3 sbd devices

### DIFF
--- a/examples/azure-rules.yaml
+++ b/examples/azure-rules.yaml
@@ -1,4 +1,4 @@
----
+
 controls:
 version: 1.0.0
 id: 1
@@ -282,10 +282,10 @@ groups:
           test_items:
             - flag: "SBD_COUNT"
               compare:
-                op: gte
-                value: 2
+                op: eq
+                value: 3
         remediation: |
-          It is recommended to configure up to 3 SBD devices for production environments.
+          It is recommended to configure 3 SBD devices for production environments.
           
           Check more information at https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
         scored: false


### PR DESCRIPTION
It was decided during the HA CHecker features review on 05.05.2021 that
we warn the not only when there are <3 sbd devices,
but also if they are > 3.