### PR TITLE
Add self-hosted actions runner continuous deployment

### DIFF
--- a/.github/actions/consul_cleanup/action.yaml
+++ b/.github/actions/consul_cleanup/action.yaml
@@ -1,0 +1,11 @@
+name: 'Consul cleanup'
+description: 'Stop and delete consul data'
+runs:
+  using: "composite"
+  steps:
+    - name: stop-consul
+      run: sudo systemctl stop consul
+      shell: bash
+    - name: delete-data
+      run: sudo rm -rf /srv/consul/data
+      shell: bash

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -1,0 +1,38 @@
+name: 'Deploy'
+description: 'Deploy trento'
+inputs:
+  role:
+    description: 'Trento role'
+    required: true
+    default: 'agent'
+runs:
+  using: "composite"
+  steps:
+    - name: stop-trento
+      run: sudo systemctl stop trento-${{ inputs.role }}
+      shell: bash
+    - name: uncompress
+      run: |
+        gunzip -f trento-amd64.gz
+        mv trento-amd64 trento
+      shell: bash
+    - name: chmod
+      run: chmod +x trento
+      shell: bash
+    - name: deploy-binary
+      run: rsync -av trento /srv/trento/
+      shell: bash
+    - name: deploy-rules
+      run: |
+        if [ "${{ inputs.role }}" = "agent" ]; then
+          rm -rf /srv/trento/examples
+          mkdir /srv/trento/examples
+          mv *.yaml /srv/trento/examples/
+        fi
+      shell: bash
+    - name: start-consul
+      run: sudo systemctl start consul
+      shell: bash
+    - name: start-trento
+      run: sudo systemctl start trento-${{ inputs.role }}
+      shell: bash

--- a/.github/actions/deploy/action.yaml
+++ b/.github/actions/deploy/action.yaml
@@ -27,7 +27,7 @@ runs:
         if [ "${{ inputs.role }}" = "agent" ]; then
           rm -rf /srv/trento/examples
           mkdir /srv/trento/examples
-          mv *.yaml /srv/trento/examples/
+          mv examples/*.yaml /srv/trento/examples/
         fi
       shell: bash
     - name: start-consul

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,12 +54,8 @@ jobs:
         with:
           name: trento-amd64-binary
           path: build/trento-amd64.gz
-      - uses: actions/upload-artifact@v2
-        with:
-          name: trento-examples-rules
-          path: examples
 
-  consul-cleanup-monitoring:
+  consul-cleanup:
     runs-on: [ self-hosted, vmmonitoring ]
     needs: build
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
@@ -70,7 +66,7 @@ jobs:
 
   deploy-hana01:
     runs-on: [ self-hosted, vmhana01 ]
-    needs: consul-cleanup-monitoring
+    needs: consul-cleanup
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v2
@@ -79,9 +75,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: trento-amd64-binary
-      - uses: actions/download-artifact@v2
-        with:
-          name: trento-examples-rules
       - id: deploy
         uses: ./.github/actions/deploy
         with:
@@ -89,7 +82,7 @@ jobs:
 
   deploy-hana02:
     runs-on: [ self-hosted, vmhana02 ]
-    needs: consul-cleanup-monitoring
+    needs: consul-cleanup
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v2
@@ -98,9 +91,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: trento-amd64-binary
-      - uses: actions/download-artifact@v2
-        with:
-          name: trento-examples-rules
       - id: deploy
         uses: ./.github/actions/deploy
         with:
@@ -108,7 +98,7 @@ jobs:
 
   deploy-monitoring:
     runs-on: [ self-hosted, vmmonitoring ]
-    needs: consul-cleanup-monitoring
+    needs: consul-cleanup
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,7 @@
 on:
   push:
   pull_request:
+  workflow_dispatch:
   release:
     types: [ published, created, edited ]
 
@@ -8,47 +9,118 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: ^1.16
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '15'
-    - uses: actions/cache@v2
-      id: go-cache
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/cache@v2
-      id: npm-cache
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - name: install-mockery
-      run: go install github.com/vektra/mockery/v2
-    - name: test
-      run: make test
-    - name: static analysis
-      run: make vet-check
-    - name: coding styles
-      run: make fmt-check
-    - name: build
-      run: make -j4 cross-compiled
-    - name: compress
-      run: |
-        set -x
-        for FILE in build/*; do
-          gzip $FILE
-        done
-    - uses: actions/upload-artifact@v2
-      with:
-        name: trento-binaries
-        path: build
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "15"
+      - uses: actions/cache@v2
+        id: go-cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/cache@v2
+        id: npm-cache
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: install-mockery
+        run: go install github.com/vektra/mockery/v2
+      - name: test
+        run: make test
+      - name: static analysis
+        run: make vet-check
+      - name: coding styles
+        run: make fmt-check
+      - name: build
+        run: make -j4 cross-compiled
+      - name: compress
+        run: |
+          set -x
+          for FILE in build/*; do
+            gzip $FILE
+          done
+      - uses: actions/upload-artifact@v2
+        with:
+          name: trento-binaries
+          path: build
+      - uses: actions/upload-artifact@v2
+        with:
+          name: trento-amd64-binary
+          path: build/trento-amd64.gz
+      - uses: actions/upload-artifact@v2
+        with:
+          name: trento-examples-rules
+          path: examples
+
+  consul-cleanup-monitoring:
+    runs-on: [ self-hosted, vmmonitoring ]
+    needs: build
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v2
+      - id: cleanup
+        uses: ./.github/actions/consul_cleanup
+
+  deploy-hana01:
+    runs-on: [ self-hosted, vmhana01 ]
+    needs: consul-cleanup-monitoring
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v2
+      - id: cleanup
+        uses: ./.github/actions/consul_cleanup
+      - uses: actions/download-artifact@v2
+        with:
+          name: trento-amd64-binary
+      - uses: actions/download-artifact@v2
+        with:
+          name: trento-examples-rules
+      - id: deploy
+        uses: ./.github/actions/deploy
+        with:
+          role: agent
+
+  deploy-hana02:
+    runs-on: [ self-hosted, vmhana02 ]
+    needs: consul-cleanup-monitoring
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v2
+      - id: cleanup
+        uses: ./.github/actions/consul_cleanup
+      - uses: actions/download-artifact@v2
+        with:
+          name: trento-amd64-binary
+      - uses: actions/download-artifact@v2
+        with:
+          name: trento-examples-rules
+      - id: deploy
+        uses: ./.github/actions/deploy
+        with:
+          role: agent
+
+  deploy-monitoring:
+    runs-on: [ self-hosted, vmmonitoring ]
+    needs: consul-cleanup-monitoring
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v2
+      - id: cleanup
+        uses: ./.github/actions/consul_cleanup
+      - uses: actions/download-artifact@v2
+        with:
+          name: trento-amd64-binary
+      - id: deploy
+        uses: ./.github/actions/deploy
+        with:
+          role: web
 
   upload-release-assets:
     needs: build
@@ -57,8 +129,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: trento-binaries
+          name: trento-binaries-gz
       - uses: AButler/upload-release-assets@v2.0
         with:
-          files: 'trento-*'
+          files: "trento-*"
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,28 +1,104 @@
-
 # Hacks
 
-This directory is a collection of scripts & utilities that can assist developers
-and users interested in testing and experimenting with Trento.
+This directory is a collection of scripts & utilities that can assist developers and users interested in testing and
+experimenting with Trento.
 
 ## deploy.sh
-`deploy.sh` is a very simple script that will attempt to copy the `trento` binary
-and the `consul` binary to a remote server and start both services
+
+`deploy.sh` is a very simple script that will attempt to copy the `trento` binary and the `consul` binary to a remote
+server and start both services
 
 ### Requirements
-The machines that we are deploying to require to have `rsync` as well as a running
-SSH server.
+
+The machines that we are deploying to require to have `rsync` as well as a running SSH server.
 
 ### Usage
+
 `./deploy.sh [username@]<target-server-ip> <consul-ip> [deploy-agent*|deploy-web]`
 
-  - `[username]@<target-server-ip>`
-    The IP address of the host where we are deploying `trento` and `consul` on.
-    
-  - `<consul-ip>`
-    The IP of the consul server that we are connecting to. When `deploy-web` is
-    used in the next field, this is ignored.
+- `[username]@<target-server-ip>`
+  The IP address of the host where we are deploying `trento` and `consul` on.
 
-  - `[deploy-agent|deploy-web]`
-    `deploy-agent` causes to deploy the `consul` and `trento` agents 
-    while
-    `deploy-web` causes to deploy the web server as well as a `consul` server instance
+- `<consul-ip>`
+  The IP of the consul server that we are connecting to. When `deploy-web` is used in the next field, this is ignored.
+
+- `[deploy-agent|deploy-web]`
+  `deploy-agent` causes to deploy the `consul` and `trento` agents while
+  `deploy-web` causes to deploy the web server as well as a `consul` server instance
+
+## Automatic deploy to private nodes with GitHub actions
+
+The repository contains a GitHub actions [workflow](../.github/workflows/ci.yaml) to deploy Trento to private nodes by
+using [self-hosted runners](https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners).
+
+This is triggered automatically when pushing (or merging PRs) into the `main` branch of the upstream remote, or manually
+by
+the [workflow_dispatch](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch)
+event
+(e.g., when working on forks).
+
+### Set up runners instances
+
+#### Generate token
+
+Refer
+to [this guide](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository)
+to add a runner to the repository. The generated token will be passed as a parameter to the provisioning script,
+see [Provision](#provision).
+
+Programmatically registering self-hosted runners is also possible by using the rest API.
+See [https://docs.github.com/en/rest/reference/actions#self-hosted-runners](https://docs.github.com/en/rest/reference/actions#self-hosted-runners)
+
+#### Runner labels
+
+The provided actions workflow expects 3 nodes in total: 2 hana nodes and a monitoring node. For the actions to run, the
+runners must have a label specifing the node type (`vmhana01`,`vmhana02` and `vmmonitoring`)
+
+#### Provision
+
+[`provision.sh`](./provision.sh) provides an easy way to boostrap a GitHub self-hosted runner environment on a private
+node.
+
+The script sets up users, configuration files, systemd unit and a self-hosted runner instance required in order to run
+Trento, Consul and the deployment process.
+
+`# ./provision.sh <github-user> <github-repo> <actions-runner-token> <actions-runner-name> <consul-bind-ip> <consul-server-ip> [agent|web]`
+
+- `<github-user>`
+  The GitHub username (e.g, `trento_project`).
+
+- `<github-repo>`
+  The GitHub repository name (e.g, `trento`).
+
+- `<actions-runner-token>`
+  See [Generate token](#generate-token).
+
+- `<actions-runner-name>`
+  The actions runner name.
+
+  One of `vmahana01`, `vmhana02`, `vmmonitoring` is expected if used in conjuction with the
+  provided [workflow](../.github/workflows/ci.yaml).
+
+- `[agent|web]`
+  `agent` provisions an agent instance
+  `web` provisions a web instance
+
+#### Example
+
+This example assumes a running cluster composed by two nodes and a monitoring instance. Refer
+to [ha-sap-terraform-deployments](https://github.com/SUSE/ha-sap-terraform-deployments) for the setup.
+
+[Generate 3 tokens](#generate-token), then run the provision script on each node.
+
+`vmhana01:~ # sh provision.sh youruser trento <TOKEN_1> vmhana01 10.162.30.92 10.162.29.225 agent`
+
+`vmhana02:~ # sh provision.sh youruser trento <TOKEN_2> vmhana02 10.162.30.93 10.162.29.225 agent`
+
+`vmmonitoring:~ # sh provision.sh youruser trento <TOKEN_3> vmmonitoring 10.162.29.225 10.162.29.225 web`
+
+### Manually triggering the deployment
+
+It is possible to manually trigger the deployment job from the GitHub Actions UI.
+
+See [https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
+for reference.

--- a/hack/consul-client.hcl.template
+++ b/hack/consul-client.hcl.template
@@ -1,0 +1,11 @@
+data_dir = "/srv/consul/data/"
+log_level = "DEBUG"
+
+datacenter = "dc1"
+
+ui = true
+
+bind_addr = "@BIND_ADDR@"
+client_addr = "0.0.0.0"
+
+retry_join = ["@JOIN_ADDR@"]

--- a/hack/consul-server.hcl.template
+++ b/hack/consul-server.hcl.template
@@ -1,0 +1,12 @@
+data_dir = "/srv/consul/data/"
+log_level = "DEBUG"
+
+datacenter = "dc1"
+
+ui = true
+
+bind_addr = "@BIND_ADDR@"
+client_addr = "0.0.0.0"
+
+server = true
+bootstrap_expect = 1

--- a/hack/consul.service
+++ b/hack/consul.service
@@ -1,0 +1,18 @@
+[Unit]
+Description="HashiCorp Consul - A service mesh solution"
+Documentation=https://www.consul.io/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/srv/consul/consul.d/consul.hcl
+
+[Service]
+User=consul
+ExecStart=/srv/consul/consul agent -config-dir=/srv/consul/consul.d
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=5
+Type=notify
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/provision.sh
+++ b/hack/provision.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+
+set -eu
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root"
+  exit
+fi
+
+echo ""
+echo "Provisioning..."
+
+if [ $# -lt 7 ]; then
+  echo "Usage: ./provision.sh <github-user> <github-repo> <actions-runner-token> <actions-runner-name> <consul-bind-ip> <consul-server-ip> [agent|web]"
+  exit 1
+fi
+
+ACTIONS_RUNNER_VERSION=2.278.0
+ACTIONS_RUNNER_USER=github-runner
+ACTIONS_RUNNER_HOME=/srv/github-runner
+ACTIONS_RUNNER_REPO_OWNER=$1
+ACTIONS_RUNNER_REPO_NAME=$2
+ACTIONS_RUNNER_TOKEN=$3
+ACTIONS_RUNNER_NAME=$4
+ACTIONS_RUNNER_PATH="$ACTIONS_RUNNER_HOME/actions-runner"
+ACTIONS_RUNNER_REPO_URL="https://github.com/$ACTIONS_RUNNER_REPO_OWNER/$ACTIONS_RUNNER_REPO_NAME"
+ACTIONS_RUNNER_SYSTEMD_UNIT="actions.runner.$ACTIONS_RUNNER_REPO_OWNER-$ACTIONS_RUNNER_REPO_NAME.$ACTIONS_RUNNER_NAME.service"
+
+CONSUL_VERSION=1.9.6
+CONSUL_BIND_IP=$5
+CONSUL_SERVER_IP=$6
+CONSUL_USER=consul
+CONSUL_HOME=/srv/consul
+CONSUL_CONFIG_PATH="$CONSUL_HOME/consul.d"
+
+ROLE=$7
+if [ "$ROLE" = "agent" ]; then
+  CONSUL_HCL="consul-client.hcl"
+elif [ "$ROLE" = "web" ]; then
+  CONSUL_HCL="consul-server.hcl"
+else
+  echo "Please specify a valid role"
+  exit
+fi
+
+CONSUL_HCL_TEMPLATE_URL="https://raw.githubusercontent.com/$ACTIONS_RUNNER_REPO_OWNER/$ACTIONS_RUNNER_REPO_NAME/main/hack/$CONSUL_HCL.template"
+
+CONSUL_SYSTEMD_UNIT="consul.service"
+CONSUL_SYSTEMD_UNIT_URL="https://raw.githubusercontent.com/$ACTIONS_RUNNER_REPO_OWNER/$ACTIONS_RUNNER_REPO_NAME/main/hack/$CONSUL_SYSTEMD_UNIT"
+
+TRENTO_PATH=/srv/trento
+TRENTO_SYSTEMD_UNIT="trento-$ROLE.service"
+TRENTO_SYSTEMD_UNIT_URL="https://raw.githubusercontent.com/$ACTIONS_RUNNER_REPO_OWNER/$ACTIONS_RUNNER_REPO_NAME/main/hack/$TRENTO_SYSTEMD_UNIT"
+
+create_user() {
+  local user=$1
+  local home=$2
+
+  echo ""
+  echo "* Creating user: $user"
+
+  if id "$user" &>/dev/null; then
+    echo "  Warning: user $user already exists. Skipping..."
+    return
+  fi
+
+  useradd --system -d "$home" "$user"
+  mkdir -p "$home"
+  chown "$user" "$home"
+}
+
+install_actions_runner() {
+  echo ""
+  echo "* Installing GitHub Actions Runner"
+
+  if [ -f "$ACTIONS_RUNNER_PATH/.runner" ]; then
+    echo "  Warning: Actions Runner already installed and configured. Skipping..."
+    return
+  fi
+
+  mkdir -p $ACTIONS_RUNNER_PATH
+  pushd -- "$ACTIONS_RUNNER_PATH" >/dev/null
+  curl -f -sS -O -L "https://github.com/actions/runner/releases/download/v${ACTIONS_RUNNER_VERSION}/actions-runner-linux-x64-${ACTIONS_RUNNER_VERSION}.tar.gz" >/dev/null
+  tar xfz "actions-runner-linux-x64-${ACTIONS_RUNNER_VERSION}.tar.gz"
+  rm "actions-runner-linux-x64-${ACTIONS_RUNNER_VERSION}.tar.gz"
+  chown -R $ACTIONS_RUNNER_USER $ACTIONS_RUNNER_PATH
+
+  echo "  Installing dependencies"
+  ./bin/installdependencies.sh >/dev/null
+
+  echo "  Configuring"
+  su -m $ACTIONS_RUNNER_USER -c "./config.sh --token $ACTIONS_RUNNER_TOKEN --unattended --url $ACTIONS_RUNNER_REPO_URL --name $ACTIONS_RUNNER_NAME --labels $ACTIONS_RUNNER_NAME >/dev/null"
+
+  if [ -f "/etc/systemd/system/$ACTIONS_RUNNER_SYSTEMD_UNIT" ]; then
+    echo "  Warning: Systemd unit already installed. Removing..."
+    systemctl stop "$ACTIONS_RUNNER_SYSTEMD_UNIT"
+    rm "/etc/systemd/system/$ACTIONS_RUNNER_SYSTEMD_UNIT"
+  fi
+
+  echo "  Installing systemd unit"
+  ./svc.sh install >/dev/null
+  systemctl enable --now "$ACTIONS_RUNNER_SYSTEMD_UNIT"
+
+  popd >/dev/null
+}
+
+install_consul() {
+  echo ""
+  echo "* Installing Consul"
+
+  mkdir -p $CONSUL_CONFIG_PATH
+  pushd -- "$CONSUL_HOME" >/dev/null
+  curl -f -sS -O -L "https://releases.hashicorp.com/consul/$CONSUL_VERSION/consul_${CONSUL_VERSION}_linux_amd64.zip" >/dev/null
+  unzip -o "consul_${CONSUL_VERSION}_linux_amd64".zip >/dev/null
+  rm "consul_${CONSUL_VERSION}_linux_amd64".zip
+  chown -R $CONSUL_USER $CONSUL_HOME
+  popd >/dev/null
+}
+
+setup_consul() {
+  echo ""
+  echo "* Setting up Consul"
+
+  echo "  Creating configuration"
+  pushd -- $CONSUL_CONFIG_PATH >/dev/null
+  curl -f -sS -O -L $CONSUL_HCL_TEMPLATE_URL >/dev/null
+  cat $CONSUL_HCL.template | sed "s|@JOIN_ADDR@|${CONSUL_SERVER_IP}|g" | sed "s|@BIND_ADDR@|${CONSUL_BIND_IP}|g" >consul.hcl
+  rm $CONSUL_HCL.template
+  popd >/dev/null
+
+  if [ -f "/etc/systemd/system/$CONSUL_SYSTEMD_UNIT" ]; then
+    echo "  Warning: Systemd unit already installed. Removing..."
+    systemctl stop "$CONSUL_SYSTEMD_UNIT"
+    rm "/etc/systemd/system/$CONSUL_SYSTEMD_UNIT"
+  fi
+
+  echo "  Installing systemd unit"
+  curl -f -sS -L $CONSUL_SYSTEMD_UNIT_URL -o /tmp/$CONSUL_SYSTEMD_UNIT >/dev/null
+
+  if [ "$ROLE" = "web" ]; then
+    sed -i "s|Type=notify|Type=simple|g" /tmp/$CONSUL_SYSTEMD_UNIT
+  fi
+
+  mv /tmp/$CONSUL_SYSTEMD_UNIT /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable --now $CONSUL_SYSTEMD_UNIT
+
+  echo "  Adding sudoers entries"
+  echo "$ACTIONS_RUNNER_USER ALL=(ALL) NOPASSWD: /bin/systemctl start consul" >/etc/sudoers.d/github-runner-consul
+  echo "$ACTIONS_RUNNER_USER ALL=(ALL) NOPASSWD: /bin/systemctl stop consul" >>/etc/sudoers.d/github-runner-consul
+  echo "$ACTIONS_RUNNER_USER ALL=(ALL) NOPASSWD: /bin/rm -rf /srv/consul/data" >>/etc/sudoers.d/github-runner-consul
+}
+
+setup_trento() {
+  echo ""
+  echo "* Setting up Trento"
+
+  echo "  Creating Trento directory"
+  mkdir -p $TRENTO_PATH
+  chown -R $ACTIONS_RUNNER_USER $TRENTO_PATH
+
+  if [ -f "/etc/systemd/system/$TRENTO_SYSTEMD_UNIT" ]; then
+    echo "  Warning: Systemd unit already installed. Removing..."
+    systemctl stop "$TRENTO_SYSTEMD_UNIT"
+    rm "/etc/systemd/system/$TRENTO_SYSTEMD_UNIT"
+  fi
+
+  echo "  Installing systemd unit"
+  curl -f -sS -L "$TRENTO_SYSTEMD_UNIT_URL" -o /tmp/"$TRENTO_SYSTEMD_UNIT" >/dev/null
+  mv /tmp/"$TRENTO_SYSTEMD_UNIT" /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable "$TRENTO_SYSTEMD_UNIT"
+
+  echo "  Adding sudoers entries"
+  echo "$ACTIONS_RUNNER_USER ALL=(ALL) NOPASSWD: /bin/systemctl start trento-$ROLE" >/etc/sudoers.d/github-runner-trento
+  echo "$ACTIONS_RUNNER_USER ALL=(ALL) NOPASSWD: /bin/systemctl stop trento-$ROLE" >>/etc/sudoers.d/github-runner-trento
+}
+
+create_user $ACTIONS_RUNNER_USER $ACTIONS_RUNNER_HOME
+install_actions_runner
+create_user $CONSUL_USER $CONSUL_HOME
+install_consul
+setup_consul
+setup_trento
+echo ""
+echo "Done!"

--- a/hack/trento-agent.service
+++ b/hack/trento-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Trento agent service
+Requires=consul.service
+After=consul.service
+
+[Service]
+ExecStart=/srv/trento/trento agent start --consul-config-dir=/srv/consul/consul.d /srv/trento/examples/generic-azure.yaml
+Type=simple
+User=root
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/hack/trento-web.service
+++ b/hack/trento-web.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Trento Web UI
+
+[Service]
+ExecStart=/srv/trento/trento web serve
+Type=simple
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds continuous deployment jobs to the GitHub actions.

GitHub self-hosted runners are used for the deployment process, this is triggered by pushing or merging  PRs to the main branch or manually by using a workflow dispatch event.
Every node needs a running instance of a self-hosted runner and consul. 
A provisioning script which bootstraps Consul, Trento and the runner environment was added to the hack folder.

By configuring the runners on forks, it is possible to deploy on private development nodes.
Please refer to the [hack/README.md ](https://github.com/fabriziosestito/trento/blob/actions/hack/README.md) for setup instructions and detailed documentation.

