### PR TITLE
WIP: Landing scope page

### DIFF
--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,111 @@
+# Table of contents
+- [About this document](#about-this-document)
+- [Goal](#goal)
+- [Scope](#scope)
+  - [Hosts](#hosts)
+    - [Discovery](#discovery)
+    - [Checks](#checks)
+      - [HA Checker: Scenario SAP HANA Performance Optimized on Azure](#ha-checker-scenario-sap-hana-performance-optimized-on-azure)
+      - [HA Checker: Scenario Pacemaker on Azure](#ha-checker-scenario-pacemaker-on-azure)
+      - [More coming](#more-coming)
+  - [Clusters](#clusters)
+  - [Environments](#environments)
+  - [Landscapes](#landscapes)
+  - [SAP Systems](#sap-systems)
+  - [Agents](#agents)
+
+# About this document
+This document aims to provide information about the current features that `trento`
+tries to cover and its main scope. Further, we provide details on the functionality
+provided by each view.
+
+# Goal
+>Provide simple to use front end for all SAP relevant OS related tasks for SAP 
+>workloads
+
+This means that `trento` focuses on the OS-related tasks without stepping into 
+specific functionality that is already covered by the relevant application layer,
+centered around SAP workloads and simplicity.
+
+# Scope
+The scope of each component of `trento` is as follows:
+
+## Hosts
+In the hosts overview, the user can get a list of all the hosts that are running
+the trento agent. For each host it will be possible to check basic information
+such as the hostname, its IP address, to what cluster it belongs and a list of
+all the tags that have been set by the discovery mechanisms to classify each
+host accordingly. 
+
+When accessing the details of each host, it will be possible to access in-depth
+information about the role each host has in the cluster such as the status of the
+core HDB processes, SAP System ID (SID), etc. Here, the SAP administrator can
+get a list of potential problems and improvements on the configuration of the
+host that the discovery mechanisms have found.
+
+### Discovery
+The discovery mechanisms are the base of the checkers. These implement the code
+in the trento agent to gather information about the nodes, their roles, the
+configuration files that each node uses (depending on their role).
+
+
+### Checks
+Under the checks view it's possible to see a representation on the data collected
+by the agents against predefined values that are provided by our own recommendations
+and our partners such as SAP. The base for the checks are the above described
+[Discovery mechanisms](#discovery)
+
+We currently support 2 checkers:
+
+#### HA Checker: Scenario SAP HANA Performance Optimized on Azure
+This checker uses Azure's recommendations to provide an overview of how well
+the deployed SAP HANA cluster meets their indicators. More details about this
+recommendation can be seen [here](https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker)
+
+#### HA Checker: Scenario Pacemaker on Azure
+This check is also comparing against Azure's recommendations for a Pacemaker
+cluster.
+> FIXME: Link to this one?
+
+#### More coming
+We are working on implementing more checkers also for other cloud providers.
+
+## Clusters
+This view currently allows to check the status of the all the discovered clusters,
+including the information of the status of each node and the role associated to
+each node. This view also allows to see the resources, their type and distribution
+within the cluster nodes.
+
+## Environments
+The environments view currently only shows a detail of the landscapes that
+are part of an environment.
+
+## Landscapes
+This view at the moment shows a list of the discovered landscapes, detailing the
+count of SAP systems inside each of them as well as the total number of hosts
+that belong to these SAP systems.
+
+## SAP Systems
+In this view are listed the SAP systems, usually identified by a SID or 
+`SAP System Idenfication` string such as `PRD`, `DEV`, or `QAS`. These are used
+often to identify productive, development and quality assurance systems.
+In this view we get an overview of the distribution of each SID, the number of
+hosts disvered of each of them and additional details.
+
+## Agents
+Though not specifically a view/section, as it is the core component of `trento`,
+it is important to understand what they are.
+
+The agents are the `trento` processes that run in each of the nodes that conform
+a highly available SAP Applications cluster. On each of these, the agents attempt
+to discover the role of the node and run a set of checks which result in the
+recommendations described above in the [Checkers](#checkers).
+The information that is gathered by them is stored through a distributed KV store
+and is made visible on the `trento` web UI through the `trento` web UI component.
+
+The agents implement the core functionality of trento. They are responsible for
+the discovery of all the clustered components that are required in order to run
+highly available SAP Applications. These agents implement discovery for:
+  - Pacemaker
+  - Corosync (soon)
+  - SAP components

--- a/web/frontend/stylesheets/override.scss
+++ b/web/frontend/stylesheets/override.scss
@@ -16,3 +16,10 @@
 footer.footer-side-menu ul.footer-list {
   color: $eos-bc-gray-900;
 }
+
+.card-text {
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}

--- a/web/home.go
+++ b/web/home.go
@@ -13,8 +13,9 @@ type HomeData struct {
 
 func HomeHandler(c *gin.Context) {
 	data := HomeData{
-		Title:     defaultLayoutData.Title,
-		Paragraph: "This is the home page",
+		Title: defaultLayoutData.Title,
+		Paragraph: `An open cloud-native web console improving on the
+				life of SAP Applications administrators`,
 	}
 	c.HTML(http.StatusOK, "home.html.tmpl", data)
 }

--- a/web/home_test.go
+++ b/web/home_test.go
@@ -22,5 +22,4 @@ func TestHomeHandler(t *testing.T) {
 	app.ServeHTTP(resp, req)
 
 	assert.Equal(t, 200, resp.Code)
-	assert.Contains(t, resp.Body.String(), "This is the home page")
 }

--- a/web/layout.go
+++ b/web/layout.go
@@ -37,7 +37,7 @@ type SubmenuItem struct {
 }
 
 var defaultLayoutData = LayoutData{
-	Title:     "Trento Console",
+	Title:     "Trento Console for SAP Applications",
 	Copyright: "© 2020-2021 SUSE LLC",
 }
 

--- a/web/templates/home.html.tmpl
+++ b/web/templates/home.html.tmpl
@@ -4,4 +4,111 @@
     <h1>{{ .Title }}</h1>
     <p>{{ .Paragraph }}</p>
 </div>
+<div class='container'>
+    <div class='card-deck'>
+        <div class='card'>
+            <h5 class='card-header'>Agents</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    The agents implement the core functionality of trento. They
+                    are responsible for the discovery of all the clustered components
+                    that are required to run SAP Applications in a highly
+                    available way. These agents implement discovery for:
+                     - Pacemaker
+                     - Corosync
+                     - HANA
+
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#agents'>Learn more</a>
+                </div>
+            </div>
+        </div>
+        <div class='card'>
+            <h5 class='card-header'>Hosts</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    In the hosts overview, the user can get a list of all the
+                    hosts that are running the trento agent. For each host it
+                    will be possible to check basic information such as the hostname,
+                    it's IP address, to what cluster it belongs and a list of all
+                    the tags that have been set by the discovery mechanisms to
+                    classify each host accordingly.
+
+                    When accessing the details of each host, it will be possible
+                    to access in-depth information about the role each host has
+                    in the cluster such as the status of the core HDB processes,
+                    SAP System ID (SID), etc.
+
+                    Here, the SAP administrator can get a list of potential problems
+                    and improvements on the configuration of the host that our
+                    discovery mechanisms have found.
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#hosts'>Learn more</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class='card-deck mt-4'>
+        <div class='card'>
+            <h5 class='card-header'>Environments</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    The environments view currently only shows a detail of the
+                    landscapes that are part of an environment.
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#environments'>Learn more</a>
+                </div>
+            </div>
+        </div>
+        <div class='card w-25'>
+            <h5 class='card-header'>Landscapes</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    This view at the moment shows a list of the discovered 
+                    landscapes, detailing the count of SAP systems inside each
+                    of them as well as the total number of hosts that belong to
+                    these SAP systems.
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#landscapes'>Learn more</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class='card-deck mt-4'>
+        <div class='card w-25'>
+            <h5 class='card-header'>Clusters</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    The scope of this view is to check the status of the
+                    all the discovered HANA DB clusters, including the information
+                    of the status of each node and the role associated to each node.
+                    This view also allows to see the resources, their type and
+                    distribution within the cluster nodes.
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#clusters'>Learn more</a>
+                </div>
+            </div>
+        </div>
+        <div class='card w-25'>
+            <h5 class='card-header'>SAP Systems</h5>
+            <div class='card-body'>
+                <p class='card-text'>
+                    In this view are listed the SAP systems, usually identified by a SID or 
+                    `SAP System Idenfication` string such as `PRD`, `DEV`, or `QAS`. These are used
+                    often to identify productive, development and quality assurance systems.
+                    In this view we get an overview of the distribution of each SID, the number of
+                    hosts disvered of each of them and additional details.
+                </p>
+                <div class='d-flex justify-content-end'>
+                    <a class='card-link' href='https://github.com/trento-project/trento/blob/main/docs/scope.md#sap-systems'>Learn more</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
 {{ end }}


### PR DESCRIPTION
This PR is about two things:
 - scope.md document, where we describe trento's general scope and the different scope of each view
 - Changes to the landing page that use this scope.md document to present this content to a new trento user looking to find out more about what it can do.
 
 These two will probably be split in two PRs.
 
 I've set it as WIP because i'm not entirely sure this is what @lee-martin and @stefanotorresi  where looking for. I'm looking for suggestions on how to fill the parts of the documents that have FIXMEs or TODOs and to review the whole content. The landing page changes are just are proposal following UX suggestions.

![landing](https://user-images.githubusercontent.com/2668401/121505162-810b7f80-c9da-11eb-9fcf-5941b630864e.png)
