### PR TITLE
Ansible records usage improvements

### DIFF
--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -1,5 +1,6 @@
 - hosts: all
   gather_facts: false
+  become: yes
 
   vars:
     ara_playbook_labels:

--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -1,5 +1,6 @@
 - hosts: all
   gather_facts: false
+  ignore_errors: yes
   become: yes
 
   vars:
@@ -13,14 +14,28 @@
       when:
         - not ansible_check_mode
 
-    - name: Post initial empty results to ARA
-      import_role:
-        name: post-results
-        tasks_from: post
+    - block:
+        - name: include load_facts
+          import_role:
+            name: load_facts
+          register: result
 
-    - name: include load_facts
-      import_role:
-        name: load_facts
+        - name: count unreachable hosts number
+          set_fact:
+            unreachable_count: |
+              {{ unreachable_count|default(0)|int + 1 }}
+          with_inventory_hostnames:
+            - all
+          when: facts_result is unreachable
+          delegate_to: localhost
+
+        - name: Post initial empty results to ARA if all hosts are unreachable
+          import_role:
+            name: post-results
+            tasks_from: post
+          when: unreachable_count|int == hostvars|length
+
+      ignore_unreachable: yes
 
     - name: include 1.1.1
       import_role:
@@ -162,6 +177,7 @@
         name: '1.5.2'
       when: "'1.5.2' in cluster_selected_checks"
 
+  post_tasks:
     - name: Post results
       import_role:
         name: post-results

--- a/runner/ansible/roles/load_facts/tasks/main.yml
+++ b/runner/ansible/roles/load_facts/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - name: gather facts
   ansible.builtin.setup:
+  register: facts_result
 
 - name: load environment variables
   include_vars: "{{ env | default('azure') }}_env.yml"

--- a/web/frontend/stylesheets/override.scss
+++ b/web/frontend/stylesheets/override.scss
@@ -55,3 +55,8 @@ footer.footer-side-menu ul.footer-list {
   border-radius: 0;
   border: none;
 }
+
+// Set the same padding as info and warning
+.alert-danger {
+  padding-right: 8px;
+}


### PR DESCRIPTION
This PR fixes 3 things:
- Use `become` option to provide root privileges to ansible to run the queries. Otherwise, the checks are executed with the user used in the connection, which might not have the rights to run our checks
- Send the empty ARA record at the beginning only if all the hosts are unreachable. Otherwise, it is being sent always, and this makes the Web show an empty health results during the ansible execution
- Fix the annoying critical health container padding...

Now the critical counter has the same padding than the 2 others
![image](https://user-images.githubusercontent.com/36370954/132178068-1d33ba34-64ab-40c1-a702-373022b1ff6d.png)

@brett060102 Could you have a look?
