### PR TITLE
Fix SID retrieval

### DIFF
--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -6,8 +6,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-
 	consulApi "github.com/hashicorp/consul/api"
 
 	"github.com/stretchr/testify/assert"
@@ -22,6 +20,21 @@ func clustersListMap() map[string]interface{} {
 		"47d1190ffb4f781974c8356d7f863b03": map[string]interface{}{
 			"cib": map[string]interface{}{
 				"Configuration": map[string]interface{}{
+					"Resources": map[string]interface{}{
+						"Clones": []interface{}{
+							map[string]interface{}{
+								"Primitive": map[string]interface{}{
+									"Type": "SAPHanaTopology",
+									"InstanceAttributes": []interface{}{
+										map[string]interface{}{
+											"Name":  "SID",
+											"Value": "PRD",
+										},
+									},
+								},
+							},
+						},
+					},
 					"CrmConfig": map[string]interface{}{
 						"ClusterProperties": []interface{}{
 							map[string]interface{}{
@@ -167,10 +180,6 @@ func TestClustersListHandler(t *testing.T) {
 	kv.On("ListMap", consul.KvClustersPath, consul.KvClustersPath).Return(clustersListMap(), nil)
 	consulInst.On("WaitLock", consul.KvClustersPath).Return(nil)
 
-	catalog := new(mocks.Catalog)
-	consulInst.On("Catalog").Return(catalog)
-	catalog.On("Nodes", mock.Anything).Return([]*consulApi.Node{}, nil, nil)
-
 	deps := DefaultDependencies()
 	deps.consul = consulInst
 
@@ -204,8 +213,8 @@ func TestClustersListHandler(t *testing.T) {
 
 	assert.Equal(t, 200, resp.Code)
 	assert.Contains(t, minified, "Clusters")
-	assert.Regexp(t, regexp.MustCompile("<td>sculpin</td><td>47d1190ffb4f781974c8356d7f863b03</td><td>HANA scale-up</td><td>3</td><td>5</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td>panther</td><td>e2f2eb50aef748e586a7baa85e0162cf</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td>PRD</td><td>sculpin</td><td>47d1190ffb4f781974c8356d7f863b03</td><td>HANA scale-up</td><td>3</td><td>5</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td></td><td>panther</td><td>e2f2eb50aef748e586a7baa85e0162cf</td>"), minified)
 }
 
 func TestClusterHandlerHANA(t *testing.T) {


### PR DESCRIPTION
Resolves #143 

`SID` is retrieved from from `SAPHanaController` instead of `GetSAPSystems`.
Removes unused code, updates relevant tests.

