### PR TITLE
Separate tags in the host list view

### DIFF
--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -21,7 +21,9 @@ func TestHostsListHandler(t *testing.T) {
 			Datacenter: "dc1",
 			Address:    "192.168.1.1",
 			Meta: map[string]string{
-				"trento-sap-environments": "land1",
+				"trento-sap-environment": "env1",
+				"trento-sap-landscape":   "land1",
+				"trento-sap-system":      "sys1",
 			},
 		},
 		{
@@ -29,7 +31,9 @@ func TestHostsListHandler(t *testing.T) {
 			Datacenter: "dc",
 			Address:    "192.168.1.2",
 			Meta: map[string]string{
-				"trento-sap-environments": "land2",
+				"trento-sap-environment": "env2",
+				"trento-sap-landscape":   "land2",
+				"trento-sap-system":      "sys2",
 			},
 		},
 	}
@@ -149,8 +153,8 @@ func TestHostsListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<select name=trento-sap-environment.*>.*env1.*env2.*</select>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<select name=trento-sap-landscape.*>.*land1.*land2.*land3.*</select>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<select name=trento-sap-system.*>.*sys1.*sys2.*sys3.*</select>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td>foo</td><td>192.168.1.1</td><td>.*land1.*</td><td>.*passing.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td>bar</td><td>192.168.1.2</td><td>.*land2.*</td><td>.*critical.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td>.*foo.*</td><td>192.168.1.1</td><td>.*sys1.*</td><td>.*land1.*</td><td>.*env1.*</td><td>.*passing.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td>.*bar.*</td><td>192.168.1.2</td><td>.*sys2.*</td><td>.*land2.*</td><td>.*env2.*</td><td>.*critical.*</td>"), minified)
 }
 
 func TestHostHandler(t *testing.T) {

--- a/web/templates/blocks/hosts_table.html.tmpl
+++ b/web/templates/blocks/hosts_table.html.tmpl
@@ -6,28 +6,41 @@
                 <th scope='col'>Name</th>
                 <th scope='col'>Address</th>
                 <th scope='col'>Cluster</th>
-                <th scope='col'>Tags</th>
+                <th scope='col'>System</th>
+                <th scope='col'>Landscape</th>
+                <th scope='col'>Environment</th>
                 <th scope='col'>Status</th>
             </tr>
             </thead>
             <tbody>
             {{- range .Hosts }}
-                <tr class='clickable' onclick="window.location='/hosts/{{ .Name }}'">
-                    <td>{{ .Name }}</td>
+                <tr>
+                    <td>
+                        <a href='/hosts/{{ .Name }}'>
+                            {{ .Name }}
+                        </a>
+                    </td>
                     <td>{{ .Address }}</td>
                     <td>
-                        <a href="/clusters/{{ index .TrentoMeta "trento-ha-cluster-id" }}">{{ index .TrentoMeta "trento-ha-cluster" }}</a>
+                        <a href='/clusters/{{ index .TrentoMeta "trento-ha-cluster-id" }}'>
+                            {{ index .TrentoMeta "trento-ha-cluster" }}
+                        </a>
                     </td>
                     <td>
-                        {{- range $Key, $Value := .TrentoMeta }}
-                            {{- if eq $Key "trento-ha-cluster" }}
-                            {{- else if eq $Key "trento-ha-cluster-id" }}
-                            {{- else }}
-                                <span class='badge badge-pill badge-info'>{{ $Value }}</span>
-                            {{- end }}
-                        {{- end }}
+                        <a href='/sapsystems/{{ index .TrentoMeta "trento-sap-system" }}?environment={{ index .TrentoMeta "trento-sap-environment" }}&landscape={{ index .TrentoMeta "trento-sap-landscape" }}'>
+                            {{ index .TrentoMeta "trento-sap-system" }}
+                        </a>
                     </td>
-
+                    <td>
+                        <a href='/landscapes/{{ index .TrentoMeta "trento-sap-landscape" }}?environment={{ index .TrentoMeta "trento-sap-environment" }}'>
+                            {{ index .TrentoMeta "trento-sap-landscape" }}
+                        </a>
+                    </td>
+                    <td>
+                        <a href='/environments/{{ index .TrentoMeta "trento-sap-environment" }}'>
+                            {{ index .TrentoMeta "trento-sap-environment" }}
+                        </a>
+                    </td>
                     <td>
                         {{- $Health := .Health }}
                         <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }}</span>


### PR DESCRIPTION
This PR changes the hosts list view "tags" column to be split in separate columns. The goal is to provide the user a better representation of what environment, landscape, and SID a host might belong to.
EDIT: Add screenshot
![hosts-table](https://user-images.githubusercontent.com/2668401/124088858-45992980-da4b-11eb-8b33-1756c863ca3b.png)
