### PR TITLE
Rename the "Checks" section in the single host page...

### DIFF
--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -56,13 +56,12 @@
             <hr/>
         {{- end }}
         <p class='clearfix'></p>
-        <h2>Checks</h2>
+        <h2>Trento Agent status</h2>
         <div class='table-responsive'>
             <table class='table eos-table'>
                 <thead>
                 <tr>
-                    <th scope='col'>Check name</th>
-                    <th scope='col'>CheckId</th>
+                    <th scope='col'>Item</th>
                     <th scope='col'>Notes</th>
                     <th scope='col'>Output</th>
                     <th scope='col'>Status</th>
@@ -73,7 +72,6 @@
                 {{- range .HealthChecks }}
                     <tr>
                         <td>{{ .Name }}</td>
-                        <td>{{ .CheckID }}</td>
                         <td>{{ .Notes }}</td>
                         <td class='show-white-space'>{{ .Output }}</td>
                         <td>
@@ -81,7 +79,7 @@
                         </td>
                     </tr>
                 {{- else }}
-                    {{ template "empty_table_body" 5}}
+                    {{ template "empty_table_body" 4}}
                 {{- end }}
                 </tbody>
             </table>


### PR DESCRIPTION
...and remove the `checkId` column, to disambiguate with the HA checker feature and make abundantly clear that these things are about Trento internals.

Before:
![Screenshot from 2021-09-14 17-38-17](https://user-images.githubusercontent.com/2952427/133288948-3416a36c-0a73-495f-8a63-59011a7f085a.png)

After:
![Screenshot from 2021-09-14 17-34-46](https://user-images.githubusercontent.com/2952427/133288767-3f1eebb8-975e-4827-b83d-84cb2f22c1b2.png)
