### PR TITLE
Use the correct dmidecode field to identify cloud provider

### DIFF
--- a/internal/cloud/metadata.go
+++ b/internal/cloud/metadata.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	azure = "azure"
+	azure       = "azure"
+	azureDmiTag = "7783-7084-3265-9085-8269-3286-77"
 )
 
 type CloudInstance struct {
@@ -22,7 +23,7 @@ var customExecCommand CustomCommand = exec.Command
 
 func IdentifyCloudProvider() (string, error) {
 	log.Info("Identifying if the VM is running in a cloud environment...")
-	output, err := customExecCommand("dmidecode", "-s", "bios-vendor").Output()
+	output, err := customExecCommand("dmidecode", "-s", "chassis-asset-tag").Output()
 	if err != nil {
 		return "", err
 	}
@@ -31,7 +32,7 @@ func IdentifyCloudProvider() (string, error) {
 	log.Debugf("dmidecode output: %s", provider)
 
 	switch string(provider) {
-	case "Microsoft Corporation":
+	case azureDmiTag:
 		log.Infof("VM is running on %s", azure)
 		return azure, nil
 	default:

--- a/internal/cloud/metadata_test.go
+++ b/internal/cloud/metadata_test.go
@@ -21,7 +21,7 @@ func TestIdentifyCloudProviderErr(t *testing.T) {
 
 	customExecCommand = mockCommand.Execute
 
-	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
 		mockDmidecodeErr(),
 	)
 
@@ -32,7 +32,7 @@ func TestIdentifyCloudProviderErr(t *testing.T) {
 }
 
 func mockDmidecodeAzure() *exec.Cmd {
-	return exec.Command("echo", "Microsoft Corporation")
+	return exec.Command("echo", "7783-7084-3265-9085-8269-3286-77")
 }
 
 func TestIdentifyCloudProviderAzure(t *testing.T) {
@@ -40,7 +40,7 @@ func TestIdentifyCloudProviderAzure(t *testing.T) {
 
 	customExecCommand = mockCommand.Execute
 
-	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
 		mockDmidecodeAzure(),
 	)
 
@@ -59,7 +59,7 @@ func TestIdentifyCloudProviderNoCloud(t *testing.T) {
 
 	customExecCommand = mockCommand.Execute
 
-	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
 		mockDmidecodeNoCloud(),
 	)
 
@@ -74,7 +74,7 @@ func TestNewCloudInstanceAzure(t *testing.T) {
 
 	customExecCommand = mockCommand.Execute
 
-	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
 		mockDmidecodeAzure(),
 	)
 
@@ -106,7 +106,7 @@ func TestNewCloudInstanceNoCloud(t *testing.T) {
 
 	customExecCommand = mockCommand.Execute
 
-	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
 		mockDmidecodeNoCloud(),
 	)
 


### PR DESCRIPTION
This is a potential fix for #194, basically we just changed the `dmidecode` field to `chassis-asset-tag`.