### PR TITLE
Avoid possible signals dropped do to unbuffered channel

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -67,7 +67,7 @@ func runOnce(cmd *cobra.Command, args []string) {
 func start(cmd *cobra.Command, args []string) {
 	var err error
 
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 
 	cfg, err := agent.DefaultConfig()


### PR DESCRIPTION
In Go 1.17, `vet` issues a warning about an unbuffered channel that might receive signals before we are ready to listen to them; causing them to be dropped. This PR makes that channel buffered.