### PR TITLE
Collect hdbnsutil -sr_state output

### DIFF
--- a/internal/consul/kv_test.go
+++ b/internal/consul/kv_test.go
@@ -302,6 +302,10 @@ func TestKVPutMap(t *testing.T) {
 						"itemd": "d",
 					},
 				},
+				"simple_list": []interface{}{
+					"value1",
+					"value2",
+				},
 			},
 			map[string]interface{}{
 				"item2": true,
@@ -350,6 +354,9 @@ func TestKVPutMap(t *testing.T) {
 		&consulApi.KVPair{Key: "/trento/list/0000/other_list/0000/itemb", Value: []byte("b"), Flags: stringFlag},
 		&consulApi.KVPair{Key: "/trento/list/0000/other_list/0001/itemc", Value: []byte("c"), Flags: stringFlag},
 		&consulApi.KVPair{Key: "/trento/list/0000/other_list/0001/itemd", Value: []byte("d"), Flags: stringFlag},
+		&consulApi.KVPair{Key: "/trento/list/0000/simple_list/", Value: []byte(""), Flags: sliceFlag},
+		&consulApi.KVPair{Key: "/trento/list/0000/simple_list/0000", Value: []byte("value1"), Flags: stringFlag},
+		&consulApi.KVPair{Key: "/trento/list/0000/simple_list/0001", Value: []byte("value2"), Flags: stringFlag},
 		&consulApi.KVPair{Key: "/trento/list/0001/item2", Value: []byte("true"), Flags: boolFlag},
 		&consulApi.KVPair{Key: "/trento/list/0002/item3", Value: []byte("3"), Flags: intFlag},
 		&consulApi.KVPair{Key: "/trento/list/0003/item4", Value: []byte("4"), Flags: intFlag},

--- a/internal/sapsystem/sapsystem.go
+++ b/internal/sapsystem/sapsystem.go
@@ -240,7 +240,7 @@ func NewSAPInstance(w sapcontrol.WebService) (*SAPInstance, error) {
 
 func runPythonSupport(sid, instance, script string) map[string]interface{} {
 	user := fmt.Sprintf("%sadm", strings.ToLower(sid))
-	cmdPath := path.Join("/usr/sap", sid, instance, "exe/python_support", script)
+	cmdPath := path.Join(sapInstallationPath, sid, instance, "exe/python_support", script)
 	cmd := fmt.Sprintf("python %s --sapcontrol=1", cmdPath)
 	// Even with a error return code, some data is available
 	srData, _ := customExecCommand("su", "-lc", cmd, user).Output()
@@ -260,7 +260,7 @@ func landscapeHostConfiguration(sid, instance string) map[string]interface{} {
 
 func hdbnsutilSrstate(sid, instance string) map[string]interface{} {
 	user := fmt.Sprintf("%sadm", strings.ToLower(sid))
-	cmdPath := path.Join("/usr/sap", sid, instance, "exe", "hdbnsutil")
+	cmdPath := path.Join(sapInstallationPath, sid, instance, "exe", "hdbnsutil")
 	cmd := fmt.Sprintf("%s -sr_state -sapcontrol=1", cmdPath)
 	srData, _ := customExecCommand("su", "-lc", cmd, user).Output()
 	dataMap := internal.FindMatches(`(.+)=(.*)`, srData)

--- a/internal/sapsystem/sapsystem_kvstore_test.go
+++ b/internal/sapsystem/sapsystem_kvstore_test.go
@@ -100,6 +100,14 @@ func TestStore(t *testing.T) {
 					"key10":       "value10",
 					"key20/key30": "value20",
 				},
+				HdbnsutilSRstate: HdbnsutilSRstate{
+					"online": "true",
+					"mode":   "primary",
+					"mapping/hana01": []interface{}{
+						"Site2/hana02",
+						"Site1/hana01",
+					},
+				},
 			},
 		},
 	}
@@ -184,6 +192,14 @@ func TestStore(t *testing.T) {
 				HostConfiguration: HostConfiguration{
 					"key10":       "value10",
 					"key20/key30": "value20",
+				},
+				HdbnsutilSRstate: HdbnsutilSRstate{
+					"online": "true",
+					"mode":   "primary",
+					"mapping/hana01": []interface{}{
+						"Site2/hana02",
+						"Site1/hana01",
+					},
 				},
 			},
 		},
@@ -282,6 +298,14 @@ func TestLoad(t *testing.T) {
 							"key30": "value20",
 						},
 					},
+					"hdbnsutilsrstate": map[string]interface{}{
+						"online": "true",
+						"mode":   "primary",
+						"mapping/hana01": []interface{}{
+							"Site2/hana02",
+							"Site1/hana01",
+						},
+					},
 				},
 			},
 		},
@@ -372,6 +396,14 @@ func TestLoad(t *testing.T) {
 						"key10": "value10",
 						"key20": map[string]interface{}{
 							"key30": "value20",
+						},
+					},
+					HdbnsutilSRstate: HdbnsutilSRstate{
+						"online": "true",
+						"mode":   "primary",
+						"mapping/hana01": []interface{}{
+							"Site2/hana02",
+							"Site1/hana01",
 						},
 					},
 				},

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -64,7 +65,16 @@ func FindMatches(pattern string, text []byte) map[string]interface{} {
 	r := regexp.MustCompile(pattern)
 	values := r.FindAllStringSubmatch(string(text), -1)
 	for _, match := range values {
-		configMap[match[1]] = match[2]
+		key := strings.Replace(match[1], " ", "_", -1)
+		if _, ok := configMap[key]; ok {
+			switch configMap[key].(type) {
+			case string:
+				configMap[key] = []interface{}{configMap[key]}
+			}
+			configMap[key] = append(configMap[key].([]interface{}), match[2])
+		} else {
+			configMap[key] = match[2]
+		}
 	}
 	return configMap
 }

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -59,6 +59,12 @@ func Md5sum(filePath string) (string, error) {
 	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
+// FindMatches finds regular expression matches in a key/value based
+// text (ini files, for example), and returns a map with them.
+// If the matched key has spaces, they will be replaced with underscores
+// If the same keys is found multiple times, the entry of the map will
+// have a list as value with all of the matched values
+// The pattern must have 2 groups. For example: `(.+)=(.*)`
 func FindMatches(pattern string, text []byte) map[string]interface{} {
 	configMap := make(map[string]interface{})
 

--- a/test/hdbnsutil_srstate
+++ b/test/hdbnsutil_srstate
@@ -1,0 +1,22 @@
+SAPCONTROL-OK: <begin>
+online=true
+mode=primary
+operation mode=primary
+site id=1
+site name=Site1
+isSource=true
+isConsumer=false
+hasConsumers=true
+isTakeoverActive=false
+isPrimarySuspended=false
+mapping/hana01=Site2/hana02
+mapping/hana01=Site1/hana01
+siteTier/Site1=1
+siteTier/Site2=2
+siteReplicationMode/Site1=primary
+siteReplicationMode/Site2=sync
+siteOperationMode/Site1=primary
+siteOperationMode/Site2=logreplay
+siteMapping/Site1=Site2
+SAPCONTROL-OK: <end>
+done.


### PR DESCRIPTION
`hdbnsutil -sr_state` command collection on the KV storage (only applies to HANA).

Basically, it calls the command and stores the information.
Unfortunately the output of this command is not that good (spaces on the keys, duplicated keys...), so I have needed to do some changes in the `utils.go` and kv functions.

Find an example of the output at: https://github.com/trento-project/trento/compare/main...arbulu89:feature/hdbnsutil_srstate?expand=1#diff-3cb2d1a90eb474b2de290c02412e79c94d2d5ea4066ee823dd3fc400d86def00

I took advantage to remodelate a bit the KV function to make them a bit cleaner and add some new UT scenario.

The data is not used yet in the frontend, but it will at some point.

This is the kv data:
![image](https://user-images.githubusercontent.com/36370954/123656962-a8fb3f80-d830-11eb-8649-4091b846ad42.png)
![image](https://user-images.githubusercontent.com/36370954/123656992-b0224d80-d830-11eb-8a9c-9937a63315c8.png)
![image](https://user-images.githubusercontent.com/36370954/123657032-ba444c00-d830-11eb-9bf6-0d28c7ae2e5c.png)


