### PR TITLE
Fix Missing link to the Host page from the HANA Cluster page

### DIFF
--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -308,8 +308,8 @@ func TestClusterHandlerHANA(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<strong>CIB last written:</strong><br><span.*>Wed Jun 30 18:11:37 2021</span>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<strong>HANA secondary sync state:</strong><br><span.*>SFAIL</span>"), minified)
 	// Nodes
-	assert.Regexp(t, regexp.MustCompile("<td>test_node_1</td><td>192.168.1.1</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td>test_node_2</td><td>192.168.1.2</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td><a.*href=/hosts/test_node_1.*>test_node_1</a></td><td>192.168.1.1</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td><a.*href=/hosts/test_node_2.*>test_node_2</a></td><td>192.168.1.2</td>"), minified)
 	// Resources
 	assert.Regexp(t, regexp.MustCompile("<td>sbd</td><td>stonith:external/sbd</td><td>Started</td><td>active</td><td>0</td>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<td>dummy_failed</td><td>dummy</td><td>Started</td><td>failed</td><td>0</td>"), minified)

--- a/web/templates/blocks/sites.html.tmpl
+++ b/web/templates/blocks/sites.html.tmpl
@@ -23,7 +23,9 @@
                                 {{ template "health_icon" .Health }}
                             </td>
                             <td>
-                                {{ .Name }}
+                                <a href='/hosts/{{ .Name }}'>
+                                    {{ .Name }}
+                                </a>
                             </td>
                             <td>
                                 {{ .Ip }}


### PR DESCRIPTION
Fix Missing link to the Host page from the HANA Cluster page

Resolves #155 