### PR TITLE
Add 1.1.9 and 1.1.9.runtime checks to the ansible runner

### DIFF
--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -110,6 +110,16 @@
         name: '1.1.8.runtime'
       when: "'1.1.8.runtime' in cluster_selected_checks"
 
+    - name: include 1.1.9
+      import_role:
+        name: '1.1.9'
+      when: "'1.1.9' in cluster_selected_checks"
+
+    - name: include 1.1.9.runtime
+      import_role:
+        name: '1.1.9.runtime'
+      when: "'1.1.9.runtime' in cluster_selected_checks"
+
     - name: include 1.2.1
       import_role:
         name: '1.2.1'

--- a/runner/ansible/meta.yml
+++ b/runner/ansible/meta.yml
@@ -85,6 +85,16 @@
         name: '1.1.8.runtime'
         tasks_from: meta
 
+    - name: include 1.1.9 meta
+      import_role:
+        name: '1.1.9'
+        tasks_from: meta
+
+    - name: include 1.1.9.runtime meta
+      import_role:
+        name: '1.1.9.runtime'
+        tasks_from: meta
+
     - name: include 1.2.1 meta
       import_role:
         name: '1.2.1'

--- a/runner/ansible/roles/1.1.9.runtime/tasks/main.yml
+++ b/runner/ansible/roles/1.1.9.runtime/tasks/main.yml
@@ -6,9 +6,9 @@
 
 - name: "{{ test_id }}.check"
   shell: |
-    corosync-cmapctl | grep totem.interface.0 || exit 1
-    corosync-cmapctl | grep totem.interface.1 || exit 1
-    exit 0
+    INTERFACE_COUNT=$(corosync-cmapctl | grep totem.interface\\..*\.ttl | wc -l)
+    [[ ${INTERFACE_COUNT} -ge "2" ]] && exit 0
+    exit 1
   check_mode: no
   register: config_updated
   changed_when: config_updated.rc != 0

--- a/runner/ansible/roles/1.1.9.runtime/tasks/main.yml
+++ b/runner/ansible/roles/1.1.9.runtime/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Set Test ID
+  set_fact:
+    test_id: '1.1.9.runtime'
+
+- name: "{{ test_id }}.check"
+  shell: |
+    corosync-cmapctl | grep totem.interface.0 || exit 1
+    corosync-cmapctl | grep totem.interface.1 || exit 1
+    exit 0
+  check_mode: no
+  register: config_updated
+  changed_when: config_updated.rc != 0
+  failed_when: config_updated.rc > 1
+
+- block:
+    - import_role:
+        name: post-results
+  when:
+    - ansible_check_mode
+  vars:
+    status: "{{ config_updated is not changed }}"

--- a/runner/ansible/roles/1.1.9.runtime/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.9.runtime/tasks/meta.yml
@@ -1,0 +1,18 @@
+- block:
+    - import_role:
+        name: post-metadata
+        tasks_from: store
+  vars:
+    id: 1.1.9.runtime
+    name: Corosync has at least 2 configured rings (runtime)
+    group: Corosync
+    labels: generic
+    description: |
+      Test if corosync has at least 2 rings configured during runtime
+    remediation: |
+      ## Abstract
+      It is strongly recommended to add a second ring to the corosync communication.
+
+      ## References
+      - section 9.1 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+    implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"

--- a/runner/ansible/roles/1.1.9.runtime/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.9.runtime/tasks/meta.yml
@@ -14,5 +14,5 @@
       It is strongly recommended to add a second ring to the corosync communication.
 
       ## References
-      - section 9.1 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+      - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
     implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"

--- a/runner/ansible/roles/1.1.9/tasks/main.yml
+++ b/runner/ansible/roles/1.1.9/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+
+- name: Set Test ID
+  set_fact:
+    test_id: '1.1.9'
+
+- name: "{{ test_id }}.check"
+  shell: |
+    INTERFACE_COUNT=$(cat /etc/corosync/corosync.conf | grep interface | wc -l)
+    [[ $INTERFACE_COUNT -ge "2" ]] && exit 0
+    exit 1
+  check_mode: no
+  register: config_updated
+  changed_when: config_updated.rc != 0
+  failed_when: config_updated.rc > 1
+
+- block:
+    - import_role:
+        name: post-results
+  when:
+    - ansible_check_mode
+  vars:
+    status: "{{ config_updated is not changed }}"

--- a/runner/ansible/roles/1.1.9/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.9/tasks/meta.yml
@@ -1,0 +1,18 @@
+- block:
+    - import_role:
+        name: post-metadata
+        tasks_from: store
+  vars:
+    id: 1.1.9
+    name: Corosync has at least 2 configured rings
+    group: Corosync
+    labels: generic
+    description: |
+      Test if corosync has at least 2 rings configured
+    remediation: |
+      ## Abstract
+      It is strongly recommended to add a second ring to the corosync communication.
+      
+      ## References
+      - section 9.1 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+    implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"

--- a/runner/ansible/roles/1.1.9/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.9/tasks/meta.yml
@@ -12,7 +12,7 @@
     remediation: |
       ## Abstract
       It is strongly recommended to add a second ring to the corosync communication.
-      
+
       ## References
-      - section 9.1 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+      - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
     implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"


### PR DESCRIPTION
Add missing 1.1.9 and 1.1.9.runtime checks to the ansible runner.
Based on: https://github.com/trento-project/trento/blob/main/examples/generic-azure.yaml#L240

@brett060102 Could you have a look?