### PR TITLE
Add cluster connection settings user input in cluster modal

### DIFF
--- a/internal/cloud/azure.go
+++ b/internal/cloud/azure.go
@@ -34,7 +34,7 @@ type Compute struct {
 	Location                   string              `json:"location,omitempty" mapstructure:"location,omitempty"`
 	Name                       string              `json:"name,omitempty" mapstructure:"name,omitempty"`
 	Offer                      string              `json:"offer,omitempty" mapstructure:"offer,omitempty"`
-	OsProfile                  OsProfile           `json:"osProfile,omitempty" mapstructure:"ofprofile,omitempty"`
+	OsProfile                  OsProfile           `json:"osProfile,omitempty" mapstructure:"osprofile,omitempty"`
 	OsType                     string              `json:"osType,omitempty" mapstructure:"ostype,omitempty"`
 	PlacementGroupId           string              `json:"placementGroupId,omitempty" mapstructure:"placementgroupid,omitempty"`
 	Plan                       Plan                `json:"plan,omitempty" mapstructure:"plan,omitempty"`

--- a/internal/cloud/metadata.go
+++ b/internal/cloud/metadata.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	azure = "azure"
+	Azure = "azure"
 )
 
 type CloudInstance struct {
@@ -32,8 +32,8 @@ func IdentifyCloudProvider() (string, error) {
 
 	switch string(provider) {
 	case "Microsoft Corporation":
-		log.Infof("VM is running on %s", azure)
-		return azure, nil
+		log.Infof("VM is running on %s", Azure)
+		return Azure, nil
 	default:
 		log.Info("VM is not running in any recognized cloud provider")
 		return "", nil
@@ -55,7 +55,7 @@ func NewCloudInstance() (*CloudInstance, error) {
 	}
 
 	switch provider {
-	case azure:
+	case Azure:
 		cloudMetadata, err = NewAzureMetadata()
 		if err != nil {
 			return nil, err

--- a/internal/cloud/metadata_kvstore.go
+++ b/internal/cloud/metadata_kvstore.go
@@ -62,7 +62,7 @@ func Load(client consul.Client, host string) (*CloudInstance, error) {
 	mapstructure.Decode(data, &cloudData)
 
 	switch cloudData.Provider {
-	case azure:
+	case Azure:
 		azureMetadata := &AzureMetadata{}
 		mapstructure.Decode(cloudData.Metadata, &azureMetadata)
 		cloudData.Metadata = azureMetadata

--- a/internal/cluster/connection_settings_kvstore.go
+++ b/internal/cluster/connection_settings_kvstore.go
@@ -1,0 +1,43 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/trento-project/trento/internal/consul"
+)
+
+func GetConnectionSettings(client consul.Client, clusterId string) (map[string]interface{}, error) {
+	err := client.WaitLock(consul.KvClustersPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "error waiting for the lock for clusters")
+	}
+
+	kvPath := fmt.Sprintf(consul.KvClustersConnectionPath, clusterId)
+
+	connectionData, err := client.KV().ListMap(kvPath, kvPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting the cluster connection settings")
+	}
+
+	return connectionData, nil
+}
+
+func StoreConnectionSettings(client consul.Client, clusterId string, connectionMap map[string]interface{}) error {
+
+	l, err := client.AcquireLockKey(consul.KvClustersPath)
+	if err != nil {
+		return errors.Wrap(err, "could not lock the kv for clusters")
+	}
+	defer l.Unlock()
+
+	kvPath := fmt.Sprintf(consul.KvClustersConnectionPath, clusterId)
+
+	err = client.KV().PutMap(kvPath, connectionMap)
+	if err != nil {
+		return errors.Wrap(err, "Error storing cluster connection settings")
+	}
+
+	return nil
+}

--- a/internal/cluster/connection_settings_kvstore_test.go
+++ b/internal/cluster/connection_settings_kvstore_test.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	"fmt"
+	"testing"
+
+	consulApi "github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/trento-project/trento/internal/consul"
+	"github.com/trento-project/trento/internal/consul/mocks"
+)
+
+func TestGetConnectionSettings(t *testing.T) {
+	consulInst := new(mocks.Client)
+	kv := new(mocks.KV)
+
+	consulInst.On("KV").Return(kv)
+
+	kvPath := fmt.Sprintf(consul.KvClustersConnectionPath, "foobar")
+
+	expectedConnData := map[string]interface{}{
+		"host1": "myuser1",
+		"host2": "myuser2",
+	}
+	consulInst.On("WaitLock", consul.KvClustersPath).Return(nil)
+	kv.On("ListMap", kvPath, kvPath).Return(expectedConnData, nil)
+
+	connData, err := GetConnectionSettings(consulInst, "foobar")
+
+	assert.NoError(t, err)
+	assert.Equal(t, expectedConnData, connData)
+	kv.AssertExpectations(t)
+}
+
+func TestStoreConnectionSettings(t *testing.T) {
+	consulInst := new(mocks.Client)
+	kv := new(mocks.KV)
+
+	consulInst.On("KV").Return(kv)
+
+	connData := map[string]interface{}{
+		"host1": "myuser1",
+		"host2": "myuser2",
+	}
+	kvPath := fmt.Sprintf(consul.KvClustersConnectionPath, "foobar")
+	testLock := consulApi.Lock{}
+	consulInst.On("AcquireLockKey", consul.KvClustersPath).Return(&testLock, nil)
+	kv.On("PutMap", kvPath, connData).Return(nil)
+
+	err := StoreConnectionSettings(consulInst, "foobar", connData)
+
+	assert.NoError(t, err)
+	kv.AssertExpectations(t)
+}

--- a/internal/consul/kv.go
+++ b/internal/consul/kv.go
@@ -33,6 +33,7 @@ const (
 	KvClustersPath           string = "trento/v0/clusters/"
 	KvClustersDiscoveredPath string = "trento/v0/clusters/%s/discovered_data"
 	KvClustersChecksPath     string = "trento/v0/clusters/%s/user_settings/checks"
+	KvClustersConnectionPath string = "trento/v0/clusters/%s/user_settings/connection"
 	KvHostsPath              string = "trento/v0/hosts/"
 	KvHostsMetadataPath      string = "trento/v0/hosts/%s/metadata/"
 	KvHostsClouddataPath     string = "trento/v0/hosts/%s/cloud/"

--- a/runner/consultemplate.go
+++ b/runner/consultemplate.go
@@ -17,12 +17,13 @@ import (
 const clusterSelectedChecks string = "cluster_selected_checks"
 
 var ansibleHostsTemplate = fmt.Sprintf(`
-{{- range $key, $pairs := tree "%[2]s" | byKey }}
-[{{ key (print (printf "%[3]s" $key) "/id") }}]
-{{- range tree (print (printf "%[3]s" $key) "/crmmon/Nodes") }}
+{{- range $clusterId, $pairs := tree "%[2]s" | byKey }}
+[{{ key (print (printf "%[3]s" $clusterId) "/id") }}]
+{{- range tree (print (printf "%[3]s" $clusterId) "/crmmon/Nodes") }}
 {{- if .Key | contains "/Name" }}
 {{- $nodename := .Value }}
-{{ $nodename }} %[1]s={{ key (printf "%[4]s" $key) }} ansible_host={{ range nodes }}{{ if eq .Node $nodename }}{{ .Address }}{{ end }}{{ end }}
+{{- $user := keyOrDefault (print (printf "%[5]s" $clusterId) "/" $nodename) "root" }}
+{{ $nodename }} %[1]s={{ keyOrDefault  (printf "%[4]s" $clusterId) "" }} ansible_host={{ range nodes }}{{ if eq .Node $nodename }}{{ .Address }}{{ end }}{{ end }} ansible_user={{ $user }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -30,7 +31,8 @@ var ansibleHostsTemplate = fmt.Sprintf(`
 	clusterSelectedChecks,
 	consul.KvClustersPath,
 	consul.KvClustersDiscoveredPath,
-	consul.KvClustersChecksPath)
+	consul.KvClustersChecksPath,
+	consul.KvClustersConnectionPath)
 
 const ansibleHostFile = "ansible_hosts"
 

--- a/runner/consultemplate.go
+++ b/runner/consultemplate.go
@@ -31,7 +31,7 @@ var ansibleHostsTemplate = fmt.Sprintf(`
 {{- if eq $user "" }}
 {{- $cloudata := printf "%[6]s" $nodename }}
 {{- if eq (keyOrDefault (print $cloudata "provider") "") "azure" }}
-{{- $user = keyOrDefault (print $cloudata "metadata/compute/ofprofile/adminusername") "root" }}
+{{- $user = keyOrDefault (print $cloudata "metadata/compute/osprofile/adminusername") "root" }}
 {{- end }}
 {{- end }}
 {{- /* Render the node entry */}}

--- a/web/alert.go
+++ b/web/alert.go
@@ -22,7 +22,7 @@ var AlertConnectionDataNotFound = func() Alert {
 	return Alert{
 		Type:  "danger",
 		Title: "Error loading the connection data",
-		Text: "Connection data couldn't be retrieved.",
+		Text:  "Connection data couldn't be retrieved.",
 	}
 }
 

--- a/web/alert.go
+++ b/web/alert.go
@@ -18,6 +18,14 @@ var AlertCatalogNotFound = func() Alert {
 	}
 }
 
+var AlertConnectionDataNotFound = func() Alert {
+	return Alert{
+		Type:  "danger",
+		Title: "Error loading the connection data",
+		Text: "Connection data couldn't be retrieved.",
+	}
+}
+
 var CheckResultsNotFound = func() Alert {
 	return Alert{
 		Type:  "danger",

--- a/web/app.go
+++ b/web/app.go
@@ -77,7 +77,7 @@ func NewAppWithDeps(host string, port int, deps Dependencies) (*App, error) {
 	engine.GET("/catalog", NewChecksCatalogHandler(deps.checksService))
 	engine.GET("/clusters", NewClusterListHandler(deps.consul, deps.checksService))
 	engine.GET("/clusters/:id", NewClusterHandler(deps.consul, deps.checksService))
-	engine.POST("/clusters/:id/checks", NewSaveChecksHandler(deps.consul))
+	engine.POST("/clusters/:id/settings", NewSaveClusterSettingsHandler(deps.consul))
 	engine.GET("/environments", NewEnvironmentListHandler(deps.consul))
 	engine.GET("/environments/:env", NewEnvironmentHandler(deps.consul))
 	engine.GET("/landscapes", NewLandscapeListHandler(deps.consul))

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -12,8 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mitchellh/mapstructure"
 
-	"github.com/trento-project/trento/internal/cluster"
 	"github.com/trento-project/trento/internal/cloud"
+	"github.com/trento-project/trento/internal/cluster"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
 	"github.com/trento-project/trento/web/models"
@@ -509,17 +509,17 @@ func NewClusterHandler(client consul.Client, s services.ChecksService) gin.Handl
 		}
 
 		c.HTML(http.StatusOK, "cluster_hana.html.tmpl", gin.H{
-			"Cluster":            clusterItem,
-			"Nodes":              nodes,
-			"StoppedResources":   stoppedResources(clusterItem),
-			"ClusterType":        clusterType,
-			"HealthContainer":    hContainer,
-			"ChecksCatalog":      checksCatalog,
-			"ChecksCatalogModal": checksCatalogModalData,
-			"ConnectionData":     connectionData,
+			"Cluster":               clusterItem,
+			"Nodes":                 nodes,
+			"StoppedResources":      stoppedResources(clusterItem),
+			"ClusterType":           clusterType,
+			"HealthContainer":       hContainer,
+			"ChecksCatalog":         checksCatalog,
+			"ChecksCatalogModal":    checksCatalogModalData,
+			"ConnectionData":        connectionData,
 			"DefaultConnectionData": defaultConnectionData,
-			"ChecksResult":       checksResult,
-			"Alerts":             GetAlerts(c),
+			"ChecksResult":          checksResult,
+			"Alerts":                GetAlerts(c),
 		})
 	}
 }
@@ -548,14 +548,14 @@ func NewSaveClusterSettingsHandler(client consul.Client) gin.HandlerFunc {
 
 		usernames := getConnectionMap(c.Request.PostForm)
 
-		err := cluster.StoreCheckSelection(
+		checkErr := cluster.StoreCheckSelection(
 			client, clusterId, strings.Join(selectedChecks.Ids, ","))
 
-		err = cluster.StoreConnectionSettings(
+		connErr := cluster.StoreConnectionSettings(
 			client, clusterId, usernames)
 
 		var newAlert Alert
-		if err == nil {
+		if checkErr == nil && connErr == nil {
 			newAlert = Alert{
 				Type:  "success",
 				Title: "Cluster settings saved",

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -16,6 +16,7 @@ import (
 	"github.com/trento-project/trento/internal/cluster"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
+	"github.com/trento-project/trento/runner"
 	"github.com/trento-project/trento/web/models"
 	"github.com/trento-project/trento/web/services"
 )
@@ -431,6 +432,8 @@ func getDefaultConnectionSettings(client consul.Client, c *cluster.Cluster) (map
 			azureMetadata := &cloud.AzureMetadata{}
 			mapstructure.Decode(data.Metadata, &azureMetadata)
 			connData[n.Name] = azureMetadata.Compute.OsProfile.AdminUserName
+		} else {
+			connData[n.Name] = runner.DefaultUser
 		}
 	}
 

--- a/web/templates/blocks/cluster_modal.html.tmpl
+++ b/web/templates/blocks/cluster_modal.html.tmpl
@@ -2,7 +2,7 @@
   <div class="modal fade" id="clusterModal" tabindex="-1" role="dialog" aria-labelledby="clusterModalLabel" aria-hidden="true">
       <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
           <div class="modal-content">
-          <form action="/clusters/{{ .Cluster.Id }}/checks" method="POST">
+          <form action="/clusters/{{ .Cluster.Id }}/settings" method="POST">
               <div class="modal-header">
                   <h5 class="modal-title" id="clusterModalLabel">{{ .Cluster.Name }}</h5>
                   <button type="button" class="close" data-dismiss="modal" aria-label="Close">
@@ -10,8 +10,48 @@
                   </button>
               </div>
               <div class="modal-body">
-                  <h6>Checks selection</h6>
+                  <div id="connection">
+                      <h6>Connection settings</h6>
+                      <p><b>**The provided connection user must have the SSH connection enabled**</b><p>
+                      <div class="card">
+                          <div class="card-header card-header-check-selection" id="connection-settings">
+                              <div class='form-check float-left'>Host connection settings</div>
+                              <div class='dropdown float-right'>
+                                  <div class='dropdown-toggle' data-toggle="collapse" data-target="#collapse-connection-settings" aria-expanded="true" aria-controls="collapse-connection-settings">
+                                      <i class="eos-icons eos-18">keyboard_arrow_down</i>
+                                  </div>
+                              </div>
+                          </div>
+
+                          <div id="collapse-connection-settings" class="collapse" aria-labelledby="connection-settings" data-parent="#connection">
+                              <div class="card-body card-check-selection">
+                                  <div class='table-responsive'>
+                                      <table class='table table-sm eos-table'>
+                                          <thead>
+                                              <tr>
+                                                  <th scope='col'>Host</th>
+                                                  <th scope='col'>Connection user</th>
+                                              </tr>
+                                          </thead>
+                                          <tbody>
+                                              {{- range .Nodes }}
+                                              <tr>
+                                                  <td>{{ .Name }}</td>
+                                                  <td><input id='username-{{ .Name }}' name='username[]' type='text'></td>
+                                              </tr>
+                                              {{- else }}
+                                                  {{ template "empty_table_body" 2 }}
+                                              {{- end }}
+                                          </tbody>
+                                      </table>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+                  </br>
                   <div id="checksAccordion">
+                      <h6>Checks selection</h6>
                       {{- $groupNumber := 0 }}
                       {{- range $group, $data := .ChecksCatalogModal }}
                       <div class="card">
@@ -43,7 +83,7 @@
                                               <tr>
                                                   <td class="row-status">
                                                       <div class='form-check'>
-                                                         <input class='parent-{{ $groupNumber }} form-check-input eos-checkbox' type='checkbox' name="ids[]" value="{{ .ID }}" id='{{ $groupNumber }}-{{ .NormalizeID }}' {{ if .Selected }}checked="checked"{{ end }}>
+                                                         <input class='parent-{{ $groupNumber }} form-check-input eos-checkbox' type='checkbox' name="check_ids[]" value="{{ .ID }}" id='{{ $groupNumber }}-{{ .NormalizeID }}' {{ if .Selected }}checked="checked"{{ end }}>
                                                          <label class='form-check-label' for='{{ $groupNumber }}-{{ .NormalizeID }}'>{{ .ID }}</label>
                                                      </div>
                                                   </td>

--- a/web/templates/blocks/cluster_modal.html.tmpl
+++ b/web/templates/blocks/cluster_modal.html.tmpl
@@ -12,8 +12,6 @@
               <div class="modal-body">
                   <div id="connection">
                       <h6>Connection settings</h6>
-                      <p><b>**The provided connection user must have the SSH connection enabled**</b><p>
-                      <p><b>**Default user is used when Connection user is empty**</b><p>
                       <div class="card">
                           <div class="card-header card-header-check-selection" id="connection-settings">
                               <div class='form-check float-left'>Host connection settings</div>
@@ -49,6 +47,10 @@
                                               {{- end }}
                                           </tbody>
                                       </table>
+                                  </div>
+                                  <div>
+                                      <b>**The provided connection user must have the SSH connection enabled**</b></br>
+                                      <b>**Default user is used when Connection user is empty**</b>
                                   </div>
                               </div>
                           </div>

--- a/web/templates/blocks/cluster_modal.html.tmpl
+++ b/web/templates/blocks/cluster_modal.html.tmpl
@@ -13,6 +13,7 @@
                   <div id="connection">
                       <h6>Connection settings</h6>
                       <p><b>**The provided connection user must have the SSH connection enabled**</b><p>
+                      <p><b>**Default user is used when Connection user is empty**</b><p>
                       <div class="card">
                           <div class="card-header card-header-check-selection" id="connection-settings">
                               <div class='form-check float-left'>Host connection settings</div>
@@ -31,17 +32,20 @@
                                               <tr>
                                                   <th scope='col'>Host</th>
                                                   <th scope='col'>Connection user</th>
+                                                  <th scope='col'>Default user</th>
                                               </tr>
                                           </thead>
                                           <tbody>
                                               {{- $connectionData := .ConnectionData }}
+                                              {{- $defConnectionData := .DefaultConnectionData }}
                                               {{- range .Nodes }}
                                               <tr>
                                                   <td>{{ .Name }}</td>
                                                   <td><input id='username-{{ .Name }}' name='username-{{ .Name }}' type='text' value='{{ index $connectionData .Name }}'></td>
+                                                  <td>{{ index $defConnectionData .Name }}</td>
                                               </tr>
                                               {{- else }}
-                                                  {{ template "empty_table_body" 2 }}
+                                                  {{ template "empty_table_body" 3 }}
                                               {{- end }}
                                           </tbody>
                                       </table>

--- a/web/templates/blocks/cluster_modal.html.tmpl
+++ b/web/templates/blocks/cluster_modal.html.tmpl
@@ -34,10 +34,11 @@
                                               </tr>
                                           </thead>
                                           <tbody>
+                                              {{- $connectionData := .ConnectionData }}
                                               {{- range .Nodes }}
                                               <tr>
                                                   <td>{{ .Name }}</td>
-                                                  <td><input id='username-{{ .Name }}' name='username[]' type='text'></td>
+                                                  <td><input id='username-{{ .Name }}' name='username-{{ .Name }}' type='text' value='{{ index $connectionData .Name }}'></td>
                                               </tr>
                                               {{- else }}
                                                   {{ template "empty_table_body" 2 }}


### PR DESCRIPTION
Implement the option to customize the ansible ssh connection settings, specifically the user that is used during the ssh connections.
This is done through the cluster settings modal.

It follows the next logic:
- User stored data goes to: `trento/v0/clusters/mycluster/user_settings/connection/` as map
- If the data is not stored, the code tries to use the Azure metadata information to get the OsProfile admin user name
- Ansible inventory is changed based on this logic, adding the `ansible_user` value

Demo:

![connection_settings](https://user-images.githubusercontent.com/36370954/132305312-aee4cd07-b8b9-4571-9775-5b458d7d2414.gif)

Follow up issues:
https://github.com/trento-project/trento/issues/218
https://github.com/trento-project/trento/issues/219