### PR TITLE
Add: Set log timestamp format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,7 @@ func initConfig() {
 		logLevel = "info"
 	}
 	internal.SetLogLevel(logLevel)
+	internal.SetLogFormatter("2006-01-02 15:04:05")
 
 	viper.AutomaticEnv() // read in environment variables that match
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -26,6 +26,13 @@ func SetLogLevel(level string) {
 	}
 }
 
+func SetLogFormatter(timestampFormat string) {
+	customFormatter := new(log.TextFormatter)
+	customFormatter.TimestampFormat = timestampFormat
+	log.SetFormatter(customFormatter)
+	customFormatter.FullTimestamp = true
+}
+
 func Contains(s []string, str string) bool {
 	for _, v := range s {
 		if v == str {


### PR DESCRIPTION
Without setting the formatter, the logrus shows zeroes instead of timestamps.