### PR TITLE
side menu: show the right title on hover

### DIFF
--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -14,29 +14,53 @@
             <div class="nav-wrap">
                 <ul class="menu-togglable no-list-style">
                     <li class="menu-item">
-                        <div class="menu-element" style="bottom: auto; top: 0; left: 0;">
+                        <div class="menu-element">
                             <span class="main-collapsed-title">Home</span>
                         </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/">
                             <i class="eos-icons">home</i>
                             <span class="menu-title-content">Home</span>
                         </a>
+                    </li>
+                    <li class="menu-item">
+                        <div class="menu-element">
+                            <span class="main-collapsed-title">Hosts</span>
+                        </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/hosts">
                             <i class='eos-icons'>desktop_windows</i>
                             <span class="menu-title-content">Hosts</span>
                         </a>
+                    </li>
+                    <li class="menu-item">
+                        <div class="menu-element">
+                            <span class="main-collapsed-title">Clusters</span>
+                        </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/clusters">
                             <i class='eos-icons'>collocation</i>
                             <span class="menu-title-content">Clusters</span>
                         </a>
+                    </li>
+                    <li class="menu-item">
+                        <div class="menu-element">
+                            <span class="main-collapsed-title">Systems</span>
+                        </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
                             <i class='eos-icons'>system_group</i>
                             <span class="menu-title-content">Systems</span>
                         </a>
+                    </li>
+                    <li class="menu-item">
+                        <div class="menu-element">
+                            <span class="main-collapsed-title">Landscapes</span>
+                        </div>                    
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/landscapes">
                             <i class='eos-icons'>landscape</i>
                             <span class="menu-title-content">Landscapes</span>
                         </a>
+                    <li class="menu-item">
+                        <div class="menu-element">
+                            <span class="main-collapsed-title">Environments</span>
+                        </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/environments">
                             <i class='eos-icons'>lock</i>
                             <span class="menu-title-content">Environments</span>


### PR DESCRIPTION
This PR addresses issue #128 .

The sidebar menu now expands only the highlighted title on hover (instead of always showing the "home" title)