### PR TITLE
Add agent version 

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/trento-project/trento/agent/discovery"
 	"github.com/trento-project/trento/internal/consul"
+	"github.com/trento-project/trento/internal/hosts"
+	"github.com/trento-project/trento/version"
 )
 
 const haConfigCheckerId = "ha_config_checker"
@@ -161,6 +163,8 @@ func (a *Agent) Start() error {
 		log.Println("consul-template loop stopped.")
 	}(&wg)
 
+	storeAgentMetadata(a.consul, version.Version)
+
 	wg.Wait()
 
 	return nil
@@ -307,4 +311,17 @@ func repeat(tick func(), interval time.Duration, ctx context.Context) {
 			return
 		}
 	}
+}
+
+func storeAgentMetadata(client consul.Client, version string) error {
+	metadata := hosts.Metadata{
+		AgentVersion: version,
+	}
+
+	err := metadata.Store(client)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/hosts/hosts.go
+++ b/internal/hosts/hosts.go
@@ -63,6 +63,16 @@ func (n *Host) TrentoMeta() map[string]string {
 	return filtered_meta
 }
 
+func (n *Host) GetAgentVersionString() string {
+	version, ok := n.TrentoMeta()["trento-agent-version"]
+
+	if !ok {
+		return "Not running"
+	}
+
+	return "v" + version
+}
+
 // todo: this method was rushed, needs to be completely rewritten to have the checker webservice decoupled in a dedicated HTTP client
 func (n *Host) HAChecks() *check.Controls {
 	checks := &check.Controls{}

--- a/internal/hosts/metadata.go
+++ b/internal/hosts/metadata.go
@@ -5,4 +5,5 @@ type Metadata struct {
 	ClusterId     string `mapstructure:"ha-cluster-id,omitempty"`
 	SAPSystems    string `mapstructure:"sap-systems,omitempty"`
 	CloudProvider string `mapstructure:"cloud-provider,omitempty"`
+	AgentVersion  string `mapstructure:"agent-version,omitempty"`
 }

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -75,6 +75,7 @@ func TestHostsListHandler(t *testing.T) {
 			Meta: map[string]string{
 				"trento-sap-systems":    "sys1",
 				"trento-cloud-provider": "azure",
+				"trento-agent-version":  "1",
 			},
 		},
 		{
@@ -84,6 +85,7 @@ func TestHostsListHandler(t *testing.T) {
 			Meta: map[string]string{
 				"trento-sap-systems":    "sys2",
 				"trento-cloud-provider": "aws",
+				"trento-agent-version":  "1",
 			},
 		},
 		{
@@ -93,6 +95,7 @@ func TestHostsListHandler(t *testing.T) {
 			Meta: map[string]string{
 				"trento-sap-systems":    "sys3",
 				"trento-cloud-provider": "gcp",
+				"trento-agent-version":  "1",
 			},
 		},
 	}
@@ -166,12 +169,12 @@ func TestHostsListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<div.*alert-success.*<i.*check_circle.*</i>.*Passing.*1"), minified)
 	assert.Regexp(t, regexp.MustCompile("<div.*alert-warning.*<i.*warning.*</i>.*Warning.*1"), minified)
 	assert.Regexp(t, regexp.MustCompile("<div.*alert-danger.*<i.*error.*</i>.*Critical.*1"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td><td>v1</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td><td>v1</td>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<select name=trento-sap-systems.*>.*sys1.*sys2.*sys3.*</select>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*<i.*danger.*error.*</i></td><td>.*bar.*</td><td>192.168.1.2</td><td>.*aws.*</td><td>.*sys2.*</td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*<i.*warning.*warning.*</i></td><td>.*buzz.*</td><td>192.168.1.3</td><td>.*gcp.*</td><td>.*sys3.*</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*<i.*success.*check_circle.*</i></td><td>.*foo.*</td><td>192.168.1.1</td><td>.*azure.*</td><td>.*sys1.*</td><td>v1</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*<i.*danger.*error.*</i></td><td>.*bar.*</td><td>192.168.1.2</td><td>.*aws.*</td><td>.*sys2.*</td><td>v1</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*<i.*warning.*warning.*</i></td><td>.*buzz.*</td><td>192.168.1.3</td><td>.*gcp.*</td><td>.*sys3.*</td><td>v1</td>"), minified)
 }
 
 func TestHostHandler(t *testing.T) {
@@ -189,7 +192,8 @@ func TestHostHandler(t *testing.T) {
 		Datacenter: "dc1",
 		Address:    "192.168.1.1",
 		Meta: map[string]string{
-			"trento-sap-systems": "sys1",
+			"trento-sap-systems":   "sys1",
+			"trento-agent-version": "1",
 		},
 	}
 
@@ -297,6 +301,7 @@ func TestHostHandler(t *testing.T) {
 
 	assert.Regexp(t, regexp.MustCompile("<dd.*>test_host</dd>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<a.*sapsystems.*>sys1</a>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<dd.*>v1</dd>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<span.*>passing</span>"), minified)
 	// SAP Instance
 	assert.Regexp(t, regexp.MustCompile("<dt.*>Name</dt><dd.*>HDB00</dd>"), minified)

--- a/web/sap_systems_test.go
+++ b/web/sap_systems_test.go
@@ -148,6 +148,7 @@ func TestSAPSystemHandler(t *testing.T) {
 				"trento-ha-cluster-id":  "e2f2eb50aef748e586a7baa85e0162cf",
 				"trento-cloud-provider": "azure",
 				"trento-sap-systems":    "HA1",
+				"trento-agent-version":  "0",
 			},
 		},
 	}
@@ -198,7 +199,7 @@ func TestSAPSystemHandler(t *testing.T) {
 	// Layout/
 	assert.Regexp(t, regexp.MustCompile("<tr><td>test_host</td><td>10</td><td>ENQREP</td><td>50013</td><td>50014</td><td>0.5</td><td><span.*primary.*>SAPControl-GREEN</span></td></tr>"), responseBody)
 	// Host
-	assert.Regexp(t, regexp.MustCompile("<tr><td>.*check_circle.*</td><td><a href=/hosts/test_host>test_host</a></td><td>192.168.10.10</td><td>azure</td><td><a href=/clusters/e2f2eb50aef748e586a7baa85e0162cf>banana</a></td><td><a href=/sapsystems/HA1>HA1</a></td></tr>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<tr><td>.*check_circle.*</td><td><a href=/hosts/test_host>test_host</a></td><td>192.168.10.10</td><td>azure</td><td><a href=/clusters/e2f2eb50aef748e586a7baa85e0162cf>banana</a></td><td><a href=/sapsystems/HA1>HA1</a></td><td>v0</td></tr>"), responseBody)
 }
 
 func TestSAPSystemHandler404Error(t *testing.T) {

--- a/web/templates/blocks/hosts_table.html.tmpl
+++ b/web/templates/blocks/hosts_table.html.tmpl
@@ -9,6 +9,7 @@
                 <th scope='col'>Cloud provider</th>
                 <th scope='col'>Cluster</th>
                 <th scope='col'>System</th>
+                <th scope='col'>Agent version</th>
             </tr>
             </thead>
             <tbody>
@@ -36,6 +37,9 @@
                             {{ $v }}
                         </a>
                         {{- end }}
+                    </td>
+                    <td>
+                        {{ .GetAgentVersionString }}
                     </td>
                 </tr>
             {{- else }}

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -15,6 +15,10 @@
             <dd class="inline"><a
                         href='/clusters/{{ index .Host.TrentoMeta "trento-ha-cluster-id" }}'>{{ index .Host.TrentoMeta "trento-ha-cluster" }}</a>
             </dd>
+            <dt class="inline">Agent version</dt>
+            <dd class="inline">
+                {{ .Host.GetAgentVersionString }}
+            </dd>
         </dl>
         <hr/>
         {{- if eq .CloudData.Provider "azure" }}


### PR DESCRIPTION
This PR stores the trento agent version on the host metadata and allows to check it from both the hosts list view (+ sapsystems details) and the host details view. This allows a user to quickly realize if there is a mismatch on the version of any of the agents.

Some screenshots to show how it looks:
![host-list-trento-version](https://user-images.githubusercontent.com/2668401/130249162-2b2d186c-36bd-483d-b35c-717bc2e65739.png)
![host-details](https://user-images.githubusercontent.com/2668401/130249168-2d08fb26-dd95-4b89-b0c8-dc8919c8ca20.png)

Also, when no trento agent is running on a registered host (the case of the monitoring node) we display a "Not running" text:
![host-details-no-agent](https://user-images.githubusercontent.com/2668401/130249221-b9b68db7-4871-4467-ac17-a8e27506b8d3.png)

