### PR TITLE
Add warning and skipped states to the checks

### DIFF
--- a/runner/ansible/roles/checks/1.1.9.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.9.runtime/defaults/main.yml
@@ -13,3 +13,4 @@ remediation: |
   ## References
   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/checks/1.1.9/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.9/defaults/main.yml
@@ -13,3 +13,4 @@ remediation: |
   ## References
   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/checks/1.3.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.4/defaults/main.yml
@@ -13,3 +13,4 @@ remediation: |
   ## References
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/checks/1.4.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.4.1/defaults/main.yml
@@ -27,3 +27,4 @@ remediation: |
   ## References
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#1-create-the-stonith-devices
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/checks/1.5.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.5.1/defaults/main.yml
@@ -19,3 +19,4 @@ remediation: |
   ## References
   - Cluster installation in https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/checks/1.5.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.5.2/defaults/main.yml
@@ -17,3 +17,4 @@ remediation: |
   ## References
   - section 9.1.2 https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+on_failure: warning

--- a/runner/ansible/roles/post-results/tasks/main.yml
+++ b/runner/ansible/roles/post-results/tasks/main.yml
@@ -3,5 +3,5 @@
 # Do not change the name. It is use in the trento callback call
 - name: set_test_result
   set_fact:
-    test_result: "{{ status }}"
+    test_result: "{{ (status == true) | ternary('passing', on_failure | default('critical')) }}"
   delegate_to: localhost

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -457,9 +457,11 @@ func NewClustersHealthContainer(t ClustersTable) *HealthContainer {
 	h := &HealthContainer{}
 	for _, r := range t {
 		switch r.Health {
-		case services.CheckPassing:
+		case models.CheckPassing:
 			h.PassingCount += 1
-		case services.CheckCritical:
+		case models.CheckWarning:
+			h.WarningCount += 1
+		case models.CheckCritical:
 			h.CriticalCount += 1
 		}
 	}

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -32,14 +32,14 @@ type ChecksByHost struct {
 }
 
 type Check struct {
-	ID             string      `json:"id,omitempty" mapstructure:"id,omitempty"`
-	Name           string      `json:"name,omitempty" mapstructure:"name,omitempty"`
-	Group          string      `json:"group,omitempty" mapstructure:"group,omitempty"`
-	Description    string      `json:"description,omitempty" mapstructure:"description,omitempty"`
-	Remediation    string      `json:"remediation,omitempty" mapstructure:"remediation,omitempty"`
-	Implementation string      `json:"implementation,omitempty" mapstructure:"implementation,omitempty"`
-	Labels         string      `json:"labels,omitempty" mapstructure:"labels,omitempty"`
-	Selected       bool        `json:"selected,omitempty" mapstructure:"selected,omitempty"`
+	ID             string `json:"id,omitempty" mapstructure:"id,omitempty"`
+	Name           string `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Group          string `json:"group,omitempty" mapstructure:"group,omitempty"`
+	Description    string `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Remediation    string `json:"remediation,omitempty" mapstructure:"remediation,omitempty"`
+	Implementation string `json:"implementation,omitempty" mapstructure:"implementation,omitempty"`
+	Labels         string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
+	Selected       bool   `json:"selected,omitempty" mapstructure:"selected,omitempty"`
 	Result         string `json:"result,omitempty" mapstructure:"result,omitempty"`
 }
 

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -5,6 +5,14 @@ import (
 	"strings"
 )
 
+const (
+	CheckPassing   string = "passing"
+	CheckWarning   string = "warning"
+	CheckCritical  string = "critical"
+	CheckSkipped   string = "skipped"
+	CheckUndefined string = "undefined"
+)
+
 type CheckData struct {
 	Metadata Metadata            `json:"metadata,omitempty" mapstructure:"metadata,omitempty"`
 	Groups   map[string]*Results `json:"results,omitempty" mapstructure:"results,omitempty"`
@@ -24,15 +32,15 @@ type ChecksByHost struct {
 }
 
 type Check struct {
-	ID             string `json:"id,omitempty" mapstructure:"id,omitempty"`
-	Name           string `json:"name,omitempty" mapstructure:"name,omitempty"`
-	Group          string `json:"group,omitempty" mapstructure:"group,omitempty"`
-	Description    string `json:"description,omitempty" mapstructure:"description,omitempty"`
-	Remediation    string `json:"remediation,omitempty" mapstructure:"remediation,omitempty"`
-	Implementation string `json:"implementation,omitempty" mapstructure:"implementation,omitempty"`
-	Labels         string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
-	Selected       bool   `json:"selected,omitempty" mapstructure:"selected,omitempty"`
-	Result         bool   `json:"result,omitempty" mapstructure:"result,omitempty"`
+	ID             string      `json:"id,omitempty" mapstructure:"id,omitempty"`
+	Name           string      `json:"name,omitempty" mapstructure:"name,omitempty"`
+	Group          string      `json:"group,omitempty" mapstructure:"group,omitempty"`
+	Description    string      `json:"description,omitempty" mapstructure:"description,omitempty"`
+	Remediation    string      `json:"remediation,omitempty" mapstructure:"remediation,omitempty"`
+	Implementation string      `json:"implementation,omitempty" mapstructure:"implementation,omitempty"`
+	Labels         string      `json:"labels,omitempty" mapstructure:"labels,omitempty"`
+	Selected       bool        `json:"selected,omitempty" mapstructure:"selected,omitempty"`
+	Result         string `json:"result,omitempty" mapstructure:"result,omitempty"`
 }
 
 func (c *Results) GetHostNames() []string {

--- a/web/models/check_test.go
+++ b/web/models/check_test.go
@@ -12,20 +12,20 @@ func TestGetHostNames(t *testing.T) {
 			"1.1.1": &ChecksByHost{
 				Hosts: map[string]*Check{
 					"host1": &Check{
-						Result: true,
+						Result: "passing",
 					},
 					"host2": &Check{
-						Result: true,
+						Result: "critical",
 					},
 				},
 			},
 			"1.1.2": &ChecksByHost{
 				Hosts: map[string]*Check{
 					"host1": &Check{
-						Result: false,
+						Result: "warning",
 					},
 					"host2": &Check{
-						Result: false,
+						Result: "skipped",
 					},
 				},
 			},

--- a/web/services/checks.go
+++ b/web/services/checks.go
@@ -12,13 +12,6 @@ import (
 
 //go:generate mockery --name=ChecksService
 
-const (
-	CheckPassing   = "passing"
-	CheckWarning   = "warning"
-	CheckCritical  = "critical"
-	CheckUndefined = "undefined"
-)
-
 type AggregatedCheckData struct {
 	PassingCount  int
 	WarningCount  int
@@ -27,14 +20,14 @@ type AggregatedCheckData struct {
 
 func (a *AggregatedCheckData) String() string {
 	if a.CriticalCount > 0 {
-		return CheckCritical
+		return models.CheckCritical
 	} else if a.WarningCount > 0 {
-		return CheckWarning
+		return models.CheckWarning
 	} else if a.PassingCount > 0 {
-		return CheckPassing
+		return models.CheckPassing
 	}
 
-	return CheckUndefined
+	return models.CheckUndefined
 }
 
 type ChecksService interface {
@@ -146,9 +139,11 @@ func (c *checksService) GetAggregatedChecksResultByHost(clusterId string) (map[s
 			if _, ok := aCheckDataByHost[hostName]; !ok {
 				aCheckDataByHost[hostName] = &AggregatedCheckData{}
 			}
-			if !host.Result {
+			if host.Result == models.CheckCritical {
 				aCheckDataByHost[hostName].CriticalCount += 1
-			} else {
+			} else if host.Result == models.CheckWarning {
+				aCheckDataByHost[hostName].WarningCount += 1
+			} else if host.Result == models.CheckPassing {
 				aCheckDataByHost[hostName].PassingCount += 1
 			}
 		}

--- a/web/services/checks_test.go
+++ b/web/services/checks_test.go
@@ -56,20 +56,40 @@ func araResultRecord() *ara.Record {
 						"1.1.1": map[string]interface{}{
 							"hosts": map[string]interface{}{
 								"host1": map[string]interface{}{
-									"result": true,
+									"result": "passing",
 								},
 								"host2": map[string]interface{}{
-									"result": true,
+									"result": "passing",
 								},
 							},
 						},
 						"1.1.2": map[string]interface{}{
 							"hosts": map[string]interface{}{
 								"host1": map[string]interface{}{
-									"result": false,
+									"result": "warning",
 								},
 								"host2": map[string]interface{}{
-									"result": false,
+									"result": "critical",
+								},
+							},
+						},
+						"1.1.3": map[string]interface{}{
+							"hosts": map[string]interface{}{
+								"host1": map[string]interface{}{
+									"result": "passing",
+								},
+								"host2": map[string]interface{}{
+									"result": "warning",
+								},
+							},
+						},
+						"1.1.4": map[string]interface{}{
+							"hosts": map[string]interface{}{
+								"host1": map[string]interface{}{
+									"result": "skipped",
+								},
+								"host2": map[string]interface{}{
+									"result": "skipped",
 								},
 							},
 						},
@@ -420,20 +440,40 @@ func TestGetChecksResult(t *testing.T) {
 				"1.1.1": &models.ChecksByHost{
 					Hosts: map[string]*models.Check{
 						"host1": &models.Check{
-							Result: true,
+							Result: models.CheckPassing,
 						},
 						"host2": &models.Check{
-							Result: true,
+							Result: models.CheckPassing,
 						},
 					},
 				},
 				"1.1.2": &models.ChecksByHost{
 					Hosts: map[string]*models.Check{
 						"host1": &models.Check{
-							Result: false,
+							Result: models.CheckWarning,
 						},
 						"host2": &models.Check{
-							Result: false,
+							Result: models.CheckCritical,
+						},
+					},
+				},
+				"1.1.3": &models.ChecksByHost{
+					Hosts: map[string]*models.Check{
+						"host1": &models.Check{
+							Result: models.CheckPassing,
+						},
+						"host2": &models.Check{
+							Result: models.CheckWarning,
+						},
+					},
+				},
+				"1.1.4": &models.ChecksByHost{
+					Hosts: map[string]*models.Check{
+						"host1": &models.Check{
+							Result: models.CheckSkipped,
+						},
+						"host2": &models.Check{
+							Result: models.CheckSkipped,
 						},
 					},
 				},
@@ -570,20 +610,40 @@ func TestGetChecksResultByCluster(t *testing.T) {
 			"1.1.1": &models.ChecksByHost{
 				Hosts: map[string]*models.Check{
 					"host1": &models.Check{
-						Result: true,
+						Result: models.CheckPassing,
 					},
 					"host2": &models.Check{
-						Result: true,
+						Result: models.CheckPassing,
 					},
 				},
 			},
 			"1.1.2": &models.ChecksByHost{
 				Hosts: map[string]*models.Check{
 					"host1": &models.Check{
-						Result: false,
+						Result: models.CheckWarning,
 					},
 					"host2": &models.Check{
-						Result: false,
+						Result: models.CheckCritical,
+					},
+				},
+			},
+			"1.1.3": &models.ChecksByHost{
+				Hosts: map[string]*models.Check{
+					"host1": &models.Check{
+						Result: models.CheckPassing,
+					},
+					"host2": &models.Check{
+						Result: models.CheckWarning,
+					},
+				},
+			},
+			"1.1.4": &models.ChecksByHost{
+				Hosts: map[string]*models.Check{
+					"host1": &models.Check{
+						Result: models.CheckSkipped,
+					},
+					"host2": &models.Check{
+						Result: models.CheckSkipped,
 					},
 				},
 			},
@@ -637,13 +697,13 @@ func TestGetAggregatedChecksResultByHost(t *testing.T) {
 
 	expectedResults := map[string]*AggregatedCheckData{
 		"host1": &AggregatedCheckData{
-			PassingCount:  1,
-			WarningCount:  0,
-			CriticalCount: 1,
+			PassingCount:  2,
+			WarningCount:  1,
+			CriticalCount: 0,
 		},
 		"host2": &AggregatedCheckData{
 			PassingCount:  1,
-			WarningCount:  0,
+			WarningCount:  1,
 			CriticalCount: 1,
 		},
 	}
@@ -694,9 +754,9 @@ func TestGetAggregatedChecksResultByCluster(t *testing.T) {
 	c, err := checksService.GetAggregatedChecksResultByCluster("myClusterId")
 
 	expectedResults := &AggregatedCheckData{
-		PassingCount:  2,
-		WarningCount:  0,
-		CriticalCount: 2,
+		PassingCount:  3,
+		WarningCount:  2,
+		CriticalCount: 1,
 	}
 
 	assert.NoError(t, err)

--- a/web/templates/blocks/cluster_checks_result_modal.html.tmpl
+++ b/web/templates/blocks/cluster_checks_result_modal.html.tmpl
@@ -42,7 +42,7 @@
                                   {{- range $node := $nodes }}
                                   {{- $result := index $checkList.Hosts $node.Name }}
                                   {{- if $result }}
-                                  <td class="align-center">{{- if $result.Result }}<i class="eos-icons eos-18 text-success">check_circle</i>{{ else }}<i class="eos-icons eos-18 text-danger">error</i>{{ end }}</td>
+                                  <td class="align-center">{{ template "health_icon" $result.Result }}</td>
                                   {{- else }}
                                   <td class="align-center"><i class="eos-icons eos-18 text-muted">sync_problem</i></td>
                                   {{- end }}


### PR DESCRIPTION
Implement the warning and skipped check results.

- The skipped check result shows up when the check is not selected
- The warning comes from the metadata entry `on_failure: warning`, and it must be defined in the test itself. This follows the same implementation that we had in benchcommon. I have cherry picked the tests with the warning output from there.

Here a pic (the warning icon is obvious, the gray circle is the skipped option):
![image](https://user-images.githubusercontent.com/36370954/134523673-a1a1553c-ab73-4093-838d-c1fec342d6cd.png)
