### PR TITLE
Update subscription Load test to use ElementsMatch

### DIFF
--- a/internal/subscription/subscription_kvstore_test.go
+++ b/internal/subscription/subscription_kvstore_test.go
@@ -120,5 +120,5 @@ func TestLoad(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expectedSubs, subs)
+	assert.ElementsMatch(t, expectedSubs, subs)
 }


### PR DESCRIPTION
The `TestLoad` in `subscription_kvstore_test.go` if failing in other CI executions.
I have not been able to reproduce it locally, but I hope this change fixes it in any case, as the error might be caused by the order of the elements

PD: Confirmed that it was an issue in the order to the list. So this fix will have good effect 100%