### PR TITLE
Run ansilble-lint in the CI process

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -52,6 +52,21 @@ jobs:
         run: make fmt-check
       - name: frontend lint and coding style check
         run: make web-check
+      - name: ansible playbooks and roles lint check
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: |
+            runner/ansible/check.yml
+            runner/ansible/meta.yml
+            runner/ansible/roles/*
+            runner/ansible/roles/checks/*
+            runner/ansible/vars/*
+          override-deps: |
+            ansible==4.6.0
+            ansible-core==2.11.5
+            ansible-lint==5.1.3
+          args: "-x role-name,risky-shell-pipe,no-tabs"
+
   build:
     runs-on: ubuntu-20.04
     needs: test
@@ -279,7 +294,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
-      env:        
+      env:
         GITHUB_OAUTH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v2
@@ -291,7 +306,7 @@ jobs:
       run: |
         /scripts/init_osc_creds.sh
         mkdir -p $HOME/.config/osc
-        cp /root/.config/osc/oscrc $HOME/.config/osc    
+        cp /root/.config/osc/oscrc $HOME/.config/osc
     - name: prepare tranto.changes file
       run: |
         VERSION=$(hack/get_version_from_git.sh)
@@ -306,7 +321,7 @@ jobs:
     - name: commit changes into OBS
       run: cp $FOLDER/_service . && /scripts/upload.sh
 
-  submit-obs:  
+  submit-obs:
     needs: commit-obs
     runs-on: ubuntu-18.04
     if: github.event.release

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -53,19 +53,12 @@ jobs:
       - name: frontend lint and coding style check
         run: make web-check
       - name: ansible playbooks and roles lint check
-        uses: ansible/ansible-lint-action@master
-        with:
-          targets: |
-            runner/ansible/check.yml
-            runner/ansible/meta.yml
-            runner/ansible/roles/*
-            runner/ansible/roles/checks/*
-            runner/ansible/vars/*
-          override-deps: |
-            ansible==4.6.0
-            ansible-core==2.11.5
-            ansible-lint==5.1.3
-          args: "-x role-name,risky-shell-pipe,no-tabs"
+        run: |
+          pip install ansible==4.6.0 ansible-core==2.11.5 ansible-lint==5.1.3 ara==1.5.7
+          export ANSIBLE_ACTION_PLUGINS=$(python3 -m ara.setup.action_plugins)
+          ansible-lint -vv -x role-name,risky-shell-pipe,no-tabs -w yaml \
+            runner/ansible/* runner/ansible/roles/* \
+            runner/ansible/roles/checks/* runner/ansible/vars/*
 
   build:
     runs-on: ubuntu-20.04

--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -1,16 +1,16 @@
 - hosts: all
   gather_facts: false
-  ignore_errors: yes
-  become: yes
+  ignore_errors: true
+  become: true
 
   vars:
     ara_playbook_labels:
-      - test # Do not change the name. It is use in the trento callback call
+      - test  # Do not change the name. It is use in the trento callback call
 
   tasks:
     - name: require check mode
       fail:
-         msg: "Only supported for --check option"
+        msg: "Only supported for --check option"
       when:
         - not ansible_check_mode
 
@@ -20,10 +20,10 @@
 
     - name: Find checks
       find:
-        paths: "{{ playbook_dir}}/roles/checks"
+        paths: "{{ playbook_dir }}/roles/checks"
         file_type: directory
       register: checks
-      run_once: yes
+      run_once: true
       delegate_to: localhost
 
     # Do not change the name. It is use in the trento callback call
@@ -32,5 +32,5 @@
         name: "{{ check_item.path }}"
       loop: "{{ checks.files }}"
       loop_control:
-        loop_var: check_item # Do not change the name. It is use in the trento callback call
+        loop_var: check_item  # Do not change the name. It is use in the trento callback call
       when: (check_item.path | basename) in cluster_selected_checks_list

--- a/runner/ansible/meta.yml
+++ b/runner/ansible/meta.yml
@@ -1,5 +1,5 @@
 - hosts: localhost
-  gather_facts: False
+  gather_facts: false
 
   vars:
     ara_playbook_labels:
@@ -12,7 +12,7 @@
 
     - name: Find checks
       find:
-        paths: "{{ playbook_dir}}/roles/checks"
+        paths: "{{ playbook_dir }}/roles/checks"
         file_type: directory
       register: checks
 

--- a/runner/ansible/roles/checks/1.1.1.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.1.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "runtime.config.totem.token (u32) = " | sed "s/^.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.1']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.1/tasks/main.yml
@@ -11,7 +11,8 @@
     - ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.2.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.2.runtime/tasks/main.yml
@@ -1,13 +1,14 @@
 ---
 
 - name: "{{ id }}.check"
-  shell:  'corosync-cmapctl | grep "runtime.config.totem.consensus (u32) = " | sed "s/^.*= //"'
-  check_mode: no
+  shell: 'corosync-cmapctl | grep "runtime.config.totem.consensus (u32) = " | sed "s/^.*= //"'
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.2']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.2/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.3.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.3.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "runtime.config.totem.max_messages (u32) = " | sed "s/^.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.3']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.3/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.4.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.4.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "runtime.config.totem.join (u32) = " | sed "s/^.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.4']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.4/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.5.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.5.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "runtime.config.totem.token_retransmits_before_loss_const (u32) = " | sed "s/^.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.5']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.5/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.6.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.6.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "totem.transport (str) = " | sed "s/.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.6']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.6/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.7/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.8.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.8.runtime/defaults/main.yml
@@ -11,7 +11,8 @@ remediation: |
   The runtime value of the corosync `two_node` parameter is not set as recommended.
 
   ## Remediation
-  Adjust the corosync `two_node` parameter to `1` to make sure Pacemaker calculates the actions properly for a two-node cluster, and reload the Corosync service.
+  Adjust the corosync `two_node` parameter to `1` to make sure Pacemaker calculates the actions properly for a two-node cluster,
+  and reload the Corosync service.
 
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker

--- a/runner/ansible/roles/checks/1.1.8.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.8.runtime/tasks/main.yml
@@ -2,12 +2,13 @@
 
 - name: "{{ id }}.check"
   shell: 'corosync-cmapctl | grep "runtime.votequorum.two_node (u8) = " | sed "s/^.*= //"'
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected['1.1.8']
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.8/tasks/main.yml
@@ -10,7 +10,8 @@
   when: ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.9.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.9.runtime/tasks/main.yml
@@ -5,13 +5,14 @@
     INTERFACE_COUNT=$(corosync-cmapctl | grep totem.interface\\..*\.ttl | wc -l)
     [[ ${INTERFACE_COUNT} -ge "2" ]] && exit 0
     exit 1
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.1.9/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.9/tasks/main.yml
@@ -5,13 +5,14 @@
     INTERFACE_COUNT=$(cat /etc/corosync/corosync.conf | grep interface | wc -l)
     [[ $INTERFACE_COUNT -ge "2" ]] && exit 0
     exit 1
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.2.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.2.1/tasks/main.yml
@@ -1,13 +1,14 @@
 ---
 
 - name: "{{ id }}.check"
-  shell: 'crm_attribute -t crm_config -G -n stonith-enabled --quiet'
-  check_mode: no
+  command: 'crm_attribute -t crm_config -G -n stonith-enabled --quiet'
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected[id]
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.2.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.2.2/tasks/main.yml
@@ -8,13 +8,14 @@
    else
      exit $([[ "${timeout}" = "{{ expected[id + '.sbd'] }}" ]])
    fi
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.1/tasks/main.yml
@@ -10,7 +10,8 @@
     - ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.2/tasks/main.yml
@@ -10,7 +10,8 @@
     - ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.3/tasks/main.yml
@@ -3,13 +3,14 @@
 - name: "{{ id }}.check"
   systemd:
     name: sbd
-    enabled: yes
+    enabled: true
   register: config_updated
   when:
     - ansible_check_mode
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.4/tasks/main.yml
@@ -8,12 +8,13 @@
     # issue: https://github.com/ansible/ansible/issues/16968
     temp_ar=(${!sbdarray[@]});  device_count=`expr ${temp_ar[-1]} + 1`
     echo "$device_count"
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected[id]
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.5/tasks/main.yml
@@ -14,12 +14,13 @@
       fi
     done
     echo "${result_wdtimeout}"
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout != expected[id]
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.6/tasks/main.yml
@@ -15,11 +15,12 @@
     done
     echo $result_msgwait
   register: config_updated
-  check_mode: no
+  check_mode: false
   changed_when: config_updated.stdout != expected[id]
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.3.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.3.7/tasks/main.yml
@@ -20,12 +20,13 @@
     fi
     exit 1
   register: config_updated
-  check_mode: no
+  check_mode: false
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.4.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.4.1/tasks/main.yml
@@ -14,13 +14,14 @@
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='monitor']" | grep -oP 'interval="\K[^"]+') != "{{ expected[id + '.monitor_interval'] }}" ]] && exit 1
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='monitor']" | grep -oP 'timeout="\K[^"]+') != "{{ expected[id + '.monitor_timeout'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.4.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.4.2/tasks/main.yml
@@ -5,13 +5,14 @@
     cibadmin -Q --xpath "//primitive[@type='fence_azure_arm']/@type" > /dev/null 2>&1 || exit 0
     [[ $(crm_attribute -t crm_config -G -n concurrent-fencing --quiet) = "{{ expected[id] }}" ]] && exit 0
     exit 1
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
-  failed_when:  config_updated.rc > 1
+  failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   vars:
     status: "{{ config_updated is not changed }}"

--- a/runner/ansible/roles/checks/1.5.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.5.1/tasks/main.yml
@@ -6,13 +6,14 @@
       if ! cat /etc/hosts |grep -q $i; then exit 1; fi
     done
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/1.5.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.5.2/tasks/main.yml
@@ -8,13 +8,14 @@
     match=$(python3 -c 'import crypt; print(crypt.crypt("linux", "$6$'${salt}'"))')
     [[ ${match} == ${epassword} ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.1/tasks/main.yml
@@ -6,13 +6,14 @@
     [[ $(crm_attribute -t rsc_defaults -G -n resource-stickiness --quiet) != "{{ expected[id + '.resource_stickiness'] }}" ]] && exit 1
     [[ $(crm_attribute -t rsc_defaults -G -n migration-threshold --quiet) != "{{ expected[id + '.migration_threshold'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.2/tasks/main.yml
@@ -15,13 +15,14 @@
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='stop']" | grep -oP 'interval="\K[^"]+') != "{{ expected[id + '.stop_interval'] }}" ]] && exit 1
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='stop']" | grep -oP 'timeout="\K[^"]+') != "{{ expected[id + '.stop_timeout'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.3/tasks/main.yml
@@ -24,13 +24,14 @@
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='AUTOMATED_REGISTER']" | grep -oP 'value="\K[^"]+' | tr '[:upper:]' '[:lower:]') != "{{ expected[id + '.nvpair_AUTOMATED_REGISTER'] }}" ]] && exit 1
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='DUPLICATE_PRIMARY_TIMEOUT']" | grep -oP 'value="\K[^"]+') != "{{ expected[id + '.nvpair_DUPLICATE_PRIMARY_TIMEOUT'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.4/tasks/main.yml
@@ -11,13 +11,14 @@
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='monitor']" | grep -oP 'interval="\K[^"]+') != "{{ expected[id + '.monitor_interval'] }}" ]] && exit 1
     [[ $(cibadmin -Q --xpath "${XPATH} [@name='monitor']" | grep -oP 'timeout="\K[^"]+') != "{{ expected[id + '.monitor_timeout'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.5/tasks/main.yml
@@ -9,13 +9,14 @@
     # Check that following match expected, exit with error if any do not
     [[ $(cibadmin -Q --xpath "//primitive[@type='azure-lb']/meta_attributes/nvpair [@name='resource-stickiness']" | grep -oP 'value="\K[^"]+') != "{{ expected[id + '.nvpair_resource_stickiness'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.6/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.6/defaults/main.yml
@@ -9,13 +9,17 @@ description: |
 remediation: |
   ## Abstract
   A constraint enforcing the group of resources containing the vIP and azurel-lb resources to
-  stay always together with the SAP HANA resource is needed to guarantee that the SAP HANA database will still be accessible in case of failover.
+  stay always together with the SAP HANA resource is needed to guarantee that the SAP HANA database
+  will still be accessible in case of failover.
 
   ## Remediation
-  Make sure that the constraint score is set to 4000 to guarantee proper actions calculations related with the defaults set for resource-stickiness=1000.
-  An order constraint is also needed to guarantee that SAPHanaTopology resource starts before the SAPHana resource, avoiding miscalculations regarding the cluster status.
+  Make sure that the constraint score is set to 4000 to guarantee proper actions calculations
+  related with the defaults set for resource-stickiness=1000.
+  An order constraint is also needed to guarantee that SAPHanaTopology resource starts before the
+  SAPHana resource, avoiding miscalculations regarding the cluster status.
 
-  **IMPORTANT**: This check is based on the resource prefix names recommended on the documentation (e.g. "g_ip_*", "col_saphana_*", "ord_SAPHana_*", "cln_SAPHanaTopology_*).
+  **IMPORTANT**: This check is based on the resource prefix names recommended on the documentation
+  (e.g. "g_ip_*", "col_saphana_*", "ord_SAPHana_*", "cln_SAPHanaTopology_*).
   Please, check the naming convention in case the resource configuration is done correctly.
 
   ## References

--- a/runner/ansible/roles/checks/2.1.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.6/tasks/main.yml
@@ -20,13 +20,14 @@
     [[ $(cibadmin -Q --xpath "${XPATH}" | grep -oP ' first="\K[^"]+' | grep -o cln_SAPHanaTopology) != "{{ expected[id + '.rsc_order_first'] }}" ]] && exit 1
     [[ $(cibadmin -Q --xpath "${XPATH}" | grep -oP ' then="\K[^"]+' | grep -o msl_SAPHana) != "{{ expected[id + '.rsc_order_then'] }}" ]] && exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.7/tasks/main.yml
@@ -18,13 +18,14 @@
     share_path=$(cat /hana/shared/${sid}/global/hdb/custom/config/global.ini | grep "path =" | sed "s/.*= //")
     [[ -s "$share_path/SAPHanaSR.py" ]] || exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.1.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.1.8/tasks/main.yml
@@ -10,13 +10,14 @@
     grep -E "^Cmnd_Alias +SFAIL_SITEB += +/usr/sbin/crm_attribute" /etc/sudoers | grep -E "\-n +hana_[a-z][a-z0-9]{2}_site_srHook_.+" | grep -E "\-v +SFAIL" | grep -E "\-t +crm_config" | grep -E "\-s +SAPHanaSR" || exit 1
     grep -E "[a-z][a-z0-9]{2}adm +ALL=\(ALL\) +NOPASSWD:" /etc/sudoers | sed "s/.*: //" | grep SOK_SITEA | grep SFAIL_SITEA | grep SOK_SITEB | grep SFAIL_SITEB || exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.1/tasks/main.yml
@@ -5,13 +5,14 @@
     #
     readlink /etc/products.d/baseproduct | grep -i "{{ expected [id] }}" || exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.10/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.10/tasks/main.yml
@@ -6,13 +6,14 @@
     inst=$(crm configure show | grep -m1 InstanceNumber= | sed -e "s/.*InstanceNumber=\(..\).*/\1/")
     cat /usr/sap/${sid}/SYS/profile/${sid}_HDB${inst}_$(hostname) | grep "Autostart = 0" || exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.2/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.3.exclude/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.3.exclude/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the pacemaker version IS NOT
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" pacemaker || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '=')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.3/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the pacemaker version IS
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" pacemaker || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.4/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the corosync version IS
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" corosync || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.5.exclude/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.5.exclude/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the sbd version IS NOT
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" sbd || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '=')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.5/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the sbd version IS
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" sbd || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.6/tasks/main.yml
@@ -5,13 +5,14 @@
     # Check the SAPHanaSR version is at least
     # If not installed, exit with error
     rpm -q --qf "%{VERSION}\n" SAPHanaSR || exit 2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.7/tasks/main.yml
@@ -4,13 +4,14 @@
   shell: |
     #  Check python version
     python3 --version | cut -d" " -f2
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc !=0
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.8/tasks/main.yml
@@ -10,13 +10,14 @@
     else
       echo "$full_version"
     fi
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.stdout is version(expected[id], '<')
   failed_when: config_updated.rc > 0
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/checks/2.2.9/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.9/tasks/main.yml
@@ -5,13 +5,14 @@
     /usr/sap/hostctrl/exe/saphostctrl -function Ping || exit 1
     /usr/sap/hostctrl/exe/sapcontrol -nr 99 -function CheckHostAgent || exit 1
     exit 0
-  check_mode: no
+  check_mode: false
   register: config_updated
   changed_when: config_updated.rc != 0
   failed_when: config_updated.rc > 1
 
 - block:
-    - import_role:
+    - name: Post results
+      import_role:
         name: post-results
   when:
     - ansible_check_mode

--- a/runner/ansible/roles/load_facts/tasks/main.yml
+++ b/runner/ansible/roles/load_facts/tasks/main.yml
@@ -7,12 +7,13 @@
 - name: load environment variables
   include_vars: "{{ env | default('azure') }}_env.yml"
   delegate_to: localhost
-  run_once: yes
+  run_once: true
 
 - name: set default value to cluster_selected_checks_list
   set_fact:
     cluster_selected_checks_list: "{{ cluster_selected_checks|default('')|split(',') }}"
 
-- debug:
+- name: debug loaded vars
+  debug:
     var: expected
     verbosity: 1


### PR DESCRIPTION
Run `ansible-lint` during the CI `test` stage.
This will help to have a better code quality in the ansible code.
The PR includes the warmed issues (I have disabled some checks as they are quite picky and not useful in our case)

PD:
We cannot use the github CI plugin because it doesn't have the option to set ENV variables, so I had to run a plain run stage
https://github.com/marketplace/actions/ansible-lint