### PR TITLE
Allow multiple SAP system tags per host

### DIFF
--- a/agent/discovery/sapsystem_test.go
+++ b/agent/discovery/sapsystem_test.go
@@ -60,7 +60,7 @@ func TestStoreSAPSystemTags(t *testing.T) {
 	expectedHostMetadata := map[string]interface{}{
 		"sap-environment": "env1",
 		"sap-landscape":   "land1",
-		"sap-system":      "DEV",
+		"sap-systems":     "DEV",
 	}
 
 	kv.On("ListMap", consul.KvEnvironmentsPath, consul.KvEnvironmentsPath).Return(env, nil)
@@ -69,7 +69,7 @@ func TestStoreSAPSystemTags(t *testing.T) {
 
 	sapSystem := &sapsystem.SAPSystem{SID: "DEV", Type: sapsystem.Database}
 
-	err := storeSAPSystemTags(client, sapSystem)
+	err := storeSAPSystemTags(client, []*sapsystem.SAPSystem{sapSystem})
 	assert.NoError(t, err)
 
 	kv.AssertExpectations(t)
@@ -120,13 +120,13 @@ func TestStoreSAPSystemTagsWithNoEnvs(t *testing.T) {
 	expectedHostMetadata := map[string]interface{}{
 		"sap-environment": "default",
 		"sap-landscape":   "default",
-		"sap-system":      "DEV",
+		"sap-systems":     "DEV",
 	}
 	kv.On("PutMap", fmt.Sprintf(consul.KvHostsMetadataPath, host), expectedHostMetadata).Return(nil, nil)
 
 	sapSystem := &sapsystem.SAPSystem{SID: "DEV", Type: sapsystem.Database}
 
-	err := storeSAPSystemTags(client, sapSystem)
+	err := storeSAPSystemTags(client, []*sapsystem.SAPSystem{sapSystem})
 	assert.NoError(t, err)
 
 	kv.AssertExpectations(t)

--- a/internal/environments/environments_kvstore.go
+++ b/internal/environments/environments_kvstore.go
@@ -53,7 +53,7 @@ func loadHosts(client consul.Client, env *Environment) error {
 			query := hosts.CreateFilterMetaQuery(map[string][]string{
 				"trento-sap-environment": []string{env.Name},
 				"trento-sap-landscape":   []string{landKey},
-				"trento-sap-system":      []string{sysKey},
+				"trento-sap-systems":     []string{sysKey},
 			})
 			h, err := hosts.Load(client, query, []string{})
 			if err != nil {

--- a/internal/environments/environments_kvstore_test.go
+++ b/internal/environments/environments_kvstore_test.go
@@ -66,7 +66,7 @@ func TestEnvironmentLoad(t *testing.T) {
 			Meta: map[string]string{
 				"trento-sap-environment": "env1",
 				"trento-sap-landscape":   "land1",
-				"trento-sap-system":      "sys1",
+				"trento-sap-systems":     "sys1,sys3",
 			},
 		},
 		{
@@ -74,13 +74,13 @@ func TestEnvironmentLoad(t *testing.T) {
 			Meta: map[string]string{
 				"trento-sap-environment": "env2",
 				"trento-sap-landscape":   "land2",
-				"trento-sap-system":      "sys2",
+				"trento-sap-systems":     "sys2,sys4",
 			},
 		},
 	}
 
 	filter := &consulApi.QueryOptions{
-		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-system\"] == \"sys1\")"}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-systems\"] contains \"sys1\")"}
 	catalog.On("Nodes", (filter)).Return(nodes, nil, nil)
 
 	returnedMap := map[string]interface{}{

--- a/internal/hosts/metadata.go
+++ b/internal/hosts/metadata.go
@@ -5,6 +5,6 @@ type Metadata struct {
 	ClusterId     string `mapstructure:"ha-cluster-id,omitempty"`
 	Environment   string `mapstructure:"sap-environment,omitempty"`
 	Landscape     string `mapstructure:"sap-landscape,omitempty"`
-	SAPSystem     string `mapstructure:"sap-system,omitempty"`
+	SAPSystems    string `mapstructure:"sap-systems,omitempty"`
 	CloudProvider string `mapstructure:"cloud-provider,omitempty"`
 }

--- a/internal/hosts/metadata_kvstore_test.go
+++ b/internal/hosts/metadata_kvstore_test.go
@@ -21,14 +21,14 @@ func TestMetadataStore(t *testing.T) {
 		Cluster:     "test-cluster",
 		Environment: "env1",
 		Landscape:   "land1",
-		SAPSystem:   "sys1",
+		SAPSystems:  "sys1",
 	}
 
 	expectedPutMap := map[string]interface{}{
 		"ha-cluster":      "test-cluster",
 		"sap-environment": "env1",
 		"sap-landscape":   "land1",
-		"sap-system":      "sys1",
+		"sap-systems":     "sys1",
 	}
 
 	kvPath := fmt.Sprintf(consul.KvHostsMetadataPath, host)

--- a/internal/sapsystem/sapsystem.go
+++ b/internal/sapsystem/sapsystem.go
@@ -30,6 +30,7 @@ const (
 )
 
 type SAPSystemsList []*SAPSystem
+type SAPSystemsMap map[string]*SAPSystem
 
 // A SAPSystem in this context is a SAP installation under one SID.
 // It will have application or database type, mutually exclusive
@@ -97,6 +98,16 @@ func NewSAPSystemsList() (SAPSystemsList, error) {
 	}
 
 	return systems, nil
+}
+
+func (sl SAPSystemsList) GetSIDsString() string {
+	var sidString []string
+
+	for _, system := range sl {
+		sidString = append(sidString, system.SID)
+	}
+
+	return strings.Join(sidString, ",")
 }
 
 func NewSAPSystem(fs afero.Fs, sysPath string) (*SAPSystem, error) {

--- a/web/environments_test.go
+++ b/web/environments_test.go
@@ -127,15 +127,15 @@ func setupEnvironmentsTest() (*mocks.Client, *mocks.Catalog, *mocks.KV) {
 	kv.On("ListMap", consul.KvEnvironmentsPath, consul.KvEnvironmentsPath).Return(filters, nil)
 
 	filterSys1 := &consulApi.QueryOptions{
-		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-system\"] == \"PRD\")"}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land1\") and (Meta[\"trento-sap-systems\"] contains \"PRD\")"}
 	catalog.On("Nodes", filterSys1).Return(nodes1, nil, nil)
 
 	filterSys2 := &consulApi.QueryOptions{
-		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land2\") and (Meta[\"trento-sap-system\"] == \"HA2\")"}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env1\") and (Meta[\"trento-sap-landscape\"] == \"land2\") and (Meta[\"trento-sap-systems\"] contains \"HA2\")"}
 	catalog.On("Nodes", filterSys2).Return(nodes1, nil, nil)
 
 	filterSys3 := &consulApi.QueryOptions{
-		Filter: "(Meta[\"trento-sap-environment\"] == \"env2\") and (Meta[\"trento-sap-landscape\"] == \"land3\") and (Meta[\"trento-sap-system\"] == \"HA3\")"}
+		Filter: "(Meta[\"trento-sap-environment\"] == \"env2\") and (Meta[\"trento-sap-landscape\"] == \"land3\") and (Meta[\"trento-sap-systems\"] contains \"HA3\")"}
 	catalog.On("Nodes", filterSys3).Return(nodes2, nil, nil)
 
 	health.On("Node", "node1", (*consulApi.QueryOptions)(nil)).Return(node1HealthChecks, nil, nil)

--- a/web/layout.go
+++ b/web/layout.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -149,6 +150,7 @@ func (r *LayoutRender) addFileFromFS(templatesFS fs.FS, file string) {
 			return a + b
 		},
 		"markdown": markdownToHTML,
+		"split":    strings.Split,
 	})
 	patterns := append([]string{r.root, file}, r.blocks...)
 	tmpl = template.Must(tmpl.ParseFS(templatesFS, patterns...))

--- a/web/templates/blocks/hosts_table.html.tmpl
+++ b/web/templates/blocks/hosts_table.html.tmpl
@@ -15,6 +15,7 @@
             </thead>
             <tbody>
             {{- range .Hosts }}
+            {{ $TrentoMeta := .TrentoMeta }}
                 <tr>
                     <td class="row-status">
                         {{ template "health_icon" .Health }}
@@ -32,9 +33,11 @@
                         </a>
                     </td>
                     <td>
-                        <a href='/sapsystems/{{ index .TrentoMeta "trento-sap-system" }}?environment={{ index .TrentoMeta "trento-sap-environment" }}&landscape={{ index .TrentoMeta "trento-sap-landscape" }}'>
-                            {{ index .TrentoMeta "trento-sap-system" }}
-                        </a>
+                        {{- range $i, $v := split (index $TrentoMeta "trento-sap-systems") "," }}{{- if $i }},{{- end }}
+                            <a href='/sapsystems/{{ $v }}?environment={{ index $TrentoMeta "trento-sap-environment" }}&landscape={{ index $TrentoMeta "trento-sap-landscape" }}'>
+                                {{ $v }}
+                            </a>
+                        {{- end }}
                     </td>
                     <td>
                         <a href='/landscapes/{{ index .TrentoMeta "trento-sap-landscape" }}?environment={{ index .TrentoMeta "trento-sap-environment" }}'>

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -7,18 +7,19 @@
             <dd class="inline">{{ .Host.Name }}</dd>
             {{ $Env := index .Host.TrentoMeta "trento-sap-environment" }}
             {{ $Land := index .Host.TrentoMeta "trento-sap-landscape" }}
-            {{ $SAPSys := index .Host.TrentoMeta "trento-sap-system" }}
             <dt class="inline">Environment</dt>
             <dd class="inline"><a href="/environments/{{ $Env }}">{{ $Env }}</a></dd>
             <dt class="inline">Landscape</dt>
             <dd class="inline"><a href="/landscapes/{{ $Land }}?environment={{ $Env }}">{{ $Land }}</a></dd>
             <dt class="inline">SAP System</dt>
-            <dd class="inline"><a
-                        href="/sapsystems/{{ $SAPSys }}?environment={{ $Env }}&landscape={{ $Land }}">{{ $SAPSys }}</a>
+            <dd class="inline">
+                {{- range $i, $v := split (index .Host.TrentoMeta "trento-sap-systems") "," }}{{- if $i }},{{- end }} <a
+                        href="/sapsystems/{{ $v }}?environment={{ $Env }}&landscape={{ $Land }}">{{ $v }}</a>{{- end }}
             </dd>
+
             <dt class="inline">Cluster</dt>
             <dd class="inline"><a
-                        href="/clusters/{{ index .Host.TrentoMeta "trento-ha-cluster-id" }}">{{ index .Host.TrentoMeta "trento-ha-cluster" }}</a>
+                        href='/clusters/{{ index .Host.TrentoMeta "trento-ha-cluster-id" }}'>{{ index .Host.TrentoMeta "trento-ha-cluster" }}</a>
             </dd>
         </dl>
         <hr/>

--- a/web/templates/hosts.html.tmpl
+++ b/web/templates/hosts.html.tmpl
@@ -40,7 +40,7 @@
                 {{- end }}
             </select>
 
-            <select name="trento-sap-system" id="trento-sap-system" class="selectpicker" multiple
+            <select name="trento-sap-systems" id="trento-sap-systems" class="selectpicker" multiple
                     data-selected-text-format="count > 3" data-actions-box="true" title="SAP system...">
                 {{- range index .Filters "sapsystems" }}
                     <option value="{{ . }}">{{ . }}</option>


### PR DESCRIPTION
This PR adds support for having multiple SIDs on the same host (useful in cost-optimized scenario). The host metadata field is now `trento-sap-systems` and the filters have been updated to allow matching e.g. `PRD` in a host where `PRD,QAS` is stored in the metadata.

Templates have been updated too to now show multiple SIDs where relevant.

Updated: Screenshots
![hostdetails](https://user-images.githubusercontent.com/2668401/127044603-792c01d8-35cd-44fd-bfa8-1919c8d28d97.png)
![hosts](https://user-images.githubusercontent.com/2668401/127044610-f4e29b8b-f18f-4e26-8baa-00f0fbfe5610.png)
