### PR TITLE
Fix: set the version in the Makefile explicitly

### DIFF
--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -60,7 +60,7 @@ local-npm-registry %{_sourcedir} install --with=dev
 %build
 
 mv node_modules web/frontend/
-make build
+VERSION=%{version} make build
 
 %install
 


### PR DESCRIPTION
The Makefile takes the version from the get_version_from_git.sh
but it might not work on the obs, so let's set it explicitly.

(It's not tested, the obs takes forever to publish).

#262 