### PR TITLE
Unify import role meta

### DIFF
--- a/runner/ansible/meta.yml
+++ b/runner/ansible/meta.yml
@@ -11,7 +11,7 @@
         name: load_facts
 
     - name: include 1.1.1 meta
-      include_role:
+      import_role:
         name: '1.1.1'
         tasks_from: meta
 
@@ -21,7 +21,7 @@
         tasks_from: meta
 
     - name: include 1.1.2 meta
-      include_role:
+      import_role:
         name: '1.1.2'
         tasks_from: meta
 
@@ -31,7 +31,7 @@
         tasks_from: meta
 
     - name: include 1.1.3 meta
-      include_role:
+      import_role:
         name: '1.1.3'
         tasks_from: meta
 
@@ -41,7 +41,7 @@
         tasks_from: meta
 
     - name: include 1.1.4 meta
-      include_role:
+      import_role:
         name: '1.1.4'
         tasks_from: meta
 
@@ -51,7 +51,7 @@
         tasks_from: meta
 
     - name: include 1.1.5 meta
-      include_role:
+      import_role:
         name: '1.1.5'
         tasks_from: meta
 
@@ -61,17 +61,17 @@
         tasks_from: meta
 
     - name: include 1.1.6 meta
-      include_role:
+      import_role:
         name: '1.1.6'
         tasks_from: meta
 
     - name: include 1.1.7 meta
-      include_role:
+      import_role:
         name: '1.1.7'
         tasks_from: meta
 
     - name: include 1.1.8 meta
-      include_role:
+      import_role:
         name: '1.1.8'
         tasks_from: meta
 
@@ -81,16 +81,16 @@
         tasks_from: meta
 
     - name: include 1.2.1 meta
-      include_role:
+      import_role:
         name: '1.2.1'
         tasks_from: meta
 
     - name: include 1.3.5 meta
-      include_role:
+      import_role:
         name: '1.3.5'
         tasks_from: meta
 
     - name: Post metadata
-      include_role:
+      import_role:
         name: post-metadata
         tasks_from: post


### PR DESCRIPTION
Just to keep consistency, replace `include_role` by `import_role`.
The unique difference is that when `import_role` is used and the task is skipped, everything within this role is skipped automatically. In the case of `include_role`, the inner tasks are executed unless they are specifically skipped