### PR TITLE
Don't let the app crash on 404s

### DIFF
--- a/web/clusters.go
+++ b/web/clusters.go
@@ -35,9 +35,15 @@ func NewClusterHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		clusterName := c.Param("name")
 
-		cluster, err := cluster.Load(client)
+		clusters, err := cluster.Load(client)
 		if err != nil {
 			_ = c.Error(err)
+			return
+		}
+
+		cluster, ok := clusters[clusterName]
+		if !ok {
+			_ = c.Error(NotFoundError("could not find cluster"))
 			return
 		}
 
@@ -49,7 +55,7 @@ func NewClusterHandler(client consul.Client) gin.HandlerFunc {
 		}
 
 		c.HTML(http.StatusOK, "cluster.html.tmpl", gin.H{
-			"Cluster": cluster[clusterName],
+			"Cluster": cluster,
 			"Hosts":   hosts,
 		})
 	}

--- a/web/environments.go
+++ b/web/environments.go
@@ -46,11 +46,11 @@ func NewEnvironmentHandler(client consul.Client) gin.HandlerFunc {
 
 func NewLandscapeListHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var env = ""
+		var envName string
 
 		query := c.Request.URL.Query()
 		if len(query["environment"]) > 0 {
-			env = query["environment"][0]
+			envName = query["environment"][0]
 		}
 
 		environments, err := environments.Load(client)
@@ -61,7 +61,7 @@ func NewLandscapeListHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "landscapes.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      env,
+			"EnvName":      envName,
 		})
 	}
 }
@@ -104,16 +104,15 @@ func NewLandscapeHandler(client consul.Client) gin.HandlerFunc {
 
 func NewSAPSystemListHandler(client consul.Client) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var env = ""
-		var land = ""
+		var envName, landName string
 
 		query := c.Request.URL.Query()
 		if len(query["environment"]) > 0 {
-			env = query["environment"][0]
+			envName = query["environment"][0]
 		}
 
 		if len(query["landscape"]) > 0 {
-			land = query["landscape"][0]
+			landName = query["landscape"][0]
 		}
 
 		environments, err := environments.Load(client)
@@ -124,8 +123,8 @@ func NewSAPSystemListHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "sapsystems.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      env,
-			"LandName":     land,
+			"EnvName":      envName,
+			"LandName":     landName,
 		})
 	}
 }

--- a/web/environments.go
+++ b/web/environments.go
@@ -30,9 +30,16 @@ func NewEnvironmentHandler(client consul.Client) gin.HandlerFunc {
 			return
 		}
 
+		envName := c.Param("env")
+		_, ok := environments[envName]
+		if !ok {
+			_ = c.Error(NotFoundError("could not find environment"))
+			return
+		}
+
 		c.HTML(http.StatusOK, "environment.html.tmpl", gin.H{
 			"Environments": environments,
-			"EnvName":      c.Param("env"),
+			"EnvName":      envName,
 		})
 	}
 }

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -238,6 +238,29 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/sapsystems/sys3\\?environment=env2&landscape=land3'\".*<td>sys3</td><td>.*critical.*</td>"), responseBody)
 }
 
+func TestLandscapeHandler404Error(t *testing.T) {
+	consulInst, _ := setupTest()
+
+	deps := DefaultDependencies()
+	deps.consul = consulInst
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/landscapes/foobar", nil)
+	req.Header.Set("Accept", "text/html")
+
+	app.ServeHTTP(resp, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.Code)
+	assert.Contains(t, resp.Body.String(), "Not Found")
+}
+
 func TestEnvironmentHandler404Error(t *testing.T) {
 	consulInst, _ := setupTest()
 

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -238,6 +238,29 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<tr.*onclick=\"window.location='/sapsystems/sys3\\?environment=env2&landscape=land3'\".*<td>sys3</td><td>.*critical.*</td>"), responseBody)
 }
 
+func TestEnvironmentHandler404Error(t *testing.T) {
+	consulInst, _ := setupTest()
+
+	deps := DefaultDependencies()
+	deps.consul = consulInst
+
+	var err error
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/environments/foobar", nil)
+	req.Header.Set("Accept", "text/html")
+
+	app.ServeHTTP(resp, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.Code)
+	assert.Contains(t, resp.Body.String(), "Not Found")
+}
+
 func TestSAPSystemHandler404Error(t *testing.T) {
 	consulInst, _ := setupTest()
 
@@ -256,11 +279,9 @@ func TestSAPSystemHandler404Error(t *testing.T) {
 
 	app.ServeHTTP(resp, req)
 
-	responseBody := minifyHtml(resp.Body.String())
 	assert.NoError(t, err)
-
 	assert.Equal(t, 404, resp.Code)
-	assert.Contains(t, responseBody, "Not Found")
+	assert.Contains(t, resp.Body.String(), "Not Found")
 }
 
 func minifyHtml(input string) string {

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -85,7 +85,7 @@ func NewHostHandler(client consul.Client) gin.HandlerFunc {
 		}
 
 		if catalogNode == nil {
-			c.AbortWithStatus(404)
+			_ = c.Error(NotFoundError("could not find host"))
 			return
 		}
 
@@ -119,7 +119,7 @@ func NewHAChecksHandler(client consul.Client) gin.HandlerFunc {
 		}
 
 		if catalogNode == nil {
-			c.AbortWithStatus(404)
+			_ = c.Error(NotFoundError("could not find host"))
 			return
 		}
 

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -169,13 +169,46 @@ func TestHostHandler404Error(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := httptest.NewRecorder()
+	resp := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/hosts/foobar", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	req.Header.Set("Accept", "text/html")
 
-	app.ServeHTTP(w, req)
+	app.ServeHTTP(resp, req)
 
-	assert.Equal(t, 404, w.Code)
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.Code)
+	assert.Contains(t, resp.Body.String(), "Not Found")
+}
+
+func TestHAChecksHandler404(t *testing.T) {
+	var err error
+
+	consulInst := new(mocks.Client)
+	catalog := new(mocks.Catalog)
+	catalog.On("Node", "foobar", (*consulApi.QueryOptions)(nil)).Return((*consulApi.CatalogNode)(nil), nil, nil)
+	consulInst.On("Catalog").Return(catalog)
+
+	deps := DefaultDependencies()
+	deps.consul = consulInst
+
+	app, err := NewAppWithDeps("", 80, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/hosts/foobar/ha-checks", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Accept", "text/html")
+
+	app.ServeHTTP(resp, req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, 404, resp.Code)
+	assert.Contains(t, resp.Body.String(), "Not Found")
 }


### PR DESCRIPTION
This PR adds checks and adds error handling on every parametric route (e.g.`/hosts/:host`)
It also adds tests for every handler.

WIP:

I am not sure on how the `NewLandscapeHandler` should behave, since it just tries to pull all the environments and then passes them to the view context, which does some filtering if the `envName` query param is passed or it just shows all the environments otherwise.
See: https://github.com/trento-project/trento/blob/2c9832ffc6fe0b500b200b0e604184f6fb81927e/web/environments.go#L62

I could cycle to check if the landscape exists, but I think I am missing some context here.

Thoughts? 