### PR TITLE
CD: Use correct name for pre-release job

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -153,7 +153,7 @@ jobs:
 
   deploy-agents:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ install-server, submit-pre-release ]
+    needs: [ install-server, release-rolling ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     env:      


### PR DESCRIPTION
Turns out name is not an alias and the dependency between jobs need to be the outer name. This fixes it.