### PR TITLE
Add templates sanity check

### DIFF
--- a/web/errors.go
+++ b/web/errors.go
@@ -1,6 +1,10 @@
 package web
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
 
 func ErrorHandler(c *gin.Context) {
 	c.Next()
@@ -53,7 +57,15 @@ func (e *HttpError) Template() string {
 func NotFoundError(msg string) *HttpError {
 	return &HttpError{
 		msg,
-		404,
+		http.StatusNotFound,
 		"error404.html.tmpl",
+	}
+}
+
+func InternalServerError(msg string) *HttpError {
+	return &HttpError{
+		msg,
+		http.StatusInternalServerError,
+		"error.html.tmpl",
 	}
 }


### PR DESCRIPTION
Gin does not handle properly errors when they occur during the template rendering.
This because the `ResponseWriter` status is immutable see: https://github.com/gin-gonic/gin/blob/ee4de846a894e9049321e809d69f4343f62d2862/response_writer.go#L63 
so when `context.HTML` is called the Status is already set and it's not changed by the panic recovering to 500.

To fix this behavior, this PR introduces a `LayoutHTML` renderer which is returned instead of gin's `render.HTML` by our `LayoutRender.Instance` method.
The `Render` method simply tries to render the template on a buffer, and renders an error template/error status code in case something goes wrong.

Now the `TestSAPSystemHandler` fails as expected, I might need some help fixing this.