### PR TITLE
Use distroless container / multistage Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+web/frontend/node_modules
+web/frontend/assets
+trento

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,23 @@
-FROM opensuse/leap:15.2
-MAINTAINER Rubén Torrero Marijnissen <rtorreromarijnissen@suse.com>
+FROM node:16 AS node-build
+WORKDIR /build
+ADD . /build
+RUN make web-assets
 
-COPY . /app
+FROM golang:1.16 as go-build
+COPY --from=node-build /build /build
+WORKDIR /build
+RUN make build
 
-RUN zypper -n in go1.16 nodejs14 make
-RUN cd /app && make build
+FROM python:3.7-slim AS python-build
+RUN ln -s /usr/local/bin/python /usr/bin/python
+RUN /usr/bin/python -m venv /venv
+RUN /venv/bin/pip install ansible ara
+
+FROM gcr.io/distroless/python3:debug
+COPY --from=python-build /venv /venv
+ENV PATH="/venv/bin:$PATH"
+ENV PYTHONPATH=/venv/lib/python3.7/site-packages
+COPY --from=go-build /build/trento /app/trento
 
 EXPOSE 8080/tcp
-
 ENTRYPOINT ["/app/trento"]


### PR DESCRIPTION
This PR changes the current Dockerfile to use distroless containers (https://github.com/GoogleContainerTools/distroless) and multistage build for the go artifact, assets and adds python ansible dependencies.

