### PR TITLE
Change GH actions release trigger

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
   workflow_dispatch:
   release:
-    types: [ published, created, edited ]
+    types: [ published ]
 
 jobs:
   build:


### PR DESCRIPTION
Removes `edit` and `create` triggers, which might cause unwanted workflow runs. We only need to upload the assets when publishing a new release, and that's it.