### PR TITLE
Add debug target to avoid always stripping debug symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
 VERSION ?= $(shell hack/get_version_from_git.sh)
 LDFLAGS = -X github.com/trento-project/trento/cmd.version="$(VERSION)"
-GO_BUILD = CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)"
 ARCHS ?= amd64 arm64 ppc64le s390x
+DEBUG ?= 0
 
-default: LDFLAGS += -s -w
-default: GO_BUILD += -trimpath
+ifeq ($(DEBUG), 0)
+	LDFLAGS += -s -w
+	GO_BUILD = CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -trimpath
+else
+	GO_BUILD = CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)"
+endif
+
 default: clean mod-tidy fmt vet-check test build
-debug: clean mod-tidy fmt vet-check build
 
 .PHONY: build clean clean-binary clean-frontend cross-compiled default fmt fmt-check generate mod-tidy test vet-check web-assets
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 VERSION ?= $(shell hack/get_version_from_git.sh)
-GO_BUILD = CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/trento-project/trento/cmd.version=$(VERSION)"
+LDFLAGS = -X github.com/trento-project/trento/cmd.version="$(VERSION)"
+GO_BUILD = CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 
+default: LDFLAGS += -s -w
+default: GO_BUILD += -trimpath
 default: clean mod-tidy fmt vet-check test build
+debug: clean mod-tidy fmt vet-check build
 
 .PHONY: build clean clean-binary clean-frontend cross-compiled default fmt fmt-check generate mod-tidy test vet-check web-assets
 


### PR DESCRIPTION
This PR adds a new debug target which behaves slightly different from the `default` target:

 - It does not run the tests
 - It doesn't use `-trimpath` which causes some issues while debugging remotely with `delve`
 - It doesn't use `-s -w` in the `LDFLAGS` which cause thinner binaries but strips symbols away needed for debugging

Note that this is only useful for development and should provide identical binaries as before when running the `default` target.