### PR TITLE
Fix: trento path is /usr/bin

### DIFF
--- a/trento-agent.service
+++ b/trento-agent.service
@@ -4,7 +4,7 @@ Requires=consul.service
 After=consul.service
 
 [Service]
-ExecStart=/usr/bin/trento/trento agent start --consul-config-dir=/srv/consul/consul.d
+ExecStart=/usr/bin/trento agent start --consul-config-dir=/srv/consul/consul.d
 Type=simple
 User=root
 Restart=on-failure


### PR DESCRIPTION
There has happened to appear a typo in the trento path in the systemd file