### PR TITLE
Fix test on subscription code, replacing Equal by ElementsMatch

### DIFF
--- a/internal/subscription/subscription_test.go
+++ b/internal/subscription/subscription_test.go
@@ -53,7 +53,7 @@ func TestNewSubscriptions(t *testing.T) {
 	}
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedSubs, subs)
+	assert.ElementsMatch(t, expectedSubs, subs)
 }
 
 func TestNewSubscriptionsErr(t *testing.T) {

--- a/web/services/subscriptions_test.go
+++ b/web/services/subscriptions_test.go
@@ -135,5 +135,5 @@ func TestGetHostSubscriptions(t *testing.T) {
 	}
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedSubs, subs)
+	assert.ElementsMatch(t, expectedSubs, subs)
 }


### PR DESCRIPTION
Fix for: https://github.com/trento-project/trento/runs/3756314103?check_suite_focus=true