### PR TITLE
Fix support for -e cluster_selected_checks= option

### DIFF
--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -33,4 +33,4 @@
       loop: "{{ checks.files }}"
       loop_control:
         loop_var: check_item # Do not change the name. It is use in the trento callback call
-      when: (check_item.path | basename) in cluster_selected_checks
+      when: (check_item.path | basename) in cluster_selected_checks_list

--- a/runner/ansible/roles/load_facts/tasks/main.yml
+++ b/runner/ansible/roles/load_facts/tasks/main.yml
@@ -9,9 +9,9 @@
   delegate_to: localhost
   run_once: yes
 
-- name: set default value to cluster_selected_checks
+- name: set default value to cluster_selected_checks_list
   set_fact:
-    cluster_selected_checks: "{{ cluster_selected_checks|default('')|split(',') }}"
+    cluster_selected_checks_list: "{{ cluster_selected_checks|default('')|split(',') }}"
 
 - debug:
     var: expected


### PR DESCRIPTION
When -e is used to set cluster_selected_check on the command line
it effectively prohibits resetting/updating cluster_selected_check
in the yml code. So the conversion of cluster_selected_check from
a text string to a list in load_facts/tasks/main.yml was only
effective for the task scope. After that cluster_selected_check was back
to a string again.

The fix is to not do the list conversion in place, but to place the result
in a new variable and use that in the when condition in main.yml.