### PR TITLE
List clusters template revamp

### DIFF
--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -26,6 +26,19 @@ type Host struct {
 	client consul.Client
 }
 
+func (h HostList) Health() string {
+	var checks consulApi.HealthChecks
+	for _, n := range h {
+		c, _, _ := n.client.Health().Node(n.Name(), nil)
+		checks = append(checks, c...)
+	}
+	if checks != nil {
+		return checks.AggregatedStatus()
+	}
+
+	return ""
+}
+
 func NewHost(node consulApi.Node, client consul.Client) Host {
 	return Host{node, client}
 }

--- a/web/templates/blocks/clusters_table.html.tmpl
+++ b/web/templates/blocks/clusters_table.html.tmpl
@@ -1,0 +1,32 @@
+{{ define "clusters_table" }}
+    <div class='table-responsive'>
+        <table class='table eos-table'>
+            <thead>
+            <tr>
+                <th scope='col'></th>
+                <th scope='col'>SID</th>
+                <th scope='col'>Cluster name</th>
+                <th scope='col'>Cluster Id</th>
+                <th scope='col'>Cluster type</th>
+                <th scope='col'>Nr. Hosts</th>
+                <th scope='col'>Nr. Resources</th>
+            </tr>
+            </thead>
+            <tbody>
+            {{- range . }}
+                <tr class='clickable' onclick="window.location='/clusters/{{ .Id }}'">
+                    <td>{{ template "health_icon" .Health }}</td>
+                    <td>{{- range $i, $v := .SIDs }}{{- if $i }},{{- end }} {{ . }}{{- end }}</td>
+                    <td>{{ .Name }}</td>
+                    <td>{{ .Id }}</td>
+                    <td>{{ .Type }}</td>
+                    <td>{{ .HostsNumber }}</td>
+                    <td>{{ .ResourcesNumber }}</td>
+                </tr>
+            {{- else }}
+                {{ template "empty_table_body" 7 }}
+            {{- end }}
+            </tbody>
+        </table>
+    </div>
+{{- end }}

--- a/web/templates/blocks/health_icon.html.tmpl
+++ b/web/templates/blocks/health_icon.html.tmpl
@@ -1,0 +1,11 @@
+{{ define "health_icon" }}
+    {{- if eq . "passing" }}
+        <i class="eos-icons eos-18 text-success">check_circle</i>
+    {{- else if eq . "warning" }}
+        <i class="eos-icons eos-18 text-warning">warning</i>
+    {{- else if eq . "critical" }}
+        <i class="eos-icons eos-18 text-danger">error</i>
+    {{- else }}
+        <i class="eos-icons eos-18 text-muted">fiber_manual_record</i>
+    {{- end }}
+{{- end }}

--- a/web/templates/blocks/sites.html.tmpl
+++ b/web/templates/blocks/sites.html.tmpl
@@ -20,13 +20,7 @@
                     {{- range $nodes}}
                         <tr>
                             <td>
-                                {{- if eq .Health "passing" }}
-                                    <i class="eos-icons eos-18 text-success">check_circle</i>
-                                {{- else if eq .Health "warning" }}
-                                    <i class="eos-icons eos-18 text-warning">warning</i>
-                                {{- else }}
-                                    <i class="eos-icons eos-18 text-danger">error</i>
-                                {{- end}}
+                                {{ template "health_icon" .Health }}
                             </td>
                             <td>
                                 {{ .Name }}

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -1,33 +1,61 @@
+{{ define "additional_scripts" }}
+    <script src="/static/frontend/assets/js/tables.js"></script>
+{{ end }}
 {{ define "content" }}
-    <div class="col">
-        <h1>Clusters</h1>
-        <div class='table-responsive'>
-            <table class='table eos-table'>
-                <thead>
-                <tr>
-                    <th scope='col'>Name</th>
-                    <th scope='col'>Id</th>
-                    <th scope='col'>Host count</th>
-                    <th scope='col'>Resource count</th>
-                    <th scope='col'>Status</th>
-                </tr>
-                </thead>
-                <tbody>
-                {{- range $Name, $Cluster := .Clusters }}
-                    <tr class='clickable' onclick="window.location='/clusters/{{ .Id }}'">
-                        <td>{{ $Cluster.Name }}</td>
-                        <td>{{ $Cluster.Id }}</td>
-                        <td>{{ $Cluster.Crmmon.Summary.Nodes.Number }}</td>
-                        <td>{{ $Cluster.Crmmon.Summary.Resources.Number }}</td>
-                        <td>
-                            <span class='badge badge-pill badge-primary'>passing</span>
-                        </td>
-                    </tr>
-                {{- else }}
-                    {{ template "empty_table_body" 4}}
-                {{- end }}
-                </tbody>
-            </table>
+    <div class="row">
+        <div class="col">
+            <h1>Clusters</h1>
+        </div>
+        <div class="col text-right">
+            <i class="eos-icons eos-dark eos-18 ">schedule</i> Updated at:
+            <span id="last_update" class="text-nowrap text-muted">
+                    Not available
+                </span>
         </div>
     </div>
+    <hr class="margin-10px"/>
+    {{ template "health_container" .HealthContainer }}
+    <h5>Filters</h5>
+    <div class="horizontal-container">
+        <script>
+            $(document).ready(function () {
+                {{- range $Key, $Value := .AppliedFilters }}
+                $("#{{ $Key }}").selectpicker("val", {{ $Value }});
+                {{- end }}
+                $('#clean').click(function () {
+                    $('.selectpicker').selectpicker("deselectAll")
+                });
+            });
+        </script>
+        <select name="health" id="health" class="selectpicker" multiple
+                data-selected-text-format="count > 3" data-actions-box="true" title="Health">
+            <option data-content="<span class='badge badge-success'>Passing</span>" value="passing">Passing</option>
+            <option data-content="<span class='badge badge-warning'>Warning</span>" value="warning">Warning</option>
+            <option data-content="<span class='badge badge-danger'>Critical</span>" value="critical">Critical
+        </select>
+        <select name="sid" id="sid" class="selectpicker" multiple
+                data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true" title="SID">
+            {{- range .ClustersTable.GetAllSIDs }}
+                <option value="{{ . }}">{{ . }}</option>
+            {{- end }}
+        </select>
+        <select name="name" id="name" class="selectpicker" multiple
+                data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
+                title="Cluster name">
+            {{- range .ClustersTable }}
+                {{- if .Name }}
+                    <option value="{{ .Name }}">{{ .Name }}</option>
+                {{- end }}
+            {{- end}}
+        </select>
+        <select name="cluster_type" id="cluster_type" class="selectpicker" multiple
+                data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
+                title="Cluster type">
+            {{- range .ClustersTable.GetAllClusterTypes }}
+                    <option value="{{ . }}">{{ . }}</option>
+            {{- end}}
+        </select>
+    </div>
+    {{ template "clusters_table" .ClustersTable }}
+    {{ template "pagination" .Pagination }}
 {{ end }}


### PR DESCRIPTION
This PR updates the cluster list view with the filters, pagination and health component.
Added autocomplete behaviour to some of the the filter inputs, such as `name` and `sid`

Structs were added to abstract the clusters list.