### PR TITLE
Display trento version UI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell hack/get_version_from_git.sh)
-GO_BUILD = CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/trento-project/trento/cmd.version=$(VERSION)"
+GO_BUILD = CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/trento-project/trento/version.Version=$(VERSION)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 
 default: clean mod-tidy fmt vet-check test build

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,19 +5,18 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+	"github.com/trento-project/trento/version"
 )
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
 }
 
-var version string
-
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of Trento",
 	Long:  `All software has versions. This is Trento's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Trento version %s\nbuilt with %s %s/%s\n", version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Trento version %s\nbuilt with %s %s/%s\n", version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,9 @@
+package version
+
+import "strings"
+
+var Version string
+
+func GetShortVersion() string {
+	return strings.Split(Version, "+")[0]
+}

--- a/web/layout.go
+++ b/web/layout.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/trento-project/trento/version"
 
 	"github.com/gin-gonic/gin/render"
 
@@ -29,6 +30,7 @@ type LayoutRender struct {
 type LayoutData struct {
 	Title     string
 	Copyright string
+	Version   string
 	Submenu   Submenu
 	Content   interface{}
 }
@@ -43,6 +45,7 @@ type SubmenuItem struct {
 var defaultLayoutData = LayoutData{
 	Title:     "Trento Console",
 	Copyright: "© 2020-2021 SUSE LLC",
+	Version:   version.GetShortVersion(),
 }
 
 type LayoutHTML struct {

--- a/web/templates/blocks/footer.html.tmpl
+++ b/web/templates/blocks/footer.html.tmpl
@@ -1,6 +1,8 @@
 {{ define "footer" }}
     <footer class="footer-content js-footer-content">
         <ul class="footer-list">
+            <li class="footer-list-item">{{ template "version" . }}</li>
+            <li class="footer-list-item divider"></li>
             <li class="footer-list-item">{{ template "license" }}</li>
             <li class="footer-list-item">{{ .Copyright }}</li>
         </ul>

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -77,7 +77,7 @@
                        data-title="{{ escapedTemplate "license" . }}" data-trigger="hover click">find_in_page</i>
                 </li>
                 <li class="footer-list-item">
-                    <i class="eos-icons" title="" data-html="true" data-toggle="tooltip" data-title="{{ .Copyright }}"
+                    <i class="eos-icons" title="" data-html="true" data-toggle="tooltip" data-title="Trento v{{.Version }}<br>{{ .Copyright }}"
                        data-trigger="hover click">info</i>
                 </li>
             </ul>

--- a/web/templates/blocks/version.html.tmpl
+++ b/web/templates/blocks/version.html.tmpl
@@ -1,0 +1,4 @@
+{{ define "version" }}
+    <a href="https://github.com/trento-project/trento/releases/tag/{{ .Version }}" target="_blank"
+       rel="noopener noreferrer">Trento v{{ .Version }}</a>
+{{ end }}


### PR DESCRIPTION
Added the trento version to the UI.
Had to move the Version injected variable to a separate package (was in `cmd` before).
Version links to the github release, only the tag is displayed (without `+git.yabba.yabba`) for UX reasons (text was too long, looks bad).
