### PR TITLE
Implement new styles for the host list view

### DIFF
--- a/web/frontend/javascripts/layout.js
+++ b/web/frontend/javascripts/layout.js
@@ -1,4 +1,7 @@
 $(document).ready(function() {
   // enable bootstrap tooltips
   $('[data-toggle="tooltip"]').tooltip();
+
+  let now = new Date();
+  $("#last_update").html(now.toLocaleString());
 });

--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -75,3 +75,38 @@ dt {
   padding: 75px 75px 0 75px !important;
   max-width: 100% !important;
 }
+
+.horizontal-container {
+  display: flex;
+  margin-bottom: 20px;
+}
+
+.health-container .alert-inline {
+  width: 150px;
+  margin-right: 15px;
+}
+
+.buttons-box {
+  margin-left: 150px;
+  display: inline-block;
+}
+
+hr.margin-10px {
+  margin: 10px 0;
+}
+
+td.row-status {
+  width: 0px;
+}
+
+td i.success {
+  color: $eos-bc-green-500;
+}
+
+td i.warning {
+  color: $eos-bc-yellow-900;
+}
+
+td i.critical {
+  color: $eos-bc-red-500;
+}

--- a/web/health_container.go
+++ b/web/health_container.go
@@ -1,0 +1,8 @@
+package web
+
+type HealthContainer struct {
+	PassingCount  int
+	WarningCount  int
+	CriticalCount int
+	Layout        string
+}

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/trento-project/trento/internal/hosts"
 )
 
-func TestNewHealthContainer(t *testing.T) {
+func TestNewHostsHealthContainer(t *testing.T) {
 	consulInst := new(mocks.Client)
 	health := new(mocks.Health)
 	consulInst.On("Health").Return(health)
@@ -56,12 +56,12 @@ func TestNewHealthContainer(t *testing.T) {
 	health.On("Node", "node5", (*consulApi.QueryOptions)(nil)).Return(warningHealthChecks, nil, nil)
 	health.On("Node", "node6", (*consulApi.QueryOptions)(nil)).Return(criticalHealthChecks, nil, nil)
 
-	hCont := NewHealthContainer(nodes)
+	hCont := NewHostsHealthContainer(nodes)
 
 	expectedHealth := &HealthContainer{
-		Passing:  2,
-		Warning:  2,
-		Critical: 2,
+		PassingCount:  2,
+		WarningCount:  2,
+		CriticalCount: 2,
 	}
 
 	assert.Equal(t, expectedHealth, hCont)

--- a/web/templates/blocks/health_container.html.tmpl
+++ b/web/templates/blocks/health_container.html.tmpl
@@ -1,0 +1,17 @@
+{{ define "health_container" }}
+<h5>Health</h5>
+<div class="health-container{{ if eq .Layout "horizontal" }} horizontal-container{{ end }}">
+    <div class="alert alert-inline alert-success">
+        <i class="eos-icons eos-18 alert-icon">check_circle</i>
+        <div class="alert-body">Passing</div>
+    {{ .Passing }}</div>
+    <div class="alert alert-inline alert-warning">
+        <i class="eos-icons eos-18 alert-icon">warning</i>
+        <div class="alert-body">Warning</div>
+    {{ .Warning }}</div>
+    <div class="alert alert-inline alert-danger">
+        <i class="eos-icons eos-18 alert-icon">error</i>
+        <div class="alert-body">Critical</div>
+    {{ .Critical }}</div>
+</div>
+{{ end }}

--- a/web/templates/blocks/health_container.html.tmpl
+++ b/web/templates/blocks/health_container.html.tmpl
@@ -4,14 +4,14 @@
     <div class="alert alert-inline alert-success">
         <i class="eos-icons eos-18 alert-icon">check_circle</i>
         <div class="alert-body">Passing</div>
-    {{ .Passing }}</div>
+    {{ .PassingCount }}</div>
     <div class="alert alert-inline alert-warning">
         <i class="eos-icons eos-18 alert-icon">warning</i>
         <div class="alert-body">Warning</div>
-    {{ .Warning }}</div>
+    {{ .WarningCount }}</div>
     <div class="alert alert-inline alert-danger">
         <i class="eos-icons eos-18 alert-icon">error</i>
         <div class="alert-body">Critical</div>
-    {{ .Critical }}</div>
+    {{ .CriticalCount }}</div>
 </div>
 {{ end }}

--- a/web/templates/blocks/hosts_table.html.tmpl
+++ b/web/templates/blocks/hosts_table.html.tmpl
@@ -3,6 +3,7 @@
         <table class='table eos-table'>
             <thead>
             <tr>
+                <th scope='col'></th>
                 <th scope='col'>Name</th>
                 <th scope='col'>Address</th>
                 <th scope='col'>Cloud provider</th>
@@ -10,12 +11,14 @@
                 <th scope='col'>System</th>
                 <th scope='col'>Landscape</th>
                 <th scope='col'>Environment</th>
-                <th scope='col'>Status</th>
             </tr>
             </thead>
             <tbody>
             {{- range .Hosts }}
                 <tr>
+                    <td class="row-status">
+                        <i class="eos-icons eos-18 {{ if eq .Health "passing" }} success">check_circle{{ else if eq .Health "warning" }} warning">warning{{ else }} critical">error{{ end }}</i>
+                    </td>
                     <td>
                         <a href='/hosts/{{ .Name }}'>
                             {{ .Name }}
@@ -42,10 +45,6 @@
                         <a href='/environments/{{ index .TrentoMeta "trento-sap-environment" }}'>
                             {{ index .TrentoMeta "trento-sap-environment" }}
                         </a>
-                    </td>
-                    <td>
-                        {{- $Health := .Health }}
-                        <span class='badge badge-pill badge-{{ if eq $Health "passing" }}primary{{ else if eq $Health "warning" }}warning{{ else }}danger{{ end }}'>{{ $Health }}</span>
                     </td>
                 </tr>
             {{- else }}

--- a/web/templates/hosts.html.tmpl
+++ b/web/templates/hosts.html.tmpl
@@ -1,7 +1,20 @@
 {{ define "content" }}
     <div class="col">
-        <h1>Hosts</h1>
-        <div class="filters">
+        <div class="row">
+            <div class="col">
+                <h1>Hosts</h1>
+            </div>
+            <div class="col text-right">
+                <i class="eos-icons eos-dark eos-18 ">schedule</i> Updated at:
+                <span id="last_update" class="text-nowrap text-muted">
+                    Not available
+                </span>
+            </div>
+        </div>
+        <hr class="margin-10px"/>
+        {{ template "health_container" .Health }}
+        <h5>Filters</h5>
+        <div class="horizontal-container">
             <script>
                 $(document).ready(function () {
                     {{- range $Key, $Value := .AppliedFilters }}
@@ -42,16 +55,16 @@
                     <option data-content="<span class='badge badge-danger'>Critical</span>" value="critical">Critical
                     </option>
                 </select>
-                <button type='submit' class='btn btn-icon btn-secondary' data-toggle='tooltip' title='Apply filters'>
-                    <i class='eos-icons eos-18'>autorenew</i>
-                </button>
-                <button id="clean" class='btn btn-icon btn-secondary' data-toggle='tooltip' title='Reset filters'>
-                    <i class='eos-icons eos-18'>cleanup</i>
-                </button>
+                <div class="buttons-box">
+                    <button type='submit' class='btn btn-icon btn-primary' data-toggle='tooltip' title='Apply filters'>
+                        Filter
+                    </button>
+                    <button id="clean" class='btn btn-icon btn-secondary' data-toggle='tooltip' title='Reset filters'>
+                        Reset
+                    </button>
+                </div>
             </form>
         </div>
-        <hr/>
-        <p class='clearfix'></p>
         {{ template "hosts_table" . }}
     </div>
 {{ end }}

--- a/web/templates/hosts.html.tmpl
+++ b/web/templates/hosts.html.tmpl
@@ -12,7 +12,7 @@
             </div>
         </div>
         <hr class="margin-10px"/>
-        {{ template "health_container" .Health }}
+        {{ template "health_container" .HealthContainer }}
         <h5>Filters</h5>
         <div class="horizontal-container">
             <script>


### PR DESCRIPTION
New styles for the Host list view, following the cluster list mockup.

- `Updated at` doesn't come from the backend. It shows just the time when the page was refreshed
- The `Filter` and `Reset` buttons might go away if we implement the ajax mechanism to reload the table page
- The `health_container` partial should be reusable in other pages, just changing the `horizontal/vertical` display option (this comes now from the backend, I didn't find a better option)

![image](https://user-images.githubusercontent.com/36370954/125283836-128f4980-e319-11eb-826c-cad2bd745026.png)
