### PR TITLE
Add a --rolling option to the install-agent script to use factory repos

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -37,6 +37,9 @@ ARGUMENT_LIST=(
     "server-ip"
 )
 
+TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}
+TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/repodata/repomd.xml.key"}
+
 opts=$(
     getopt \
         --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
@@ -59,14 +62,19 @@ while [[ $# -gt 0 ]]; do
         shift 2
         ;;
 
+    --rolling)
+        TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento:/factory/15.3/devel:sap:trento:factory.repo"}
+        TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento:/factory/15.3/repodata/repomd.xml.key"}
+
+        shift 1
+        ;;
+
     *)
         break
         ;;
     esac
 done
 
-TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/repodata/repomd.xml.key"}
-TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}
 
 CONSUL_VERSION=1.9.6
 CONSUL_PATH=/srv/consul

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -34,8 +34,8 @@ case "$1" in
 esac
 
 ARGUMENT_LIST=(
-    "agent-bind-ip"
-    "server-ip"
+    "agent-bind-ip:"
+    "server-ip:"
     "rolling"
 )
 
@@ -44,7 +44,7 @@ TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/d
 
 opts=$(
     getopt \
-        --longoptions "$(printf "%s:," "${ARGUMENT_LIST[@]}")" \
+        --longoptions "$(printf "%s," "${ARGUMENT_LIST[@]}")" \
         --name "$(basename "$0")" \
         --options "" \
         -- "$@"

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -21,6 +21,7 @@ Arguments:
   --agent-bind-ip   The private address to which the trento-agent should be bound for internal communications.
                     This is an IP address that should be reachable by the other hosts, including the trento server.
   --server-ip       The trento server ip.
+  --rolling         Use the factory/rolling-release version instead of the stable one.
   --help            Print this help.
 END
 }
@@ -35,6 +36,7 @@ esac
 ARGUMENT_LIST=(
     "agent-bind-ip"
     "server-ip"
+    "rolling"
 )
 
 TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}


### PR DESCRIPTION
In the past week the team spotted the need for the installers to set up the latest RPM package coming from the Factory repository, so we're adding this to the `install-agent.sh` script. We'll do that in a further PR for the `install-server.sh` script too.