### PR TITLE
Add server installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ of existing clusters, rather than deploying new one.
   - [Build dependencies](#build-dependencies)
   - [Development dependencies](#development-dependencies)
 - [Quick-start installation](#quick-start-installation)
+  - [Trento Server installation](#trento-server-installation)
+  - [Trento Agent installation](#trento-agent-installation)
 - [Manual installation](#manual-installation)
+  - [Pre-built binaries](#pre-built-binaries)
+  - [Compile from source](#compile-from-source)
+  - [Helm chart](#helm-chart)
 - [Running Trento](#running-trento)
   - [Consul](#consul)
   - [Trento Agents](#trento-agents)
@@ -88,102 +93,45 @@ Additionally, for the development we use:
 
 > See the [Development](#development) section for details on how to install `mockery`.
 
-# Quick-Start Installation
+# Quick-Start installation
 
-We provide an installation script to automatically install and update the latest version of Trento.
+We provide installations scripts for to automatically install and update the latest version of Trento.
+Please follow the installation in the given order/
 
-## Trento Server Installation
+## Trento Server installation
 
-The [packaging/helm](packaging/helm) directory contains the Helm chart for installing Trento Server in a Kubernetes cluster.
-
-### Install K3s
-
-If installing as root:
-
-```
-# curl -sfL https://get.k3s.io | sh
-```
-
-If installing as non-root user:
-
-```
-$ curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
-```
-
-Export KUBECONFIG env variable:
-
-```
-$ export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-```
-
-Please refer to the [K3s official documentation](https://rancher.com/docs/k3s/latest/en/installation/) for more information about the installation.
-
-### Install Helm and chart dependencies
-
-Install Helm:
-
-```
-$ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-```
-
-Please refer to the [Helm official documentation](https://helm.sh/docs/intro/install/) for more information about the installation.
-
-### Install the Trento Server Helm chart
-
-Add HashiCorp Helm repository:
-
-```
-$ helm repo add hashicorp https://helm.releases.hashicorp.com
-$ helm repo update
-```
-
-Install chart dependencies:
-
-```
-$ cd packaging/helm/trento-server/
-$ helm dependency update
-```
-
-The runner component of Trento server needs ssh access to the agent nodes to perform the checks.
-
-You need to pass a valid private key used for SSH authentication to the Helm chart, and it will be stored
-in the K3s cluster as a secret.
-
-Please refer to the [Trento Runner](#trento-runner) for more information.
-
-Install Trento server chart:
-
-```
-$ helm install trento . --set-file trento-runner.privateKey=/your/path/id_rsa_runner
-```
-
-or perform a rolling update:
-
-```
-$ helm upgrade trento . --set-file trento-runner.privateKey=/your/path/id_rsa_runner
-```
-
-Now you can connect to the web server via `http://localhost` and point the agents to the cluster IP address.
-
-### Other Helm chart usage examples:
-
-Use a different container image:
-
-```
-$ helm install trento . --set trento-web.tag="runner" --set trento-runner.tag="runner" --set-file trento-runner.privateKey=id_rsa_runner
-```
-
-Use a different container registry:
-
-```
-$ helm install trento . --set trento-web.image.repository="ghcr.io/myrepo/trento" --set trento-runner.image.repository="ghcr.io/myrepo/trento" --set-file trento-runner.privateKey=id_rsa_runner
-```
-
-Please refer to the the subcharts `values.yaml` for an advanced usage.
-
-## Trento Agent Installation
+The script installs a single node K3s cluster and uses the [trento-server Helm chart](packaging/helm/trento-server)
+to bootstrap a complete Trento server component.
 
 You can `curl | bash` if you want to live on the edge.
+
+```
+$ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-server.sh | bash
+```
+
+Or you can fetch the script, and then execute it manually.
+
+```
+$ curl -O https://raw.githubusercontent.com/trento-project/trento/main/install-server.sh
+$ chmod 700 install-server.sh
+$ sudo ./install-server.sh
+```
+
+The script will ask you for a private key that is used by the runner service to perform checks in the agent hosts via ssh.
+
+_Note: if a Trento server is already installed in the host, it will be updated._
+
+Please refer to the [Trento Runner](#trento-runner) section for more information.
+Please refer to the [Helm chart](#helm-chart) section for more information about the Helm chart.
+
+## Trento Agent installation
+
+After the server installation, you might want to install Trento agents in a running cluster.
+Please add the public key to the ssh authorized_keys to enable the runner checks in the agent host, 
+as mentioned in the server installation above.
+
+As for the server component an installation script is provided, 
+you can `curl | bash` it if you want to live on the edge.
 
 ```
 $ curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh | sudo bash
@@ -256,6 +204,93 @@ T.B.D.
 ## RPM Packages
 
 T.B.D.
+
+## Helm chart
+
+The [packaging/helm](packaging/helm) directory contains the Helm chart for installing Trento Server in a Kubernetes cluster.
+
+### Install K3s
+
+If installing as root:
+
+```
+# curl -sfL https://get.k3s.io | sh
+```
+
+If installing as non-root user:
+
+```
+$ curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
+```
+
+Export KUBECONFIG env variable:
+
+```
+$ export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+```
+
+Please refer to the [K3s official documentation](https://rancher.com/docs/k3s/latest/en/installation/) for more information about the installation.
+
+### Install Helm and chart dependencies
+
+Install Helm:
+
+```
+$ curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+```
+
+Please refer to the [Helm official documentation](https://helm.sh/docs/intro/install/) for more information about the installation.
+
+### Install the Trento Server Helm chart
+
+Add HashiCorp Helm repository:
+
+```
+$ helm repo add hashicorp https://helm.releases.hashicorp.com
+$ helm repo update
+```
+
+Install chart dependencies:
+
+```
+$ cd packaging/helm/trento-server/
+$ helm dependency update
+```
+
+The runner component of Trento server needs ssh access to the agent nodes to perform the checks.
+You need to pass a valid private key used for ssh authentication to the Helm chart, and it will be stored
+in the K3s cluster as a secret.
+Please refer to the [Trento Runner](#trento-runner) section for more information.
+
+Install Trento server chart:
+
+```
+$ helm install trento . --set-file trento-runner.privateKey=/your/path/id_rsa_runner
+```
+
+or perform a rolling update:
+
+```
+$ helm upgrade trento . --set-file trento-runner.privateKey=/your/path/id_rsa_runner
+```
+
+Now you can connect to the web server via `http://localhost` and point the agents to the cluster IP address.
+
+### Other Helm chart usage examples:
+
+Use a different container image:
+
+```
+$ helm install trento . --set trento-web.tag="runner" --set trento-runner.tag="runner" --set-file trento-runner.privateKey=id_rsa_runner
+```
+
+Use a different container registry:
+
+```
+$ helm install trento . --set trento-web.image.repository="ghcr.io/myrepo/trento" --set trento-runner.image.repository="ghcr.io/myrepo/trento" --set-file trento-runner.privateKey=id_rsa_runner
+```
+
+Please refer to the the subcharts `values.yaml` for an advanced usage.
 
 # Running Trento
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Additionally, for the development we use:
 
 # Quick-Start installation
 
-We provide installations scripts for to automatically install and update the latest version of Trento.
-Please follow the installation in the given order/
+Installation scripts are provided to automatically install and update the latest version of Trento.
+Please follow the installation in the given order
 
 ## Trento Server installation
 

--- a/install-server.sh
+++ b/install-server.sh
@@ -12,7 +12,7 @@ usage() {
     Install Trento Server
 
     OPTIONS:
-       -p --private-key         the private key used by the runner to connect to the hosts
+       -p --private-key         pre-authorized private SSH key used by the runner to connect to the hosts
        -h --help                show this help
 
 
@@ -30,6 +30,7 @@ cmdline() {
             --private-key)  args="${args}-p ";;
             --help)         args="${args}-h ";;
             
+            # pass through anything else
             *) [[ "${arg:0:1}" == "-" ]] || delim="\""
             args="${args}${delim}${arg}${delim} ";;
         esac
@@ -37,7 +38,7 @@ cmdline() {
     
     eval set -- "$args"
     
-    while getopts "ph" OPTION
+    while getopts "p:h" OPTION
     do
         case $OPTION in
             h)
@@ -75,6 +76,7 @@ check_deps() {
 install_k3s() {
     echo "Installing K3s..."
     curl -sfL https://get.k3s.io | sh >/dev/null
+    mkdir -p ~/.kube
     sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
     sudo chown "$USER": ~/.kube/config
     unset KUBECONFIG
@@ -108,6 +110,7 @@ install_trento_server_chart() {
     pushd -- /tmp/trento-"${repo_branch}"/packaging/helm/trento-server >/dev/null 
     helm dep update >/dev/null
     helm upgrade --install trento-server . --set-file trento-runner.privateKey="${private_key}" --set trento-web.image.tag="${image_tag}" --set trento-runner.image.tag="${image_tag}"
+    rm -rf /tmp/trento-"${repo_branch}"
     popd >/dev/null
 }
 

--- a/install-server.sh
+++ b/install-server.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+set -e
+
+readonly ARGS=( "$@" )
+readonly PROGNAME="./install-server.sh"
+
+usage() {
+    cat <<- EOF
+    usage: $PROGNAME options
+
+    Install Trento Server
+
+    OPTIONS:
+       -p --private-key         the private key used by the runner to connect to the hosts
+       -h --help                show this help
+
+
+    Example:
+       $PROGNAME --private-key ./id_rsa_runner
+EOF
+}
+
+cmdline() {
+    local arg=
+    for arg
+    do
+        local delim=""
+        case "$arg" in
+            --private-key)  args="${args}-p ";;
+            --help)         args="${args}-h ";;
+            
+            *) [[ "${arg:0:1}" == "-" ]] || delim="\""
+            args="${args}${delim}${arg}${delim} ";;
+        esac
+    done
+    
+    eval set -- "$args"
+    
+    while getopts "ph" OPTION
+    do
+        case $OPTION in
+            h)
+                usage
+                exit 0
+            ;;
+            p)
+                readonly PRIVATE_KEY=$OPTARG
+            ;;
+            *)
+                usage
+                exit 0
+            ;;
+        esac
+    done
+
+    if [[ -z "$PRIVATE_KEY" ]]; then
+        read -rp "Please provide the path of the runner private key: " PRIVATE_KEY </dev/tty
+    fi
+
+    return 0
+}
+
+check_deps() {
+    if ! which curl >/dev/null 2>&1; then
+        echo "curl is required by this script, please install it and try again."
+        exit 1
+    fi
+    if ! which unzip >/dev/null 2>&1; then
+        echo "unzip is required by this script, please install it and try again."
+        exit 1
+    fi
+}
+
+install_k3s() {
+    echo "Installing K3s..."
+    curl -sfL https://get.k3s.io | sh >/dev/null
+    sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+    sudo chown "$USER": ~/.kube/config
+    unset KUBECONFIG
+}
+
+install_helm() {
+    echo "Installing Helm..."
+    curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash >/dev/null
+}
+
+update_helm_dependencies() {
+    echo "Updating Helm dependencies..."
+    helm repo add hashicorp https://helm.releases.hashicorp.com >/dev/null
+    helm repo update >/dev/null
+}
+
+
+install_trento_server_chart() {
+    local repo_owner=${TRENTO_REPO_OWNER:-"trento-project"}
+    local repo_branch=${TRENTO_REPO_BRANCH:-"main"}
+    local private_key=${PRIVATE_KEY:-"./id_rsa_runner"}
+    local image_tag=${IMAGE_TAG:-""}
+    
+    echo "Installing trento-server chart..."
+    pushd -- /tmp >/dev/null
+    curl -f -sS -O -L https://github.com/"${repo_owner}"/trento/archive/refs/heads/"${repo_branch}".zip>/dev/null
+    unzip -o "${repo_branch}".zip >/dev/null
+    rm "${repo_branch}".zip
+    popd >/dev/null
+    
+    pushd -- /tmp/trento-"${repo_branch}"/packaging/helm/trento-server >/dev/null 
+    helm dep update >/dev/null
+    helm upgrade --install trento-server . --set-file trento-runner.privateKey="${private_key}" --set trento-web.image.tag="${image_tag}" --set trento-runner.image.tag="${image_tag}"
+    popd >/dev/null
+}
+
+main() {
+    cmdline "${ARGS[@]}"
+    echo "Installing trento-server on k3s..."
+    install_k3s
+    install_helm
+    update_helm_dependencies
+    install_trento_server_chart
+}
+main

--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
       volumes:
       - name: sshconfig
         secret:
-          secretName: trento-runner-privatekey
+          secretName: {{ include "trento-runner.fullname" . }}-privatekey
           defaultMode: 0400
           items:
           - key: privatekey

--- a/packaging/helm/trento-server/charts/trento-runner/templates/privatekey.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/privatekey.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: trento-runner-privatekey
+  name: {{ include "trento-runner.fullname" . }}-privatekey
 data:
   privatekey: |- 
     {{ .Values.privateKey | b64enc  }}

--- a/packaging/helm/trento-server/templates/NOTES.txt
+++ b/packaging/helm/trento-server/templates/NOTES.txt
@@ -19,7 +19,7 @@ _---~            |     |  .   /+++++++\    . | .   |         ~---_
 {{- if  (index .Values "trento-web").ingress.enabled }}
 {{- range $host := (index .Values "trento-web").ingress.hosts }}
   {{- range .paths }}
-URL: http{{ if (index $.Values "trento-web").ingress.tls }}s{{ end }}://{{ $host.host }}
+URL: http{{ if (index $.Values "trento-web").ingress.tls }}s{{ end }}://{{ $host.host | default "localhost" }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- Fixes some minor stuff in the helm chart
- Adds a server installer that can be used in the CI as well by overriding IMAGE_TAG env var
- Updates README with server installer instruction + other improvements 