### PR TITLE
Add version command to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-GO_BUILD = CGO_ENABLED=0 go build -trimpath -ldflags "-s -w"
+VERSION ?= $(shell hack/get_version_from_git.sh)
+GO_BUILD = CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/trento-project/trento/cmd.version=$(VERSION)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 
 default: clean mod-tidy fmt vet-check test build

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,23 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var version string
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of Trento",
+	Long:  `All software has versions. This is Trento's`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Trento version %s\nbuilt with %s %s/%s\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	},
+}

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+
+if [ -n "${TAG}" ]; then
+  COMMITS_SINCE_TAG=$(git rev-list "${TAG}".. --count)
+  if [ "${COMMITS_SINCE_TAG}" -gt 0 ]; then
+    COMMIT_SHA=$(git show -s --format=%ct.%h HEAD)
+    SUFFIX="+git.dev${COMMITS_SINCE_TAG}.${COMMIT_SHA}"
+  fi
+else
+  TAG="0"
+fi
+
+echo "${TAG}${SUFFIX}"


### PR DESCRIPTION
This PR adds the `version` command to trento CLI by injecting the version number when building.

Resolves #104 