### PR TITLE
Remove dead function from the agent command

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -120,9 +120,3 @@ func startArgsValidator(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-
-func must(err error) {
-	if err != nil {
-		panic(err)
-	}
-}


### PR DESCRIPTION
:wave: 

Roaming around the codebase I noticed that the `must`function in the `agent.go` file looked pretty dead so I took the freedom to remove it :smile: 