### PR TITLE
Add ansible_host connection option to ansibleHostsTemplate

### DIFF
--- a/runner/consultemplate.go
+++ b/runner/consultemplate.go
@@ -21,7 +21,7 @@ var ansibleHostsTemplate = fmt.Sprintf(`
 [{{ key (print (printf "%[3]s" $key) "/name") }}]
 {{- range tree (print (printf "%[3]s" $key) "/crmmon/Nodes") }}
 {{- if .Key | contains "/Name" }}
-{{ .Value }} %[1]s={{ key (printf "%[4]s" $key) }}
+{{ .Value }} %[1]s={{ key (printf "%[4]s" $key) }} ansible_host={{ with node .Value }}{{ .Node.Address }}{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR adds the `ansible_host` connection option to the generated ansible inventory by using the node discovered IP address.
See: https://docs.ansible.com/ansible/latest/reference_appendices/special_variables.html#connection-variables

This is required in order to let ansible know the ip of the hosts without resolving them, so we don't ask the user to modify `/etc/hosts` or alter `resolv.conf/k8s core dns or pod dns policies.

See: https://github.com/trento-project/trento/pull/191#discussion_r691861673