### PR TITLE
Display SID instead of pacemaker status

### DIFF
--- a/web/clusters.go
+++ b/web/clusters.go
@@ -465,6 +465,7 @@ func NewClusterHandler(client consul.Client) gin.HandlerFunc {
 
 		c.HTML(http.StatusOK, "cluster_hana.html.tmpl", gin.H{
 			"Cluster":          cluster,
+			"SID":              getHanaSID(cluster),
 			"Nodes":            nodes,
 			"StoppedResources": stoppedResources(cluster),
 			"ClusterType":      clusterType,

--- a/web/templates/cluster_hana.html.tmpl
+++ b/web/templates/cluster_hana.html.tmpl
@@ -32,8 +32,8 @@
                     </div>
 
                     <div class="col-3 mt-5">
-                        <strong>Pacemaker status:</strong><br>
-                        <span class="text-muted">-</span>
+                        <strong>SID:</strong><br>
+                        <span class="text-muted">{{ .SID }}</span>
                     </div>
                     <div class="col-3 mt-5">
                         <strong>SAPHanaSR health state:</strong><br>


### PR DESCRIPTION
Remove "Pacemaker status" from the cluster details view and replace it with SID 