### PR TITLE
Add a default ansible configuration file usage

### DIFF
--- a/runner/ansible/ansible.cfg
+++ b/runner/ansible/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+forks = 100
+
+[ssh_connection]
+ssh_args = -o ControlMaster=auto -o ControlPersist=300s -o PreferredAuthentications=publickey
+control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+pipelining = True

--- a/runner/ansiblerunner.go
+++ b/runner/ansiblerunner.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	AnsibleConfigFileEnv   = "ANSIBLE_CONFIG"
 	AnsibleCallbackPlugins = "ANSIBLE_CALLBACK_PLUGINS"
 	AnsibleActionPlugins   = "ANSIBLE_ACTION_PLUGINS"
 	AraApiClient           = "ARA_API_CLIENT"
@@ -74,6 +75,10 @@ func (a *AnsibleRunner) SetInventory(inventory string) error {
 
 	a.Inventory = inventory
 	return nil
+}
+
+func (a *AnsibleRunner) SetConfigFile(confFile string) {
+	a.setEnv(AnsibleConfigFileEnv, confFile)
 }
 
 // ARA_API_CLIENT is always set to "http" to ensure the usage of the REST API

--- a/runner/ansiblerunner_test.go
+++ b/runner/ansiblerunner_test.go
@@ -111,10 +111,13 @@ func TestRunPlaybookComplex(t *testing.T) {
 		cmd,
 	)
 
+	runnerInst.SetConfigFile("/path/myconfig.conf")
+
 	err := runnerInst.RunPlaybook()
 
 	assert.Contains(t, cmd.Env, "env1=value1")
 	assert.Contains(t, cmd.Env, "env2=value2")
+	assert.Contains(t, cmd.Env, "ANSIBLE_CONFIG=/path/myconfig.conf")
 	assert.NoError(t, err)
 
 	mockCommand.AssertExpectations(t)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -19,8 +19,9 @@ import (
 var ansibleFS embed.FS
 
 const (
-	AnsibleMain = "ansible/check.yml"
-	AnsibleMeta = "ansible/meta.yml"
+	AnsibleMain       = "ansible/check.yml"
+	AnsibleMeta       = "ansible/meta.yml"
+	AnsibleConfigFile = "ansible/ansible.cfg"
 )
 
 type Runner struct {
@@ -163,6 +164,8 @@ func NewAnsibleMetaRunner(cfg *Config) (*AnsibleRunner, error) {
 		return ansibleRunner, err
 	}
 
+	configFile := path.Join(cfg.AnsibleFolder, AnsibleConfigFile)
+	ansibleRunner.SetConfigFile(configFile)
 	ansibleRunner.SetAraServer(cfg.AraServer)
 
 	return ansibleRunner, err
@@ -186,6 +189,8 @@ func NewAnsibleCheckRunner(cfg *Config) (*AnsibleRunner, error) {
 	}
 
 	ansibleRunner.Check = true
+	configFile := path.Join(cfg.AnsibleFolder, AnsibleConfigFile)
+	ansibleRunner.SetConfigFile(configFile)
 	ansibleRunner.SetAraServer(cfg.AraServer)
 
 	return ansibleRunner, nil

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -51,6 +51,7 @@ func TestNewAnsibleMetaRunner(t *testing.T) {
 	expectedMetaRunner := &AnsibleRunner{
 		Playbook: path.Join(TestAnsibleFolder, "ansible/meta.yml"),
 		Envs: map[string]string{
+			"ANSIBLE_CONFIG":           path.Join(TestAnsibleFolder, "ansible/ansible.cfg"),
 			"ANSIBLE_CALLBACK_PLUGINS": "callback",
 			"ANSIBLE_ACTION_PLUGINS":   "action",
 			"ARA_API_CLIENT":           "http",
@@ -90,6 +91,7 @@ func TestNewAnsibleCheckRunner(t *testing.T) {
 		Playbook:  path.Join(TestAnsibleFolder, "ansible/check.yml"),
 		Inventory: path.Join(TestAnsibleFolder, "ansible_hosts"),
 		Envs: map[string]string{
+			"ANSIBLE_CONFIG":           path.Join(TestAnsibleFolder, "ansible/ansible.cfg"),
 			"ANSIBLE_CALLBACK_PLUGINS": "callback",
 			"ANSIBLE_ACTION_PLUGINS":   "action",
 			"ARA_API_CLIENT":           "http",


### PR DESCRIPTION
In order to optimize the ansible execution, we can tune some parameters in the config file. Some info:
https://docs.ansible.com/ansible/2.3/intro_configuration.html

And a guide I followed (there are many, but all of them reference to these 3 elements):
https://gryzli.info/2019/02/21/tuning-ansible-for-maximum-performance/

In order to use a configuration file, the env variable `ANSIBLE_CONFIG` is used.

The applied changes are:
- `forks = 100` (default 5). How many ssh connections in parallel are allowed. I put a quite big number. We might have bigger deployments, but higher values might affect the ansible performance for the bad
- `ControlPersist=300s` (default 60s). The ssh connection "keep-alive" kind of option. 300s should be always higher than the execution time, so we should be fine.
- `pipelinening=true` (default false). Reduces the number of SSH operations required to execute a module on the remote server

@brett060102 Could you have a look too?