### PR TITLE
Pin golang version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: 1.16
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
Pins CI golang version to `1.16.x`