### PR TITLE
Add: Output for ha_cluster_discovery and sap_system_discovery

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -241,18 +241,19 @@ func (a *Agent) startCheckTicker() {
 func (a *Agent) startDiscoverTicker() {
 	tick := func() {
 		for _, d := range a.discoveries {
-			var status string
+			var status, result string
 			var err error
 
-			err = d.Discover()
+			result, err = d.Discover()
 			if err != nil {
 				log.Printf("Error while running discovery '%s': %s", d.GetId(), err)
+				result = err.Error()
 				status = consulApi.HealthWarning
 			} else {
 				status = consulApi.HealthPassing
 			}
 
-			err = a.consul.Agent().UpdateTTL(d.GetId(), "", status)
+			err = a.consul.Agent().UpdateTTL(d.GetId(), result, status)
 			if err != nil {
 				log.Println("An error occurred while trying to update TTL with Consul:", err)
 			}

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"fmt"
+
 	"github.com/trento-project/trento/internal/cloud"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
@@ -24,23 +26,23 @@ func (d CloudDiscovery) GetId() string {
 	return d.id
 }
 
-func (d CloudDiscovery) Discover() error {
+func (d CloudDiscovery) Discover() (string, error) {
 	cloudData, err := cloud.NewCloudInstance()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = cloudData.Store(d.discovery.client)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = storeCloudMetadata(d.discovery.client, cloudData.Provider)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return fmt.Sprintf("Cloud provider %s discovered", cloudData.Provider), nil
 }
 
 func storeCloudMetadata(client consul.Client, cloudProvider string) error {

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"fmt"
+
 	"github.com/trento-project/trento/internal/cluster"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
@@ -27,26 +29,26 @@ func (c ClusterDiscovery) GetId() string {
 }
 
 // Execute one iteration of a discovery and store the result in the Consul KVStore.
-func (d ClusterDiscovery) Discover() error {
+func (d ClusterDiscovery) Discover() (string, error) {
 	cluster, err := cluster.NewCluster()
 
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	d.Cluster = cluster
 
 	err = d.Cluster.Store(d.discovery.client)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = storeClusterMetadata(d.discovery.client, cluster.Name, cluster.Id)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return fmt.Sprintf("Cluster with name: %s successfully discovered", cluster.Name), nil
 }
 
 func storeClusterMetadata(client consul.Client, clusterName string, clusterId string) error {

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -10,7 +10,7 @@ type Discovery interface {
 	// Returns an arbitrary unique string identifier of the discovery, so that we can associate it to a Consul check ID
 	GetId() string
 	// Execute the discovery mechanism
-	Discover() error
+	Discover() (string, error)
 }
 
 type BaseDiscovery struct {
@@ -24,9 +24,9 @@ func (d BaseDiscovery) GetId() string {
 }
 
 // Execute one iteration of a discovery and store the result in the Consul KVStore.
-func (d BaseDiscovery) Discover() error {
+func (d BaseDiscovery) Discover() (string, error) {
 	d.host, _ = os.Hostname()
-	return nil
+	return "Basic discovery example", nil
 }
 
 // Return a Host Discover instance


### PR DESCRIPTION
This is an init PR for the ticket CFSA-166.

Quote from CFSA-166: 

"""

We currently do have the Discovery health check loops report any output when they tick.

We should always report some output from all the health checks, both in case of success and failure.

It might also be worth re-thinking their error handling: for example, if the Agent is executed in a host that is not part of any SAP System, that discovery loop will still appear as green, while this is probably either a configuration mistake or an Agent malfunction.

Bear in mind that the output size is limited to 4KB, so we can't just dump extensive data there. Thus, this rework should go hand in hand with better logging.

Acceptance Criteria
The discovery loops have to report some human readable output to the Consul API, both in case of success and failure.
In case such health checks fail, a full trace of the occurred errors must be reported in the Agent logs.
A discovery loop health check failure must be reproduced and demonstrated live.

"""