### PR TITLE
Rename sidebar entries to Pacemaker Clusters and SAP Systems

### DIFF
--- a/docs/scope.md
+++ b/docs/scope.md
@@ -8,8 +8,8 @@
       - [HA Checker: Scenario SAP HANA Performance Optimized on Azure](#ha-checker-scenario-sap-hana-performance-optimized-on-azure)
       - [HA Checker: Scenario Pacemaker on Azure](#ha-checker-scenario-pacemaker-on-azure)
       - [More coming](#more-coming)
-  - [Clusters](#clusters)
-  - [Systems](#systems)
+  - [Pacemaker Clusters](#pacemaker-clusters)
+  - [SAP Systems](#sap-systems)
   - [Agents](#agents)
 
 # About this document
@@ -67,14 +67,14 @@ cluster.
 #### More coming
 Additional checkers are being implemented for other cloud providers.
 
-## Clusters
-This view currently allows to check the status of the all the discovered clusters,
+## Pacemaker Clusters
+This view currently allows to check the status of the all the discovered pacemaker clusters,
 including the information of the status of each node and the role associated to
 each node. This view also allows to see the resources, their type and distribution
 within the cluster nodes.
 
-## Systems
-In this view are listed the systems, usually identified by a SID or
+## SAP Systems
+In this view are listed the SAP Systems, usually identified by a SID or
 `SAP System Idenfication` string such as `PRD`, `DEV`, or `QAS`. These are used
 often to identify productive, development and quality assurance systems.
 In this view we get an overview of the distribution of each SID, the number of

--- a/web/templates/blocks/sidebar.html.tmpl
+++ b/web/templates/blocks/sidebar.html.tmpl
@@ -33,20 +33,20 @@
                     </li>
                     <li class="menu-item">
                         <div class="menu-element">
-                            <span class="main-collapsed-title">Clusters</span>
+                            <span class="main-collapsed-title">Pacemaker Clusters</span>
                         </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/clusters">
                             <i class='eos-icons'>collocation</i>
-                            <span class="menu-title-content">Clusters</span>
+                            <span class="menu-title-content">Pacemaker Clusters</span>
                         </a>
                     </li>
                     <li class="menu-item">
                         <div class="menu-element">
-                            <span class="main-collapsed-title">Systems</span>
+                            <span class="main-collapsed-title">SAP Systems</span>
                         </div>
                         <a class="menu-title js-select-current-parent js-feature-flag" href="/sapsystems">
                             <i class='eos-icons'>system_group</i>
-                            <span class="menu-title-content">Systems</span>
+                            <span class="menu-title-content">SAP Systems</span>
                         </a>
                     </li>
                     <li class="menu-item menu-dropdown">

--- a/web/templates/cluster_generic.html.tmpl
+++ b/web/templates/cluster_generic.html.tmpl
@@ -1,7 +1,7 @@
 {{ define "content" }}
     <div class="col">
-        <h6><a href="/clusters">Clusters</a> > {{ .Cluster.Name }}</h6>
-        <h1>Cluster details</h1>
+        <h6><a href="/clusters">Pacemaker Clusters</a> > {{ .Cluster.Name }}</h6>
+        <h1>Pacemaker Cluster details</h1>
         <dl class="inline">
             <dt class="inline">Hosts number</dt>
             <dd class="inline">{{ .Cluster.Crmmon.Summary.Nodes.Number }}</dd>

--- a/web/templates/cluster_hana.html.tmpl
+++ b/web/templates/cluster_hana.html.tmpl
@@ -2,11 +2,11 @@
 <script src="/static/frontend/assets/js/check_selection.js"></script>{{ end }}
 {{ define "content" }}
     {{ template "alerts" .Alerts }}
-    <h1>Cluster details <i class="eos-icons eos-24 cluster-settings" data-toggle="modal" data-target="#clusterModal">settings</i></h1>
+    <h1>Pacemaker Cluster details <i class="eos-icons eos-24 cluster-settings" data-toggle="modal" data-target="#clusterModal">settings</i></h1>
     <div class="row">
         <div class="col">
             <h6>
-                <a href="/clusters">Clusters</a> > {{ .Cluster.Name }}
+                <a href="/clusters">Pacemaker Clusters</a> > {{ .Cluster.Name }}
             </h6>
         </div>
         <div class="col text-right">

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -5,7 +5,7 @@
 {{ define "content" }}
     <div class="row">
         <div class="col">
-            <h1>Clusters</h1>
+            <h1>Pacemaker Clusters</h1>
         </div>
         <div class="col text-right">
             <i class="eos-icons eos-dark eos-18 ">schedule</i> Updated at:

--- a/web/templates/home.html.tmpl
+++ b/web/templates/home.html.tmpl
@@ -29,14 +29,14 @@
                 </div>
             </div>
             <div class='card'>
-                <h5 class='card-header'>Clusters</h5>
+                <h5 class='card-header'>Pacemaker Clusters</h5>
                 <div class='card-body'>
                     <p class='card-text'>
-                        This view currently allows to check the status of the all the discovered clusters,
-                        including the information of the status of each node and the role associated to
-                        each node. This view also allows to see the node's attributes which reflect details
-                        found from their configuration as well as resources, their type and distribution
-                        within the cluster nodes.
+                        This view currently allows to check the status of the all the discovered
+                        Pacemaker clusters, including the information of the status of each node and
+                        the role associated to each node. This view also allows to see the node's
+                        attributes which reflect detailsfound from their configuration as well as
+                        resources, their type and distributionwithin the cluster nodes.
                     </p>
                     <div class='d-flex justify-content-end'>
                         <a class='card-link' href='/clusters'>Go to view</a>
@@ -46,10 +46,10 @@
         </div>
         <div class='card-deck mt-4'>
             <div class='card'>
-                <h5 class='card-header'>Systems</h5>
+                <h5 class='card-header'>SAP Systems</h5>
                 <div class='card-body'>
                     <p class='card-text'>
-                        In this view are listed the systems, usually identified by a SID or
+                        In this view are listed the SAP Systems, usually identified by a SID or
                         `SAP System Idenfication` string such as `PRD`, `DEV`, or `QAS`. These are used
                         often to identify productive, development and quality assurance systems.
                         In this view we get an overview of the distribution of each SID, the number of


### PR DESCRIPTION
Rename sidebar entries:
- `Clusters` -> `Pacemaker Clusters`
- `Systems` -> `SAP Systems`

Besides the sidebar, I have renamed the Cluster pages to add the `Pacemaker` prefix (the SAP systems already had the SAP prefix).

**Question:** Should be rename the hosts page table columns name too? `Clusters` to `P. Clusters` and `Systems` to `SAP Systems` maybe

![image](https://user-images.githubusercontent.com/36370954/135422564-6c5d6190-8376-466e-976d-bc24a9decd07.png)
![image](https://user-images.githubusercontent.com/36370954/135422601-7d089eed-0e61-4eee-9c33-720b8b757880.png)
![image](https://user-images.githubusercontent.com/36370954/135422650-e407afa7-5f08-4896-b916-194d995d80f5.png)
![image](https://user-images.githubusercontent.com/36370954/135425322-8dba2c1d-1c48-4f92-a235-5d7747e47b3e.png)

