### PR TITLE
CD: halt deploy until images / packages are ready

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -132,7 +132,7 @@ jobs:
 
   install-server:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: test
+    needs: build-and-push-image
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     env:
@@ -153,7 +153,7 @@ jobs:
 
   deploy-agents:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: install-server
+    needs: [ install-server, submit-pre-release ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     env:      


### PR DESCRIPTION
This PR does a small fix in the ordering of the jobs so that the deployment to the demo environment is done only when the required packages have been successfully built.