### PR TITLE
Improve ARA error alerts

### DIFF
--- a/web/alert.go
+++ b/web/alert.go
@@ -8,6 +8,16 @@ import (
 
 const AlertsKey string = "alerts"
 
+// Here some generic alerts
+var AlertCatalogNotFound = func() Alert {
+	return Alert{
+		Type:  "danger",
+		Title: "Error loading the checks catalog",
+		Text: "Checks catalog couldn't be retrieved. Check if the ARA service is running" +
+			" and the --ara-addr flag is pointing corretly to the service",
+	}
+}
+
 type Alert struct {
 	Type  string
 	Title string
@@ -31,20 +41,20 @@ func InitAlerts() {
 	gob.Register(Alert{})
 }
 
-func StoreAlert(c *gin.Context, a *Alert) {
+func StoreAlert(c *gin.Context, a Alert) {
 	session := sessions.Default(c)
 	session.AddFlash(a, AlertsKey)
 	session.Save()
 }
 
-func GetAlerts(c *gin.Context) []*Alert {
+func GetAlerts(c *gin.Context) []Alert {
 	session := sessions.Default(c)
 	f := session.Flashes(AlertsKey)
-	var alerts []*Alert
+	var alerts []Alert
 
 	for _, alertI := range f {
 		alert, _ := alertI.(Alert)
-		alerts = append(alerts, &alert)
+		alerts = append(alerts, alert)
 	}
 	session.Save()
 

--- a/web/checks_catalog.go
+++ b/web/checks_catalog.go
@@ -12,7 +12,9 @@ func NewChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		checkList, err := s.GetChecksCatalogByGroup()
 		if err != nil {
-			_ = c.Error(err)
+			tipMsg := AlertCatalogNotFound().Text
+			_ = c.Error(InternalServerError(err.Error()))
+			_ = c.Error(InternalServerError(tipMsg))
 			return
 		}
 

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -488,8 +488,7 @@ func NewClusterHandler(client consul.Client, s services.ChecksService) gin.Handl
 
 		checksCatalog, err := getChecksCatalog(clusterId, client, s)
 		if err != nil {
-			_ = c.Error(err)
-			return
+			StoreAlert(c, AlertCatalogNotFound())
 		}
 
 		nodes := NewNodes(clusterItem, hosts)
@@ -527,15 +526,15 @@ func NewSaveChecksHandler(client consul.Client) gin.HandlerFunc {
 		err := cluster.StoreCheckSelection(
 			client, clusterId, strings.Join(selectedChecks.Ids, ","))
 
-		var newAlert *Alert
+		var newAlert Alert
 		if err == nil {
-			newAlert = &Alert{
+			newAlert = Alert{
 				Type:  "success",
 				Title: "Check selection saved",
 				Text:  "The cluster checks selection has been saved correctly.",
 			}
 		} else {
-			newAlert = &Alert{
+			newAlert = Alert{
 				Type:  "danger",
 				Title: "Error saving check selection",
 				Text:  "The cluster checks selection couldn't be saved.",

--- a/web/errors_test.go
+++ b/web/errors_test.go
@@ -31,6 +31,7 @@ func TestErrorHandlerContentNegotiation(t *testing.T) {
 	app.Use(ErrorHandler)
 	app.GET("/", func(c *gin.Context) {
 		c.Error(errors.New("error message"))
+		c.Error(errors.New("2nd error message"))
 	})
 
 	w := httptest.NewRecorder()
@@ -41,6 +42,8 @@ func TestErrorHandlerContentNegotiation(t *testing.T) {
 
 	assert.Equal(t, 500, w.Code)
 	assert.Contains(t, w.Body.String(), "Ooops")
+	assert.Contains(t, w.Body.String(), "error message</br>")
+	assert.Contains(t, w.Body.String(), "2nd error message</br>")
 }
 
 func TestErrorHandlerWithHttpError(t *testing.T) {

--- a/web/templates/error.html.tmpl
+++ b/web/templates/error.html.tmpl
@@ -1,7 +1,13 @@
 {{ define "content" }}
     <div class="col">
         <h1>Ooops</h1>
-        <p class="lead">Something went wrong!</p>
+        <p class="lead">
+          {{- range . }}
+          {{ . }}</br>
+          {{- else }}
+          Something went wrong!
+          {{- end}}
+        </p>
     </div>
 {{ end }}
 {{ define "errors" }}


### PR DESCRIPTION
Implementation of some error notifications, specially oriented for the scenario where ARA is down or not correctly configured.
Here the pics:
Checks catalog:
![image](https://user-images.githubusercontent.com/36370954/128028174-b4e8c35f-a915-47f4-a133-0e5f0fb826cb.png)

Cluster page. This is a partial failure, so it shows the flash alert but still returns the 200 return code
![image](https://user-images.githubusercontent.com/36370954/128028297-d00938a9-9fda-4ca6-a410-11cec596a2e2.png)
