### PR TITLE
Update generic layout styles to make the view wider

### DIFF
--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -70,3 +70,8 @@ dt {
   vertical-align: middle;
   font-size: 1.57em;
 }
+
+.container {
+  padding: 75px 75px 0 75px !important;
+  max-width: 100% !important;
+}

--- a/web/templates/blocks/submenu.html.tmpl
+++ b/web/templates/blocks/submenu.html.tmpl
@@ -1,11 +1,6 @@
 {{ define "submenu" }}
-    {{ if gt (len .) 0 }}
-        <div class="submenu js-submenu-section">
-            <nav class="main-submenu js-submenu-make-visible" data-parent-menu="">
-                {{ range . }}
-                    <a class="submenu-item js-select-current" href="{{ .URL }}">{{ .Label }}</a>
-                {{ end }}
-            </nav>
-        </div>
-    {{ end }}
+<div class="submenu js-submenu-section">
+    <nav class="main-submenu js-submenu-make-visible" data-parent-menu="">
+    </nav>
+</div>
 {{ end }}


### PR DESCRIPTION
Some main layout style changes:
- Update layout padding to have a wider content view
- Create the submenu bar always, even if its emtpy

![image](https://user-images.githubusercontent.com/36370954/125243029-cda1ed80-e2ed-11eb-8be8-d68e405989e7.png)
![image](https://user-images.githubusercontent.com/36370954/125243067-da264600-e2ed-11eb-8d1f-972a6a323ed4.png)

Old style:
![image](https://user-images.githubusercontent.com/36370954/125243244-1d80b480-e2ee-11eb-9f71-6a5c010cc48b.png)
![image](https://user-images.githubusercontent.com/36370954/125243269-26718600-e2ee-11eb-856c-2ae5d7569b70.png)


