### PR TITLE
Set the TRENTO_REPO variable properly inside install-agent.sh

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -39,9 +39,6 @@ ARGUMENT_LIST=(
     "rolling"
 )
 
-TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}
-TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/repodata/repomd.xml.key"}
-
 opts=$(
     getopt \
         --longoptions "$(printf "%s," "${ARGUMENT_LIST[@]}")" \
@@ -77,6 +74,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+TRENTO_REPO=${TRENTO_REPO:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/devel:sap:trento.repo"}
+TRENTO_REPO_KEY=${TRENTO_REPO_KEY:-"https://download.opensuse.org/repositories/devel:/sap:/trento/15.3/repodata/repomd.xml.key"}
 
 CONSUL_VERSION=1.9.6
 CONSUL_PATH=/srv/consul


### PR DESCRIPTION
Turns out I'm an idiot :sweat_smile: I moved the generic variables about `TRENTO_REPO` upwards because I wanted to have early defaults, but actually it was _too_ early, so even with the `--rolling` option set the variable wasn't set properly.

I noticed it only after a bit of deep testing, my bad.