### PR TITLE
Improve sidebar template

### DIFF
--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -27,6 +27,10 @@
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Clusters</span>
           </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">Systems</span>
+          </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Environments</span>
@@ -34,10 +38,6 @@
           <a class="menu-title js-select-current-parent js-feature-flag" href="/landscapes">
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Landscapes</span>
-          </a>
-          <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
-            <i class='eos-icons'>collocation</i>
-            <span class="menu-title-content">SAP Systems</span>
           </a>
         </li>
       </ul>

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -20,7 +20,7 @@
             <span class="menu-title-content">Home</span>
           </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/hosts">
-            <i class='eos-icons'>collocation</i>
+            <i class='eos-icons'>desktop_windows</i>
             <span class="menu-title-content">Hosts</span>
           </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/clusters">
@@ -28,15 +28,15 @@
             <span class="menu-title-content">Clusters</span>
           </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
-            <i class='eos-icons'>collocation</i>
+            <i class='eos-icons'>system_group</i>
             <span class="menu-title-content">Systems</span>
           </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/landscapes">
-            <i class='eos-icons'>collocation</i>
+            <i class='eos-icons'>landscape</i>
             <span class="menu-title-content">Landscapes</span>
           </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
-            <i class='eos-icons'>collocation</i>
+            <i class='eos-icons'>lock</i>
             <span class="menu-title-content">Environments</span>
           </a>
         </li>

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -31,13 +31,13 @@
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Systems</span>
           </a>
-          <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
-            <i class='eos-icons'>collocation</i>
-            <span class="menu-title-content">Environments</span>
-          </a>
           <a class="menu-title js-select-current-parent js-feature-flag" href="/landscapes">
             <i class='eos-icons'>collocation</i>
             <span class="menu-title-content">Landscapes</span>
+          </a>
+          <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
+            <i class='eos-icons'>collocation</i>
+            <span class="menu-title-content">Environments</span>
           </a>
         </li>
       </ul>


### PR DESCRIPTION
- reorder entries by size of the logical grouping
- remove the "SAP" prefix from "systems"
- change icons as [suggested by the UI team](https://xd.adobe.com/view/373605a0-149a-4b00-99b8-e84153fe0ca1-6265/)

Result:
![Screenshot from 2021-06-11 12-42-55](https://user-images.githubusercontent.com/2952427/121674765-c3a08b00-cab2-11eb-9055-3b6e3f0b3ca7.png)
