### PR TITLE
Helm chart fixes

### DIFF
--- a/packaging/helm/trento-server/Chart.lock
+++ b/packaging/helm/trento-server/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: trento-web
+  repository: ""
+  version: '>0.0.0'
+- name: trento-runner
+  repository: ""
+  version: '>0.0.0'
+- name: ara
+  repository: ""
+  version: '>0.0.0'
+- name: consul
+  repository: https://helm.releases.hashicorp.com
+  version: 0.32.1
+digest: sha256:bff2dfdc3c192b2b4c9bdb928d23f0fa9a587135d2083232db67b87fbc4994fc
+generated: "2021-09-14T17:46:57.219498157+02:00"

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -8,15 +8,12 @@ version: 0.1.0
 
 dependencies:
   - name: trento-web
-    repository: file://charts/trento-web
     version: ">0.0.0"
     condition: trento-web.enabled
   - name: trento-runner
-    repository: file://charts/trento-runner
     version: ">0.0.0"
     condition: trento-runner.enabled
   - name: ara
-    repository: file://charts/ara
     version: ">0.0.0"
     condition: ara.enabled
   - name: consul

--- a/packaging/helm/trento-server/charts/trento-runner/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 privateKey: ""
 
 image:
-  repository: ghcr.io/fabriziosestito/trento
+  repository: ghcr.io/trento-project/trento
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -49,7 +49,7 @@ ingress:
     kubernetes.io/ingress.class: "traefik"
     kubernetes.io/tls-acme: "true"
   hosts:
-    - host: "localhost"
+    - host: ""
       paths:
         - path: /
           pathType: ImplementationSpecific

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
   
 image:
-  repository: ghcr.io/fabriziosestito/trento
+  repository: ghcr.io/trento-project/trento
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
A set of fixes for the helm chart:
- removes repository directive from local subcharts  deps
- changes the image registry to the trento-project one
- fixes the ingress value in the trento-web subchart
- adds Chart.lock