### PR TITLE
Remove discovery health checks; add trento-agent health check

### DIFF
--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -42,6 +42,10 @@ func (d CloudDiscovery) Discover() (string, error) {
 		return "", err
 	}
 
+	if cloudData.Provider == "" {
+		return "No cloud provider discovered on this host", nil
+	}
+
 	return fmt.Sprintf("Cloud provider %s discovered", cloudData.Provider), nil
 }
 

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -31,9 +31,8 @@ func (c ClusterDiscovery) GetId() string {
 // Execute one iteration of a discovery and store the result in the Consul KVStore.
 func (d ClusterDiscovery) Discover() (string, error) {
 	cluster, err := cluster.NewCluster()
-
 	if err != nil {
-		return "", err
+		return "No HA cluster discovered on this host", nil
 	}
 
 	d.Cluster = cluster

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -50,10 +50,11 @@ func (d SAPSystemsDiscovery) Discover() (string, error) {
 
 	sysNames := systems.GetSIDsString()
 	if sysNames != "" {
+
 		return fmt.Sprintf("SAP system(s) with ID: %s discovered", sysNames), nil
 	}
-	output := "No SAP systems were found (you possibly need to run the trento agent with root privileges)"
-	return output, nil
+
+	return "No SAP system discovered on this host", nil
 }
 
 func storeSAPSystemTags(client consul.Client, systems sapsystem.SAPSystemsList) error {

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -261,7 +261,8 @@ func TestHostHandler(t *testing.T) {
 
 	healthChecks := consulApi.HealthChecks{
 		&consulApi.HealthCheck{
-			Status: consulApi.HealthPassing,
+			CheckID: "trentoAgent",
+			Status:  consulApi.HealthPassing,
 		},
 	}
 	health.On("Node", "test_host", (*consulApi.QueryOptions)(nil)).Return(healthChecks, nil, nil)

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -90,32 +90,27 @@
         {{- end }}
         <p class='clearfix'></p>
         <h2>Trento Agent status</h2>
-        <div class='table-responsive'>
-            <table class='table eos-table'>
-                <thead>
-                <tr>
-                    <th scope='col'>Item</th>
-                    <th scope='col'>Notes</th>
-                    <th scope='col'>Output</th>
-                    <th scope='col'>Status</th>
-                </tr>
-                </thead>
-                <tbody>
-                {{- $HostName := .Host.Name }}
-                {{- range .HealthChecks }}
+        {{- if .TrentoAgentCheck }}
+            <div class='table-responsive'>
+                <table class='table eos-table'>
+                    <thead>
                     <tr>
-                        <td>{{ .Name }}</td>
-                        <td>{{ .Notes }}</td>
-                        <td class='show-white-space'>{{ .Output }}</td>
-                        <td>
-                            <span class='badge badge-pill badge-{{ if eq .Status "passing" }}primary{{ else if eq .Status "warning" }}warning{{ else }}danger{{ end }}'>{{ .Status }}</span>
-                        </td>
+                        <th scope='col'>Status</th>
+                        <th scope='col'>Output</th>
                     </tr>
-                {{- else }}
-                    {{ template "empty_table_body" 4}}
-                {{- end }}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>
+                                <span class='badge badge-pill badge-{{ if eq .TrentoAgentCheck.Status "passing" }}primary{{ else if eq .TrentoAgentCheck.Status "warning" }}warning{{ else }}danger{{ end }}'>{{ .TrentoAgentCheck.Status }}</span>
+                            </td>
+                            <td class='show-white-space'>{{ .TrentoAgentCheck.Output }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        {{- else }}
+            Agent not running
+        {{- end }}
     </div>
 {{ end }}


### PR DESCRIPTION
This PR removes the discovery health checks and adds a single trento-agent health check, which fails in case of discovery error. The check is green as long as the any of the discovery loops doesn't _fail_.

It also changes the domain definition of _failed discovery_, till now we considered a discovery as failed also when the discovery was having a negative result, for example no cloud provider found would trigger a failed check.
Now we save the negative output on the consul check note, but we don't fail in this case.

Closes: #208 
