### PR TITLE
Add the discovery-period flag to the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ To start the trento agent:
 ./trento agent start
 ```
 
+> If the discovery loop is being executed too frequently, and this impacts the Web interface performance, the agent
+has the option to configure the discovery loop mechanism using the `--discovery-period` flag. Increasing this value improves the overall performance of the application
+
 ## Trento Runner
 
 The Trento Runner is responsible for running the health checks. It is based on [Ansible](https://docs.ansible.com/ansible/latest/index.html) and [ARA](https://ara.recordsansible.org/).

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -13,6 +14,7 @@ import (
 )
 
 var consulConfigDir string
+var discoveryPeriod int
 
 func NewAgentCmd() *cobra.Command {
 
@@ -27,6 +29,7 @@ func NewAgentCmd() *cobra.Command {
 		Run:   start,
 	}
 	startCmd.Flags().StringVarP(&consulConfigDir, "consul-config-dir", "", "consul.d", "Consul configuration directory used to store node meta-data")
+	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 2, "Discovery mechanism loop period on minutes")
 
 	agentCmd.AddCommand(startCmd)
 
@@ -45,6 +48,7 @@ func start(cmd *cobra.Command, args []string) {
 	}
 
 	cfg.ConsulConfigDir = consulConfigDir
+	cfg.DiscoveryPeriod = time.Duration(discoveryPeriod) * time.Minute
 
 	a, err := agent.NewWithConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
Add the `discovery-period` flag to the agent cmd line execution, to make the discovery loop period configurable. The default value is 2 minutes.

With this, the user can select different periods, as having a low period (1 or 2 minutes) when there are many cluster (even with 3 clusters the performance starts suffereing), the web starts behaving poorly due to the lock mechanism.

This PR tries to be a workaround before having a better solution for the persistance layer.