### PR TITLE
Trento agent one-line installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ of existing clusters, rather than deploying new one.
   - [Runtime dependencies](#runtime-dependencies)
   - [Build dependencies](#build-dependencies)
   - [Development dependencies](#development-dependencies)
-- [Installation](#installation)
+- [Quick-start installation](#quick-start-installation)
+- [Manual installation](#manual-installation)
 - [Running Trento](#running-trento)
   - [Consul](#consul)
   - [Trento Agents](#trento-agents)
@@ -88,13 +89,73 @@ Additionally, for the development we use:
 
 > See the [Development](#development) section for details on how to install `mockery`.
 
-# Installation
+# Quick-Start Installation
 
-## From binaries
+We provide an installation script to automatically install and update the latest version of Trento.
+
+## Trento Server Installation
+
+T.B.D.
+
+## Trento Agent Installation
+
+You can `curl | bash` if you want to live on the edge.
+
+```
+$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install.sh | sudo bash
+```
+
+Or you can fetch the script, and then execute it manually.
+
+```
+$ curl -O https://raw.githubusercontent.com/trento-project/trento/main/install.sh
+$ chmod 700 install.sh
+$ sudo ./install.sh
+```
+
+The script will ask you for two IP addresses.
+
+- `agent bind IP`: the private address to which the trento-agent should be bound for internal communications.
+  This is an IP address that should be reachable by the other hosts, including the trento server.
+  Note for the Pacemaker users: this IP address _should not be_ a floating IP.
+
+- `trento server IP`: the address where Trento server can be reached.
+
+You can pass these arguments as flags or env variables too:
+
+```
+$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install.sh | sudo bash -s - --agent-bind-ip=192.168.33.10 --server-ip=192.168.33.1
+```
+
+```
+$ AGENT_BIND_IP=192.168.33.10 SERVER_IP=192.168.33.1 sudo ./install.sh
+```
+
+### Start Trento Agent
+
+The installation script does not start the agent automatically.
+
+You can start it by simply:
+
+```
+$ sudo systemctl start trento-agent
+```
+
+Please make sure the server is running before starting the agent
+
+To enable the service execute:
+
+```
+$ sudo systemctl enable trento-agent
+```
+
+# Manual Installation
+
+## Pre-built binaries
 
 Pre-built statically linked binaries are made available via [GitHub releases](https://github.com/trento-project/trento/releases).
 
-## Manual
+## Compile from source
 
 You clone also clone and build it manually:
 

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ T.B.D.
 You can `curl | bash` if you want to live on the edge.
 
 ```
-$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install.sh | sudo bash
+$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh | sudo bash
 ```
 
 Or you can fetch the script, and then execute it manually.
 
 ```
-$ curl -O https://raw.githubusercontent.com/trento-project/trento/main/install.sh
-$ chmod 700 install.sh
-$ sudo ./install.sh
+$ curl -O https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh
+$ chmod 700 install-agent.sh
+$ sudo ./install-agent.sh
 ```
 
 The script will ask you for two IP addresses.
@@ -124,11 +124,11 @@ The script will ask you for two IP addresses.
 You can pass these arguments as flags or env variables too:
 
 ```
-$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install.sh | sudo bash -s - --agent-bind-ip=192.168.33.10 --server-ip=192.168.33.1
+$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh | sudo bash -s - --agent-bind-ip=192.168.33.10 --server-ip=192.168.33.1
 ```
 
 ```
-$ AGENT_BIND_IP=192.168.33.10 SERVER_IP=192.168.33.1 sudo ./install.sh
+$ AGENT_BIND_IP=192.168.33.10 SERVER_IP=192.168.33.1 sudo ./install-agent.sh
 ```
 
 ### Start Trento Agent

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -15,7 +15,7 @@ that can help you deploy, provision and operate infrastructure for SAP Applicati
 
 Usage:
 
-  sudo ./install.sh --agent-bind-ip <192.168.122.10> --server-ip <192.168.122.5>
+  sudo ./install-agent.sh --agent-bind-ip <192.168.122.10> --server-ip <192.168.122.5>
 
 Arguments:
   --agent-bind-ip   The private address to which the trento-agent should be bound for internal communications.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# The script requires root permissions
+
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run as root."
+    exit
+fi
+
+function print_help() {
+    cat << END
+This is a trento-agent installer. Trento is a web-based graphical user interface
+that can help you deploy, provision and operate infrastructure for SAP Applications
+
+Usage:
+
+  sudo ./install.sh --agent-bind-ip <192.168.122.10> --server-ip <192.168.122.5>
+
+Arguments:
+  --agent-bind-ip   The private address to which the trento-agent should be bound for internal communications.
+                    This is an IP address that should be reachable by the other nodes, including the trento server.
+  --server-ip       The trento server ip.
+  --help            Print this help.
+END
+}
+
+case "$1" in
+--help)
+    print_help
+    exit 0
+    ;;
+esac
+
+ARGUMENT_LIST=(
+    "agent-bind-ip"
+    "server-ip"
+)
+
+opts=$(
+    getopt \
+        --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
+        --name "$(basename "$0")" \
+        --options "" \
+        -- "$@"
+)
+
+eval set "--$opts"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --agent-bind-ip)
+        AGENT_BIND_IP=$2
+        shift 2
+        ;;
+
+    --server-ip)
+        SERVER_IP=$2
+        shift 2
+        ;;
+
+    *)
+        break
+        ;;
+    esac
+done
+
+if [ -z "$AGENT_BIND_IP" ]; then
+    read -rp "Please provide a bind IP for the agent: " AGENT_BIND_IP < /dev/tty
+fi
+if [ -z "$SERVER_IP" ]; then
+    read -rp "Please provide the server IP: " SERVER_IP < /dev/tty
+fi
+if [ -z "$NODE_NAME" ]; then
+    NODE_NAME="$HOSTNAME"
+fi
+
+TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/repodata/repomd.xml.key"}
+TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}
+
+CONSUL_VERSION=1.9.6
+CONSUL_PATH=/srv/consul
+CONFIG_PATH="$CONSUL_PATH/consul.d"
+CONSUL_HCL_TEMPLATE='data_dir = "/srv/consul/data/"
+log_level = "DEBUG"
+datacenter = "dc1"
+ui = true
+bind_addr = "@BIND_ADDR@"
+client_addr = "0.0.0.0"
+retry_join = ["@JOIN_ADDR@"]'
+
+CONSUL_SERVICE_NAME="consul.service"
+CONSUL_SERVICE_TEMPLATE='[Unit]
+Description="HashiCorp Consul - A service mesh solution"
+Documentation=https://www.consul.io/
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/srv/consul/consul.d/consul.hcl
+PartOf=trento-agent.service
+
+[Service]
+ExecStart=/srv/consul/consul agent -config-dir=/srv/consul/consul.d
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=5
+Type=notify
+
+
+[Install]
+WantedBy=multi-user.target'
+
+. /etc/os-release
+if [[ ! $PRETTY_NAME =~ "SUSE" ]]; then
+    echo "Operating system is not supported. Exiting."
+    exit 1
+fi
+
+echo "Installing trento-agent..."
+
+function install_deps() {
+    echo "* Installing dependencies... "
+    if ! which unzip > /dev/null 2>&1; then
+        echo "* Installing unzip"
+        zypper in -y unzip > /dev/null
+    fi
+    if ! which curl > /dev/null 2>&1; then
+        echo "* Installing curl"
+        zypper in -y curl > /dev/null
+    fi
+}
+
+function install_consul() {
+    mkdir -p $CONFIG_PATH
+    pushd -- "$CONSUL_PATH" > /dev/null
+    curl -f -sS -O -L "https://releases.hashicorp.com/consul/$CONSUL_VERSION/consul_${CONSUL_VERSION}_linux_amd64.zip" > /dev/null
+    unzip -o "consul_${CONSUL_VERSION}_linux_amd64".zip > /dev/null
+    rm "consul_${CONSUL_VERSION}_linux_amd64".zip
+    popd > /dev/null
+}
+
+function setup_consul() {
+    echo "$CONSUL_HCL_TEMPLATE" |
+        sed "s|@JOIN_ADDR@|${SERVER_IP}|g" |
+        sed "s|@BIND_ADDR@|${AGENT_BIND_IP}|g" |
+        sed "s|@NODE_NAME@|${NODE_NAME}|g" \
+            >${CONFIG_PATH}/consul.hcl
+
+    if [ -f "/usr/lib/systemd/system/$CONSUL_SERVICE_NAME" ]; then
+        echo "  Warning: Consul systemd unit already installed. Removing..."
+        systemctl stop "$CONSUL_SERVICE_NAME"
+        rm "/usr/lib/systemd/system/$CONSUL_SERVICE_NAME"
+    fi
+
+    echo "$CONSUL_SERVICE_TEMPLATE" >/usr/lib/systemd/system/$CONSUL_SERVICE_NAME
+    systemctl daemon-reload
+}
+
+function install_trento() {
+    rpm --import "${TRENTO_REPO_KEY}" > /dev/null
+    path=${TRENTO_REPO%/*}/
+    if zypper lr --details | cut -d'|' -f9 | grep "$path" > /dev/null 2>&1; then
+        echo "* $path repository already exists. Skipping."
+    else
+        zypper ar "$TRENTO_REPO" > /dev/null
+    fi
+    zypper ref > /dev/null
+    if which trento > /dev/null 2>&1; then
+        echo "* Trento is already installed. Updating trento"
+        zypper up -y trento > /dev/null
+    else
+        echo "* Installing trento"
+        zypper in -y trento > /dev/null
+    fi
+}
+
+install_consul
+setup_consul
+install_trento
+
+echo -e "\e[92mDone.\e[97m"
+echo -e "You can now start trento-agent with: \033[1msystemctl start trento-agent\033[0m"


### PR DESCRIPTION
Iteration of PR: #152 

Adds the one line `curl-bashable` installer which

- Installs or upgrades dependencies
- Installs or upgrades, configure consul
- Adds consul systemd unit
- Installs or upgrade trento rpm 

Mandatory parameters were kept to the bare minimum and they are asked interactively if the user doesn't provide them as flags or env variables.

Updates the README with the quick installation instructions.