### PR TITLE
Trigger rebuilding of trento in obs

### DIFF
--- a/.ci/gh_release_to_obs_changeset.py
+++ b/.ci/gh_release_to_obs_changeset.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+import textwrap
+import urllib.request
+import urllib.error
+from datetime import datetime
+from datetime import timezone
+import tempfile
+
+parser = argparse.ArgumentParser(description="Add a GitHub release to an RPM changelog", usage=argparse.SUPPRESS)
+parser.add_argument("repo", help="GitHub repository (owner/name)")
+parser.add_argument("-t", "--tag", help="A specific Git tag to get; if none, latest will be used")
+parser.add_argument("-a", "--author", help="The author of the RPM changelog entry")
+parser.add_argument("-f", "--file", help="Prepend the new changelog entry to file instead of printing in stdout")
+
+if len(sys.argv) == 1:
+    parser.print_help(sys.stderr)
+    sys.exit(1)
+
+args = parser.parse_args()
+
+releaseSegment = f"/tags/{args.tag}" if args.tag else "/latest"
+url = f'https://api.github.com/repos/{args.repo}/releases{releaseSegment}'
+
+request = urllib.request.Request(url)
+
+githubToken = os.getenv("GITHUB_OAUTH_TOKEN")
+if githubToken:
+    request.add_header("Authorization", "token " + githubToken)
+
+try:
+    response = urllib.request.urlopen(request)
+except urllib.error.HTTPError as error:
+    if error.code == 404:
+        print(f"Release {args.tag} not found in {args.repo}. Skipping changelog generation.")
+        sys.exit(0)
+    print(f"GitHub API responded with a {error.code} error!", file=sys.stderr)
+    print("Url:", url, file=sys.stderr)
+    print("Response:", json.dumps(json.load(error), indent=4), file=sys.stderr, sep="\n")
+    sys.exit(1)
+
+release = json.load(response)
+
+releaseDate = datetime.strptime(release['published_at'], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+with tempfile.TemporaryFile("r+") as temp:
+    print("-------------------------------------------------------------------", file=temp)
+
+    print(f"{releaseDate.strftime('%c')} {releaseDate.strftime('%Z')}", end="", file=temp)
+    if args.author:
+        print(f" - {args.author}", end="", file=temp)
+    print("\n", file=temp)
+
+    print(f"- Release {args.tag}", end="", file=temp)
+    if release['name'] and release['name'] != args.tag:
+        print(f" - {release['name']}", end="", file=temp)
+    print("\n", file=temp)
+
+    if release['body']:
+        print(textwrap.indent(release['body'], "  "), file=temp, end="\n\n")
+    temp.seek(0)
+
+    if args.file:
+        try:
+            with open(args.file, "r") as prev:
+                old = prev.read()
+        except FileNotFoundError:
+            old = ""
+        with open(args.file, "w") as new:
+            for line in temp:
+                new.write(line)
+            new.write(old)
+        sys.exit(0)
+
+    print(temp.read())

--- a/.github/workflows/submit-to-obs.yml
+++ b/.github/workflows/submit-to-obs.yml
@@ -1,0 +1,74 @@
+name: Rebuild trento in obs
+on: [push]
+env:
+  PACKAGE_NAME: trento
+  OBS_USER: ${{ secrets.OBS_USER }}
+  OBS_PASS: ${{ secrets.OBS_PASS }}
+  OBS_PROJECT: ${{ secrets.OBS_PROJECT}}
+  TARGET_PROJECT: ${{ secrets.TARGET_PROJECT}}
+  FOLDER: packaging/suse
+  REPOSITORY: ${{ github.repository }}
+jobs:
+  delivery:
+    runs-on: ubuntu-18.04
+    if: github.ref == 'refs/heads/main'
+    container:
+      image: shap/continuous_deliver
+      env:
+        OBS_UNSTABLE: https://download.opensuse.org/repositories/OBS:/Server:/Unstable/SLE_15_SP3/OBS:Server:Unstable.repo
+        OBS_UNSTABLE_KEY: https://download.opensuse.org/repositories/OBS:/Server:/Unstable/SLE_15_SP3/repodata/repomd.xml.key
+        GITHUB_OAUTH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: configure OSC
+    # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
+    # that is used to run osc commands
+      run: |
+        /scripts/init_osc_creds.sh
+        mkdir -p $HOME/.config/osc
+        cp /root/.config/osc/oscrc $HOME/.config/osc
+    - name: update go and install obs-service-node_modules
+      run: |
+        rpm --import ${OBS_UNSTABLE_KEY}
+        zypper ar ${OBS_UNSTABLE}
+        zypper ref
+        zypper in -y obs-service-node_modules go
+        go version
+    - name: prepare tranto.changes file
+      run: |
+        VERSION=$(hack/get_version_from_git.sh)
+        TAG=$(echo $VERSION | cut -f1 -d+)
+        .ci/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento.changes
+    - name: prepare _service file
+      run: |
+        VERSION=$(hack/get_version_from_git.sh)
+        sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+        sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
+        sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+    - name: deliver package
+      run: cp $FOLDER/_service . && /scripts/upload.sh
+  submit:
+    needs: delivery
+    runs-on: ubuntu-18.04
+    if: ${{ github.event_name != 'pull_request' }}
+    container:
+      image: shap/continuous_deliver
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: configure OSC
+      run: |
+        /scripts/init_osc_creds.sh
+        mkdir -p $HOME/.config/osc
+        cp /root/.config/osc/oscrc $HOME/.config/osc
+    - name: prepare _service file
+      run: |
+        VERSION=$(hack/get_version_from_git.sh)
+        sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+        sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
+        sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+    - name: submit package
+      run: cp $FOLDER/_service . && /scripts/submit.sh

--- a/packaging/suse/_service
+++ b/packaging/suse/_service
@@ -1,0 +1,27 @@
+<services>
+    <service name="tar_scm" mode="disabled">
+        <param name="url">https://github.com/%%REPOSITORY%%.git</param>
+        <param name="scm">git</param>
+        <param name="revision">%%REVISION%%</param>
+        <param name="exclude">.git</param>
+        <param name="exclude">.github</param>
+        <param name="extract">web/frontend/package.json</param>
+        <param name="extract">web/frontend/package-lock.json</param>
+        <param name="exclude">web/frontend/package-lock.json</param>
+        <param name="versionformat">%%VERSION%%</param>
+        <param name="filename">trento</param>
+    </service>
+    <service name="set_version" mode="disabled">
+        <param name="file">trento.spec</param>
+    </service>
+    <service name="recompress" mode="disabled">
+        <param name="file">*.tar</param>
+        <param name="compression">gz</param>
+    </service>
+    <service name="node_modules" mode="disabled">
+        <param name="cpio">node_modules.obscpio</param>
+        <param name="output">node_modules.spec.inc</param>
+        <param name="source-offset">10000</param>
+    </service>
+    <service name="go_modules" mode="disabled" />
+</services>

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -1,0 +1,114 @@
+#
+# spec file for package trento
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative   .
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+Name:           trento
+# Version will be processed via set_version source service
+Version:        0
+Release:        0
+License:        Apache-2.0
+Summary:        An open cloud-native web console improving on the life of SAP Applications administrators .
+Group:          System/Monitoring
+URL:            https://github.com/trento-project/trento
+Source:         %{name}-%{version}.tar.gz
+Source1:        vendor.tar.gz
+Source2:        node_modules.spec.inc
+Source3:	package.json
+%include %_sourcedir/node_modules.spec.inc
+ExclusiveArch:  aarch64 x86_64 ppc64le s390x
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  golang-packaging
+BuildRequires:  golang(API) = 1.16
+BuildRequires:  npm
+BuildRequires:  local-npm-registry
+Provides:       trento = %{version}-%{release}
+
+%{go_nostrip}
+
+%description
+An open cloud-native web console improving on the life of SAP Applications administrators.
+
+Trento is a city on the Adige River in Trentino-Alto Adige/Suedtirol in Italy. [...] It is one of the nation''s wealthiest and most prosperous cities, [...] often ranking highly among Italian cities for quality of life, standard of living, and business and job opportunities. (source)
+
+This project is a reboot of the "SUSE Console for SAP Applications", also known as the Blue Horizon for SAP prototype, which is focused on automated infrastructure deployment and provisioning for SAP Applications.
+
+As opposed to that first iteration, this new one will focus more on operations of existing clusters, rather than deploying new one.
+
+%prep
+%setup -q            # unpack project sources
+%setup -q -T -D -a 1 # unpack go dependencies in vendor.tar.gz, which was prepared by the source services
+
+cp %SOURCE3 .
+local-npm-registry %{_sourcedir} install --with=dev
+
+%define shortname trento
+
+%build
+
+mv node_modules web/frontend/
+make build
+
+%install
+
+# Install the binary.
+install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{shortname}"
+
+# Install the systemd unit
+install -D -m 0644 hack/trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
+sed -i "s+/srv/trento/trento agent start+trento agent start+g" %{buildroot}%{_unitdir}/trento-agent.service
+
+# Install compat wrapper for legacy init systems
+install -Dd -m 0755 %{buildroot}%{_sbindir}
+ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rc%{name}
+
+# Install checkers
+install -D -m 0644 examples/hana-scale-up-perf-optimized-azure.yaml "%{buildroot}/srv/%{shortname}/examples/hana-scale-up-perf-optimized-azure.yaml"
+install -D -m 0644 examples/generic-azure.yaml "%{buildroot}/srv/%{shortname}/examples/generic-azure.yaml"
+
+# Create a link
+#ln -s "%{buildroot}%{_bindir}/%{shortname}" "%{buildroot}/srv/%{shortname}/"
+
+%pre
+%service_add_pre trento-agent.service
+
+%post
+%service_add_post trento-agent.service
+
+%preun
+%service_del_preun trento-agent.service
+
+%postun
+%service_del_postun trento-agent.service
+
+%files
+%defattr(-,root,root)
+%doc *.md
+%doc docs/*.md
+%if 0%{?suse_version} >= 1500
+%license LICENSE
+%else
+%doc LICENSE
+%endif
+%{_bindir}/%{shortname}
+%{_unitdir}/trento-agent.service
+%{_sbindir}/rc%{name}
+%dir /srv/%{shortname}/
+%dir /srv/%{shortname}/examples/
+%config /srv/%{shortname}/examples/generic-azure.yaml
+%config /srv/%{shortname}/examples/hana-scale-up-perf-optimized-azure.yaml
+
+%changelog

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -21,7 +21,7 @@ Name:           trento
 Version:        0
 Release:        0
 License:        Apache-2.0
-Summary:        An open cloud-native web console improving on the life of SAP Applications administrators .
+Summary:        An open cloud-native web console improving on the life of SAP Applications administrators.
 Group:          System/Monitoring
 URL:            https://github.com/trento-project/trento
 Source:         %{name}-%{version}.tar.gz
@@ -42,7 +42,7 @@ Provides:       trento = %{version}-%{release}
 %description
 An open cloud-native web console improving on the life of SAP Applications administrators.
 
-Trento is a city on the Adige River in Trentino-Alto Adige/Suedtirol in Italy. [...] It is one of the nation''s wealthiest and most prosperous cities, [...] often ranking highly among Italian cities for quality of life, standard of living, and business and job opportunities. (source)
+Trento is a city on the Adige River in Trentino-Alto Adige/Suedtirol in Italy. [...] It is one of the nation's wealthiest and most prosperous cities, [...] often ranking highly among Italian cities for quality of life, standard of living, and business and job opportunities. (source)
 
 This project is a reboot of the "SUSE Console for SAP Applications", also known as the Blue Horizon for SAP prototype, which is focused on automated infrastructure deployment and provisioning for SAP Applications.
 
@@ -68,19 +68,7 @@ make build
 install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{shortname}"
 
 # Install the systemd unit
-install -D -m 0644 hack/trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
-sed -i "s+/srv/trento/trento agent start+trento agent start+g" %{buildroot}%{_unitdir}/trento-agent.service
-
-# Install compat wrapper for legacy init systems
-install -Dd -m 0755 %{buildroot}%{_sbindir}
-ln -s /usr/sbin/service %{buildroot}%{_sbindir}/rc%{name}
-
-# Install checkers
-install -D -m 0644 examples/hana-scale-up-perf-optimized-azure.yaml "%{buildroot}/srv/%{shortname}/examples/hana-scale-up-perf-optimized-azure.yaml"
-install -D -m 0644 examples/generic-azure.yaml "%{buildroot}/srv/%{shortname}/examples/generic-azure.yaml"
-
-# Create a link
-#ln -s "%{buildroot}%{_bindir}/%{shortname}" "%{buildroot}/srv/%{shortname}/"
+install -D -m 0644 trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
 
 %pre
 %service_add_pre trento-agent.service
@@ -98,17 +86,8 @@ install -D -m 0644 examples/generic-azure.yaml "%{buildroot}/srv/%{shortname}/ex
 %defattr(-,root,root)
 %doc *.md
 %doc docs/*.md
-%if 0%{?suse_version} >= 1500
 %license LICENSE
-%else
-%doc LICENSE
-%endif
 %{_bindir}/%{shortname}
 %{_unitdir}/trento-agent.service
-%{_sbindir}/rc%{name}
-%dir /srv/%{shortname}/
-%dir /srv/%{shortname}/examples/
-%config /srv/%{shortname}/examples/generic-azure.yaml
-%config /srv/%{shortname}/examples/hana-scale-up-perf-optimized-azure.yaml
 
 %changelog

--- a/trento-agent.service
+++ b/trento-agent.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Trento agent service
+Requires=consul.service
+After=consul.service
+
+[Service]
+ExecStart=/usr/bin/trento/trento agent start --consul-config-dir=/srv/consul/consul.d
+Type=simple
+User=root
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
(EDITED)
The first commit adds a GitHub action that calls obs services to make a package and then submits it to the OBS.
The second commit is to correctly rebase the PR over the main. (Lately the example/*.yaml cheks were removed)
