### PR TITLE
add more rules to the .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,9 @@
-[examples/azure-rules.yaml]
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.md,examples/*.yaml}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
This ensures that we all use the same conventions, when using editors that support the [editorconfig.org](https://editorconfig.org/) standard