### PR TITLE
Remove HANA role badge

### DIFF
--- a/web/clusters.go
+++ b/web/clusters.go
@@ -99,17 +99,6 @@ func getHanaSID(c *cluster.Cluster) string {
 	return ""
 }
 
-// HANARole parses the hana_prd_roles string and returns the HANA Role
-// Possible values: master, slave
-// e.g. 4:P:master1:master:worker:master returns master (last element)
-func (node *Node) HANARole() string {
-	if r, ok := node.Attributes["hana_prd_roles"]; ok {
-		role := r[strings.LastIndex(r, ":")+1:]
-		return strings.Title(role)
-	}
-	return "-"
-}
-
 // HANAHealthState parses the hana_prd_roles string and returns the SAPHanaSR Health state
 // Possible values: 0-4
 // 4 - SAP HANA database is up and OK. The cluster does interpret this as a correctly running database.

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -401,7 +401,7 @@ func TestClusterHandlerHANA(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<strong>CIB last written:</strong><br><span.*>Wed Jun 30 18:11:37 2021</span>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<strong>HANA secondary sync state:</strong><br><span.*>SFAIL</span>"), minified)
 	// Nodes
-	assert.Regexp(t, regexp.MustCompile("<td><a.*href=/hosts/test_node_1.*>test_node_1</a></td><td>192.168.1.1</td><td>10.123.123.123</td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td><a.*href=/hosts/test_node_1.*>test_node_1</a></td><td>192.168.1.1</td><td>10.123.123.123</td><td><span .*>HANA Primary</span>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<td><a.*href=/hosts/test_node_2.*>test_node_2</a></td><td>192.168.1.2</td>"), minified)
 	// Resources
 	assert.Regexp(t, regexp.MustCompile("<td>sbd</td><td>stonith:external/sbd</td><td>Started</td><td>active</td><td>0</td>"), minified)

--- a/web/templates/blocks/sites.html.tmpl
+++ b/web/templates/blocks/sites.html.tmpl
@@ -34,7 +34,6 @@
                                 {{- range $i, $v := .VirtualIps }}{{- if $i }} ,{{- end }}{{ . }}{{- end }}
                             </td>
                             <td>
-                                <span class="badge badge-pill badge-info">HANA {{ .HANARole }}</span>
                                 <span class="badge badge-pill badge-info">HANA {{ .HANAStatus }}</span>
                             </td>
 


### PR DESCRIPTION
This PR removes the HANA role badge from the site/node view of the cluster scale-up detail view, as mentioned in #186 