### PR TITLE
Fix trento-server chart name

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: Trento server chart
+name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes


### PR DESCRIPTION
The chart name could be referenced by other charts and the name includes spaces, capital letters, etc..
Changed to an idiomatic name.