### PR TITLE
Fix the liveness probe in the ARA chart due to sporadic sigterms

### DIFF
--- a/packaging/helm/trento-server/charts/ara/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/ara/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthcheck/
               port: ara-http
           readinessProbe:
             httpGet:


### PR DESCRIPTION
This PR ~removes~ fixes the liveness probe for ARA that is causing sporadic failures in our azure demo environment.