### PR TITLE
Fix 1.1.6 check remediation text

### DIFF
--- a/runner/ansible/roles/1.1.6.runtime/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.6.runtime/tasks/meta.yml
@@ -11,13 +11,40 @@
       Test if the configured corosync transport parameter has the correct value during runtime: {{ expected['1.1.6'] }}
     remediation: |
       ## Remediation
-      It will be difficult to change the corosync MCAST transport to UCAST
-      on an existing cluster. Besides adding the 'transport: udpu' parameter one
-      would have to configure each node separatelly. The easiest way to
-      make the cluster UCAST it to bootstrap it. When creating the cluster
-      you would have to add the key -u, for example
-      $ crm cluster init -u ...
+      To change the corosync MCAST transport to UCAST edit the /etc/corosync/corosync.conf
+      as in the example
+      ```
+          max_messages: 20
+          interface {
+              ringnumber: 0
+      -       bindnetaddr: 10.162.32.167
+      -       mcastaddr: 239.11.100.41
+              mcastport: 5405
+              ttl: 1
+          }
+      +   transport: udpu
+      ...
+      +nodelist {
+      +       node {
+      +               ring0_addr: 10.162.32.167
+      +               nodeid: 1
+      +       }
+      +
+      +       node {
+      +               ring0_addr: 10.162.32.89
+      +               nodeid: 2
+      +       }
+      +
+      +}
+      ```
+      1. stop the already running cluster by using **systemctl stop pacemaker**
+      2. In the totem section, in the interface subsection remove the
+      keys-value pairs **bindnetaddr** and **mcastaddr**
+      3. In the totem section add key-value pair **transport: udpu**
+      4. Add section nodelist and subsections node for each nodes of the
+      cluster, where the **ring0_addr** is the IP address of the node
 
       ## References
+      - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
       - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
     implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"

--- a/runner/ansible/roles/1.1.6/tasks/meta.yml
+++ b/runner/ansible/roles/1.1.6/tasks/meta.yml
@@ -11,13 +11,40 @@
       Test if the configured corosync transport parameter has the correct value: {{ expected[id] }}
     remediation: |
       ## Remediation
-      It will be difficult to change the corosync MCAST transport to UCAST
-      on an existing cluster. Besides adding the 'transport: udpu' parameter one
-      would have to configure each node separatelly. The easiest way to
-      make the cluster UCAST it to bootstrap it. When creating the cluster
-      you would have to add the key -u, for example
-      $ crm cluster init -u ...
+      To change the corosync MCAST transport to UCAST edit the /etc/corosync/corosync.conf
+      as in the example
+      ```
+          max_messages: 20
+          interface {
+              ringnumber: 0
+      -       bindnetaddr: 10.162.32.167
+      -       mcastaddr: 239.11.100.41
+              mcastport: 5405
+              ttl: 1
+          }
+      +   transport: udpu
+      ...
+      +nodelist {
+      +       node {
+      +               ring0_addr: 10.162.32.167
+      +               nodeid: 1
+      +       }
+      +
+      +       node {
+      +               ring0_addr: 10.162.32.89
+      +               nodeid: 2
+      +       }
+      +
+      +}
+      ```
+      1. stop the already running cluster by using **systemctl stop pacemaker**
+      2. In the totem section, in the interface subsection remove the
+      keys-value pairs **bindnetaddr** and **mcastaddr**
+      3. In the totem section add key-value pair **transport: udpu**
+      4. Add section nodelist and subsections node for each nodes of the
+      cluster, where the **ring0_addr** is the IP address of the node
 
       ## References
+      - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
       - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
     implementation: "{{ lookup('file', 'roles/'+id+'/tasks/main.yml') }}"


### PR DESCRIPTION
Fix 1.1.6 and 1.1.6.runtime remediation texts.
Based on: https://github.com/trento-project/trento/pull/201