### PR TITLE
Remove hardcoded SID prefix (prd) from attributes keys

### DIFF
--- a/web/templates/cluster_hana.html.tmpl
+++ b/web/templates/cluster_hana.html.tmpl
@@ -28,7 +28,7 @@
                     </div>
                     <div class="col-6">
                         <strong>HANA system replication mode:</strong><br>
-                        <span class="text-muted">{{ index $firstNode.Attributes "hana_prd_srmode" }}</span>
+                        <span class="text-muted">{{ .Nodes.HANASystemReplicationMode }}</span>
                     </div>
 
                     <div class="col-3 mt-5">
@@ -71,7 +71,7 @@
                     </div>
                     <div class="col-6 mt-5">
                         <strong>HANA system replication operation mode:</strong><br>
-                        <span class="text-muted">{{ index $firstNode.Attributes "hana_prd_op_mode" }}</span>
+                        <span class="text-muted">{{ .Nodes.HANASystemReplicationOperationMode }}</span>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes broken attribute fetching when `SID != "PRD"`