### PR TITLE
Runner - Create new check ids system

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -59,6 +59,10 @@ jobs:
           ansible-lint -vv -x role-name,risky-shell-pipe,no-tabs -w yaml \
             runner/ansible/* runner/ansible/roles/* \
             runner/ansible/roles/checks/* runner/ansible/vars/*
+      - name: trento checks sanity test
+        run:
+          pip install PyYAML
+          python3 runner/ansible/support/id_checker.py
 
   build:
     runs-on: ubuntu-20.04

--- a/runner/ansible/README.md
+++ b/runner/ansible/README.md
@@ -8,17 +8,35 @@ To be defined...
 
 ## Metadata files
 
-The metadata files provide information about the test themselves. They are used to get information
+The metadata files provide information about the check themselves. They are used to get information
 from the Trento Web GUI and render properly everything related with the Ansible tasks.
 
 In order to use them properly, some fields are required. An example is available at [defaults/main.yml](roles/checks/1.1.1/defaults/main.yml).
 
 These are the fields needed by Trento:
 
-- `id`: The test unique identifier.
-- `name`: A short name for the check. It is used as more user friendly identifier for the test
+- `external_id`: The check unique identifier. This value must not be changed during the lifetime of the check
+- `id`: The internal identifier. It is used to identify the checks internally (a more user-friendly nomenclature), to specify the expected values and to apply the ordering to the lists in the web side. This value can be changed to adapt to any new internal need.
+- `name`: A short name for the check. It is used as more user friendly identifier for the check
 - `group`: The group which the check belongs to. It is used to group the checks under different visual elements in Trento
 - `labels`: A list of labels (separated by command) which helps to group the checks by execution groups. The difference between this and the `group` field
 is that the labels are used for control purpose (select all the checks with this label e.g.), and the groups are used just for visual purposes
-- `description`: A longer description about the test purpose. It can be written using markdown.
+- `description`: A longer description about the check purpose. It can be written using markdown
 - `implementation`: Usually the task `main.yml` content
+
+## Creating a new external_id
+
+The `external_id` must be unique in the check collection. It must be 6 hexadecimal digits string.
+In order to create a new unique identifier, and to check if there are any duplicated entries, the
+`id_checker.py` script can be used.
+
+To use it:
+```
+# Check if the checks include all the required metadata values and if there is any duplicated external_id
+python3 support/id_checker.py
+```
+
+To add a new unique `external_id`:
+```
+python3 support/id_checker.py --generate
+```

--- a/runner/ansible/callback_plugins/trento.py
+++ b/runner/ansible/callback_plugins/trento.py
@@ -13,6 +13,7 @@ https://github.com/ansible-community/ara/blob/master/ara/plugins/action/ara_reco
 """
 
 import os
+import yaml
 
 from ansible.plugins.callback import CallbackBase
 from ara.clients.http import AraHttpClient
@@ -22,6 +23,7 @@ TRENTO_TEST_LABEL = "test"
 TRENTO_RECORD_KEY = "trento-results"
 TEST_RESULT_TASK_NAME = "set_test_result"
 TEST_INCLUDE_TASK_NAME = "run_checks"
+EXTERNAL_ID = "external_id"
 
 
 class Results(object):
@@ -33,10 +35,10 @@ class Results(object):
     "results": {
         "clusterId": {
             "checks": {
-                "1.1.1": {
+                "ABCDEF": {
                     "hosts": {
                         "host1": {
-                            "result": true
+                            "result": "passing"
                         }
                     }
                 }
@@ -122,7 +124,7 @@ class CallbackModule(CallbackBase):
 
         test_result = result._task_fields["args"]["test_result"]
         for group in task_vars["group_names"]:
-            self.results.add_result(group, task_vars["id"], host, test_result)
+            self.results.add_result(group, task_vars[EXTERNAL_ID], host, test_result)
 
     def v2_runner_on_failed(self, result):
         """
@@ -135,7 +137,7 @@ class CallbackModule(CallbackBase):
         task_vars = self._all_vars(host=result._host, task=result._task)
 
         for group in task_vars["group_names"]:
-            self.results.add_result(group, task_vars["id"], host, False)
+            self.results.add_result(group, task_vars[EXTERNAL_ID], host, False)
 
     def v2_playbook_on_stats(self, _stats):
         """
@@ -212,7 +214,11 @@ class CallbackModule(CallbackBase):
         for check_result in result._result["results"]:
             skipped = check_result.get("skipped", False)
             if skipped:
-                check_id = os.path.basename(check_result["check_item"]["path"])
+                with open(os.path.join(
+                    check_result["check_item"]["path"], "defaults/main.yml")) as file_ptr:
+
+                    data = yaml.load(file_ptr, Loader=yaml.Loader)
+                    check_id = data[EXTERNAL_ID]
 
                 for group in task_vars["group_names"]:
                     self.results.add_result(group, check_id, host, "skipped")

--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -33,4 +33,4 @@
       loop: "{{ checks.files }}"
       loop_control:
         loop_var: check_item  # Do not change the name. It is use in the trento callback call
-      when: (check_item.path | basename) in cluster_selected_checks_list
+      when: ((lookup("file", check_item.path+"/defaults/main.yml")|from_yaml).external_id)|default("") in cluster_selected_checks_list

--- a/runner/ansible/roles/checks/1.1.1.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.1.runtime/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 53D035

--- a/runner/ansible/roles/checks/1.1.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.1/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: token
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 156F64

--- a/runner/ansible/roles/checks/1.1.2.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.2.runtime/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: FB0E0D

--- a/runner/ansible/roles/checks/1.1.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.2/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: consensus
+
+# check external_id. This value must not be changed over the life of this check
+external_id: A1244C

--- a/runner/ansible/roles/checks/1.1.3.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.3.runtime/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 00081D

--- a/runner/ansible/roles/checks/1.1.3/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.3/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: max_messages
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 845CC9

--- a/runner/ansible/roles/checks/1.1.4.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.4.runtime/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 822E47

--- a/runner/ansible/roles/checks/1.1.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.4/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: join
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 24ABCB

--- a/runner/ansible/roles/checks/1.1.5.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.5.runtime/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 15F7A8

--- a/runner/ansible/roles/checks/1.1.5/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.5/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: token_retransmits_before_loss_const
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 21FCA6

--- a/runner/ansible/roles/checks/1.1.6.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.6.runtime/defaults/main.yml
@@ -45,3 +45,6 @@ remediation: |
   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 7E0221

--- a/runner/ansible/roles/checks/1.1.6/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.6/defaults/main.yml
@@ -48,3 +48,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: transport
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 33403D

--- a/runner/ansible/roles/checks/1.1.7/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.7/defaults/main.yml
@@ -16,3 +16,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: expected_votes
+
+# check external_id. This value must not be changed over the life of this check
+external_id: C620DC

--- a/runner/ansible/roles/checks/1.1.8.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.8.runtime/defaults/main.yml
@@ -17,3 +17,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: D78671

--- a/runner/ansible/roles/checks/1.1.8/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.8/defaults/main.yml
@@ -19,3 +19,6 @@ implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 
 # Test data
 key_name: two_node
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 6E9B82

--- a/runner/ansible/roles/checks/1.1.9.runtime/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.9.runtime/defaults/main.yml
@@ -14,3 +14,6 @@ remediation: |
   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 32CFC6

--- a/runner/ansible/roles/checks/1.1.9/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.9/defaults/main.yml
@@ -14,3 +14,6 @@ remediation: |
   - section 9.1.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-adapting-the-corosync-and-sbd-configuration
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: DA114A

--- a/runner/ansible/roles/checks/1.2.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.2.1/defaults/main.yml
@@ -18,3 +18,6 @@ remediation: |
   ## References
   - T.B.D.
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 205AF7

--- a/runner/ansible/roles/checks/1.2.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.2.2/defaults/main.yml
@@ -20,3 +20,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 373DB8

--- a/runner/ansible/roles/checks/1.3.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.1/defaults/main.yml
@@ -31,3 +31,6 @@ remediation: |
   ## References
   - T.B.D.
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 0B6DB2

--- a/runner/ansible/roles/checks/1.3.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.2/defaults/main.yml
@@ -31,3 +31,6 @@ remediation: |
   ## References
   - T.B.D.
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 49591F

--- a/runner/ansible/roles/checks/1.3.3/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.3/defaults/main.yml
@@ -19,3 +19,6 @@ remediation: |
   ## References
   - T.B.D.
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 816815

--- a/runner/ansible/roles/checks/1.3.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.4/defaults/main.yml
@@ -14,3 +14,6 @@ remediation: |
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 61451E

--- a/runner/ansible/roles/checks/1.3.5/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.5/defaults/main.yml
@@ -12,3 +12,6 @@ remediation: |
   ## References
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: B089BE

--- a/runner/ansible/roles/checks/1.3.6/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.6/defaults/main.yml
@@ -13,3 +13,6 @@ remediation: |
   ## References
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#set-up-sbd-device
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 68626E

--- a/runner/ansible/roles/checks/1.3.7/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.7/defaults/main.yml
@@ -13,3 +13,6 @@ remediation: |
   ## References
   - section 2 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: A2EF8C

--- a/runner/ansible/roles/checks/1.4.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.4.1/defaults/main.yml
@@ -28,3 +28,6 @@ remediation: |
   -  https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#1-create-the-stonith-devices
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: DE74B2

--- a/runner/ansible/roles/checks/1.4.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.4.2/defaults/main.yml
@@ -19,3 +19,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#1-create-the-stonith-devices
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 6E0DEC

--- a/runner/ansible/roles/checks/1.5.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.5.1/defaults/main.yml
@@ -20,3 +20,6 @@ remediation: |
   - Cluster installation in https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 438525

--- a/runner/ansible/roles/checks/1.5.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.5.2/defaults/main.yml
@@ -18,3 +18,6 @@ remediation: |
   - section 9.1.2 https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
 on_failure: warning
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 790926

--- a/runner/ansible/roles/checks/2.1.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.1/defaults/main.yml
@@ -20,3 +20,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: B3DA7E

--- a/runner/ansible/roles/checks/2.1.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.2/defaults/main.yml
@@ -22,3 +22,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 553B84

--- a/runner/ansible/roles/checks/2.1.3/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.3/defaults/main.yml
@@ -29,3 +29,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: AE0C5F

--- a/runner/ansible/roles/checks/2.1.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.4/defaults/main.yml
@@ -19,3 +19,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 9CFD28

--- a/runner/ansible/roles/checks/2.1.5/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.5/defaults/main.yml
@@ -18,3 +18,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 610C10

--- a/runner/ansible/roles/checks/2.1.6/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.6/defaults/main.yml
@@ -25,3 +25,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#create-sap-hana-cluster-resources
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 3D8598

--- a/runner/ansible/roles/checks/2.1.7/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.7/defaults/main.yml
@@ -13,3 +13,6 @@ remediation: |
   ## References
   - https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability#implement-the-python-system-replication-hook-saphanasr
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 2A4BEE

--- a/runner/ansible/roles/checks/2.1.8/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.1.8/defaults/main.yml
@@ -13,3 +13,6 @@ remediation: |
   ## References
   - Section 8.3 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-allowing-sidadm-to-access-the-cluster
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 8F6362

--- a/runner/ansible/roles/checks/2.2.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.1/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: CAEFF1

--- a/runner/ansible/roles/checks/2.2.10/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.10/defaults/main.yml
@@ -20,3 +20,6 @@ remediation: |
   ## References
   - Section 2 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.hana-sr.scenario
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: C35E72

--- a/runner/ansible/roles/checks/2.2.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.2/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: D028B9

--- a/runner/ansible/roles/checks/2.2.3.exclude/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.3.exclude/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 9FAAD0

--- a/runner/ansible/roles/checks/2.2.3/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.3/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 9FEFB0

--- a/runner/ansible/roles/checks/2.2.4/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.4/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: DC5429

--- a/runner/ansible/roles/checks/2.2.5.exclude/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.5.exclude/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: C3166E

--- a/runner/ansible/roles/checks/2.2.5/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.5/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 222A57

--- a/runner/ansible/roles/checks/2.2.6/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.6/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 31BDCB

--- a/runner/ansible/roles/checks/2.2.7/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.7/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: F50AF5

--- a/runner/ansible/roles/checks/2.2.8/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.8/defaults/main.yml
@@ -17,3 +17,6 @@ remediation: |
   ## References
   - Section 2 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.hana-sr.scenario
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: 2C2D43

--- a/runner/ansible/roles/checks/2.2.9/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.9/defaults/main.yml
@@ -16,3 +16,6 @@ remediation: |
   ## Reference
   - Section 6.1 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#id-installing-the-sap-hana-databases-on-both-cluster-nodes
 implementation: "{{ lookup('file', 'roles/checks/'+id+'/tasks/main.yml') }}"
+
+# check external_id. This value must not be changed over the life of this check
+external_id: ABA3CA

--- a/runner/ansible/roles/post-metadata/tasks/store.yml
+++ b/runner/ansible/roles/post-metadata/tasks/store.yml
@@ -8,8 +8,9 @@
         {
           'metadata': {
             'checks': {
-              id: {
+              external_id: {
                 'id': id,
+                'external_id': external_id|default("unknown"),
                 'name': name,
                 'group': group,
                 'description': description,

--- a/runner/ansible/roles/post-metadata/tasks/store.yml
+++ b/runner/ansible/roles/post-metadata/tasks/store.yml
@@ -4,21 +4,19 @@
 - name: Set metadata {{ id }}
   set_fact:
     metadata: |
-      {{ (metadata | default({})) | combine(
-        {
-          'metadata': {
-            'checks': {
-              external_id: {
-                'id': id,
-                'external_id': external_id|default("unknown"),
-                'name': name,
-                'group': group,
-                'description': description,
-                'remediation': remediation,
-                'labels': labels,
-                'implementation': implementation
-              }
-            }
+      {{ (metadata|default({})) | combine(
+        {'metadata':
+          {
+            'checks': [{
+              'id': id,
+              'external_id': (external_id|default('unknown'))|string,
+              'name': name,
+              'group': group,
+              'description': description,
+              'remediation': remediation,
+              'labels': labels,
+              'implementation': implementation
+            }]
           }
-        }, recursive=True)
+        }, recursive=True, list_merge='append')
       }}

--- a/runner/ansible/support/id_checker.py
+++ b/runner/ansible/support/id_checker.py
@@ -1,0 +1,151 @@
+"""
+The ID checker is a support script to check if all the trento checks have an unique ID and
+to set new IDs if they don't exist
+
+:author: xarbulu
+:organization: SUSE Linux GmbH
+:contact: xarbulu@suse.com
+
+:since: 2021-09-16
+"""
+
+import os
+import logging
+import random
+import argparse
+
+try:
+    import yaml
+except ModuleNotFoundError:
+    logging.getLogger(__name__).error(
+        "yaml package not found. To install it run `pip install PyYAML`")
+
+
+CHECKS_FOLDER = "../roles/checks"
+HEXDIGITS = "0123456789ABCDEF"
+ID_LENGTH = 6
+EXTERNAL_ID = "external_id"
+REQUIRED_FIELDS = ["id", "name", "group", "labels", "description", "remediation", "implementation"]
+
+
+def parse_args():
+    """
+    Parse arguments
+    """
+    parser = argparse.ArgumentParser(description="Trento Ansible checks ID checker")
+    parser.add_argument(
+        "--generate", dest="generate", action="store_true",
+        help="Generate a new ID on the checks that do not have it")
+
+    return parser.parse_args()
+
+
+def get_checks_folder():
+    """
+    Get the checks folder absolute path
+    """
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), CHECKS_FOLDER)
+
+def create_id():
+    """
+    Create ID with specified lenght based on HEX digits
+    """
+    generated_id = "".join([random.choice(HEXDIGITS) for _ in range(ID_LENGTH)])
+    return generated_id
+
+
+def id_sanity_check(check_id):
+    """
+    Check ID syntax sanity check
+    """
+    str_check_id = str(check_id)
+    if len(str_check_id) != ID_LENGTH:
+        return False
+
+    for char in str_check_id:
+        if char not in HEXDIGITS:
+            return False
+
+    return True
+
+def sanity_check(check_data, check_file, logger):
+    """
+    Check sanity
+    """
+    for field in REQUIRED_FIELDS:
+        if field not in check_data:
+            logger.error("field %s not found in check %s", field, check_file)
+            return False
+
+    if not id_sanity_check(check_data[EXTERNAL_ID]):
+        logger.error(
+            "%s id (%s) does not follow the ID correct syntax "\
+            "(%s chars length hex string)",
+            check_file, check_data[EXTERNAL_ID], ID_LENGTH)
+        return False
+
+    return True
+
+def append_id_to_check(check_file, new_id):
+    """
+    Add the new ID to the check file
+    """
+    with open(check_file, "a") as write_ptr:
+        write_ptr.write("\n")
+        write_ptr.write(
+            "# check {}. This value must not be changed over the life of this check\n".format(
+                EXTERNAL_ID))
+        write_ptr.write("{}: {}\n".format(EXTERNAL_ID, new_id))
+
+
+def main(generate, logger):
+    """
+    Main method
+    """
+    id_list = []
+    check_add_id = []
+    checks_folder = get_checks_folder()
+    for c_file in os.listdir(checks_folder):
+        if os.path.isdir(os.path.join(checks_folder, c_file)):
+            logger.info("check directory found: %s", c_file)
+            check_path = os.path.join(checks_folder, c_file, "defaults/main.yml")
+            try:
+                with open(check_path) as file_ptr:
+                    data = yaml.load(file_ptr, Loader=yaml.Loader)
+                    if EXTERNAL_ID not in data:
+                        logger.info("check %s doesn't have the external_id value", c_file)
+                        if generate:
+                            check_add_id.append(check_path)
+                            continue
+                        else:
+                            logger.error("to add a new ids, use the --generate flag on the script")
+                            return 1
+                    if not sanity_check(data, check_path, logger):
+                        return 1
+                    if data[EXTERNAL_ID] in id_list:
+                        logger.error("%s %s already exists!", EXTERNAL_ID, data[EXTERNAL_ID])
+                        return 1
+                    id_list.append(data[EXTERNAL_ID])
+            except FileNotFoundError:
+                logger.error("check %s doesn't have the defaults/main.yml file", c_file)
+                continue
+
+    if generate:
+        logger.info("generating new ids...")
+        for check_file in check_add_id:
+            new_id = create_id()
+            while new_id in id_list:
+                new_id = create_id()
+
+            id_list.append(new_id)
+            append_id_to_check(check_file, new_id)
+            logger.info("new id %s added to check %s", new_id, check_file)
+
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    logger = logging.getLogger(__name__)
+    args = parse_args()
+    exit(main(args.generate, logger))

--- a/web/checks_catalog.go
+++ b/web/checks_catalog.go
@@ -19,7 +19,7 @@ func NewChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 		}
 
 		c.HTML(http.StatusOK, "checks_catalog.html.tmpl", gin.H{
-			"Checks": checkList,
+			"ChecksCatalog": checkList.OrderById(),
 		})
 	}
 }

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -1,8 +1,7 @@
 package models
 
 import (
-	"fmt"
-	"strings"
+	"sort"
 )
 
 const (
@@ -18,8 +17,18 @@ type CheckData struct {
 	Groups   map[string]*Results `json:"results,omitempty" mapstructure:"results,omitempty"`
 }
 
+// List is used instead of a map as it guarantees order
+type CheckList []*Check
+
+type GroupedChecks struct {
+	Group  string
+	Checks CheckList
+}
+
+type GroupedCheckList []*GroupedChecks
+
 type Metadata struct {
-	Checks map[string]*Check `json:"checks,omitempty" mapstructure:"checks,omitempty"`
+	Checks CheckList `json:"checks,omitempty" mapstructure:"checks,omitempty"`
 }
 
 type Results struct {
@@ -33,6 +42,7 @@ type ChecksByHost struct {
 
 type Check struct {
 	ID             string `json:"id,omitempty" mapstructure:"id,omitempty"`
+	ExternalID     string `json:"external_id,omitempty" mapstructure:"external_id,omitempty"`
 	Name           string `json:"name,omitempty" mapstructure:"name,omitempty"`
 	Group          string `json:"group,omitempty" mapstructure:"group,omitempty"`
 	Description    string `json:"description,omitempty" mapstructure:"description,omitempty"`
@@ -65,11 +75,21 @@ func (c *Results) HostResultPresent(host string) bool {
 	return false
 }
 
-func (c *Check) NormalizeID() string {
-	return strings.Replace(c.ID, ".", "-", -1)
+// Sorting methods for GroupedCheckList
+
+func (g GroupedCheckList) Len() int {
+	return len(g)
 }
 
-func (c *Check) ExtendedGroupName() string {
-	item := strings.Split(c.ID, ".")
-	return fmt.Sprintf("%s.%s - %s", item[0], item[1], c.Group)
+func (g GroupedCheckList) Less(i, j int) bool {
+	return g[i].Checks[0].ID < g[j].Checks[0].ID
+}
+
+func (g GroupedCheckList) Swap(i, j int) {
+	g[i], g[j] = g[j], g[i]
+}
+
+func (g GroupedCheckList) OrderById() GroupedCheckList {
+	sort.Sort(g)
+	return g
 }

--- a/web/templates/blocks/cluster_checks_result_modal.html.tmpl
+++ b/web/templates/blocks/cluster_checks_result_modal.html.tmpl
@@ -20,7 +20,7 @@
                               <th scope="col">Description</th>
                               {{- if $checksResult }}
                               {{- range $node := $nodes }}
-                              <th scope="col">
+                              <th scope="col" class="text-center">
                                   {{- $result := $checksResult.HostResultPresent $node.Name }}
                                   {{- if not $result }}
                                   <i class="eos-icons eos-18 text-warning" data-toggle="tooltip" title="Node is unreacheable">warning</i>
@@ -32,22 +32,25 @@
                           </tr>
                           </thead>
                           <tbody>
-                          {{- $checksMetadata := .ChecksCatalog }}
                           {{- if $checksResult }}
-                          {{- range $checkID, $checkList := $checksResult.Checks }}
-                              {{- $checkMeta := index $checksMetadata $checkID }}
-                              <tr>
-                                  <td>{{ $checkID }}</td>
-                                  <td>{{ if $checkMeta }}{{ $checkMeta.Description }}{{ else }}Test metadata not found{{ end }}</td>
-                                  {{- range $node := $nodes }}
-                                  {{- $result := index $checkList.Hosts $node.Name }}
-                                  {{- if $result }}
-                                  <td class="align-center">{{ template "health_icon" $result.Result }}</td>
-                                  {{- else }}
-                                  <td class="align-center"><i class="eos-icons eos-18 text-muted">sync_problem</i></td>
+                          {{- range .ChecksCatalog }}
+                              {{- range $checkMeta := .Checks }}
+                                  {{- $checkResultData := index $checksResult.Checks $checkMeta.ExternalID }}
+                                  {{- if $checkResultData }}
+                                  <tr>
+                                      <td>{{ $checkMeta.ExternalID }}</td>
+                                      <td>{{ $checkMeta.Description }}</td>
+                                      {{- range $node := $nodes }}
+                                      {{- $result := index $checkResultData.Hosts $node.Name }}
+                                      {{- if $result }}
+                                      <td class="align-center">{{ template "health_icon" $result.Result }}</td>
+                                      {{- else }}
+                                      <td class="align-center"><i class="eos-icons eos-18 text-muted">sync_problem</i></td>
+                                      {{- end }}
+                                      {{- end }}
+                                  </tr>
                                   {{- end }}
-                                  {{- end }}
-                              </tr>
+                              {{- end }}
                           {{- else }}
                               {{ template "empty_table_body" (sum 2 (len $nodes )) }}
                           {{- end }}

--- a/web/templates/blocks/cluster_modal.html.tmpl
+++ b/web/templates/blocks/cluster_modal.html.tmpl
@@ -60,12 +60,12 @@
                   <div id="checksAccordion">
                       <h6>Checks selection</h6>
                       {{- $groupNumber := 0 }}
-                      {{- range $group, $data := .ChecksCatalogModal }}
+                      {{- range .ChecksCatalog }}
                       <div class="card">
                           <div class="card-header card-header-check-selection" id="check-{{ $groupNumber }}">
                               <div class='form-check float-left'>
-                                  <input class='parent form-check-input eos-checkbox' type='checkbox' id='{{ $groupNumber }}' {{ $found := .Selected }}{{- range $index, $check := $data }}{{ if and .Selected (not $found) }}checked="checked"{{ $found := true }}{{ end }}{{ end }}>
-                                  <label class='form-check-label' for='{{ $groupNumber }}'>{{ $group }}</label>
+                                  <input class='parent form-check-input eos-checkbox' type='checkbox' id='{{ $groupNumber }}' {{ $found := false }}{{- range $index, $check := .Checks }}{{ if and $check.Selected (not $found) }}checked="checked"{{ $found := true }}{{ end }}{{ end }}>
+                                  <label class='form-check-label' for='{{ $groupNumber }}'>{{ .Group }}</label>
                               </div>
                               <div class='dropdown float-right'>
                                   <div class='dropdown-toggle' data-toggle="collapse" data-target="#collapse-{{ $groupNumber }}" aria-expanded="true" aria-controls="collapse-{{ $groupNumber }}">
@@ -86,15 +86,15 @@
                                               </tr>
                                           </thead>
                                           <tbody>
-                                              {{- range $index, $check := $data }}
+                                              {{- range .Checks }}
                                               <tr>
                                                   <td class="row-status">
                                                       <div class='form-check'>
-                                                         <input class='parent-{{ $groupNumber }} form-check-input eos-checkbox' type='checkbox' name="check_ids[]" value="{{ .ID }}" id='{{ $groupNumber }}-{{ .NormalizeID }}' {{ if .Selected }}checked="checked"{{ end }}>
-                                                         <label class='form-check-label' for='{{ $groupNumber }}-{{ .NormalizeID }}'>{{ .ID }}</label>
+                                                         <input class='parent-{{ $groupNumber }} form-check-input eos-checkbox' type='checkbox' name="check_ids[]" value="{{ .ExternalID }}" id='{{ $groupNumber }}-{{ .ExternalID }}' {{ if .Selected }}checked="checked"{{ end }}>
+                                                         <label class='form-check-label' for='{{ $groupNumber }}-{{ .ExternalID }}'>{{ .ExternalID }}</label>
                                                      </div>
                                                   </td>
-                                                  <td>{{ .ID }}</td>
+                                                  <td>{{ .ExternalID }}</td>
                                                   <td>{{ .Description}}</td>
                                               </tr>
                                               {{- else }}

--- a/web/templates/checks_catalog.html.tmpl
+++ b/web/templates/checks_catalog.html.tmpl
@@ -13,12 +13,12 @@
     <hr class="margin-10px"/>
     <div id="checksAccordion">
         {{- $groupIndex := 0 }}
-        {{- range $group, $checkList := .Checks }}
+        {{- range .ChecksCatalog }}
         {{- $groupIndex = sum $groupIndex 1 }}
         <div class="card">
             <div class="card-header" id="heading-{{ $groupIndex }}">
                 <h4 class="float-left">
-                    {{ $group }}
+                    {{ .Group }}
                 </h4>
                 <i class="eos-icons eos-18 collapse-toggle clickable collapsed" data-toggle="collapse" data-target="#collapse-{{ $groupIndex }}"></i>
             </div>
@@ -34,15 +34,15 @@
                             </tr>
                             </thead>
                             <tbody>
-                            {{- range $checkList }}
+                            {{- range .Checks }}
                                 <tr>
-                                    <td class="align-top">{{ .ID }}</td>
+                                    <td class="align-top">{{ .ExternalID }}</td>
                                     <td class="align-top">
                                         {{ .Description }}
-                                        <div class="ha-check-remediation collapse" id="info-{{ .NormalizeID }}">
+                                        <div class="ha-check-remediation collapse" id="info-{{ .ExternalID }}">
                                             {{ markdown (.Remediation) }}
                                         </div>
-                                        <div class="ha-check-remediation collapse" id="info-{{ .NormalizeID }}">
+                                        <div class="ha-check-remediation collapse" id="info-{{ .ExternalID }}">
                                             <h2>Implementation</h2>
                                             <pre>{{ .Implementation }}</pre>
                                         </div>
@@ -51,9 +51,9 @@
                                     <td class="align-top text-center">
                                         <a class="link-dark" type="button"
                                            data-toggle="collapse"
-                                           href="#info-{{ .NormalizeID }}"
+                                           href="#info-{{ .ExternalID }}"
                                            aria-expanded="false"
-                                           aria-controls="info-{{ .NormalizeID }}"
+                                           aria-controls="info-{{ .ExternalID }}"
                                            title="Details">
                                             <i class='eos-icons eos-18'>info</i>
                                         </a>


### PR DESCRIPTION
**Don't merge, UT are missing**

Create a new Trento checks identifier system to have always unique-lifetime check identifier.

In order to facilitate the check identification, without any direct impact in the technical details, this PR introduces a new `external_id` fields to checks metadata. This ID is always unique within the checks catalog, and must not be changed during the lifetime of the check.

More details:
- The old identifier is kept to provide an easier way to continue working with the checks. If the external id would've replaced the id in the code structure, it would be super complex to find and change the checks. It would be source of errors. So, to make the development easier (we can mentally identify better the code with numerical order), we will still continue having the current numbering in the code. In any, case this numbers don't affect at all in the user interface. They won't even be displayed.
- The old identifier is still used to provide the ordering of the checks in the user-interface
- We can freely change the internal id at any point, if we find any better solution
- The checks metadata type is moved from dictionary to list. Dictionary are pretty bad option to manage order in golang. Using lists makes life easier, and I don't see any disadvantage.

Besides this, there is not mayor impact in the user side, except we show the `external_id`.