### PR TITLE
Fetch tags before building container images

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -69,10 +69,11 @@ jobs:
     needs: test
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - uses: actions/setup-node@v2
         with:
           node-version: "15"
@@ -90,8 +91,6 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      - name: get git tags
-        run: git fetch --prune --unshallow --tags
       - name: build
         run: make -j4 cross-compiled
       - name: compress
@@ -203,6 +202,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Log in to the Container registry


### PR DESCRIPTION
We need to fetch the tags before building images so that the script can get the right version.

Fixes: #301 