### PR TITLE
Avoid using "rolling" as version and use the previous version instead

### DIFF
--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 TAG=$(git describe --tags --abbrev=0 2>/dev/null)
+if [[ "$TAG" == "rolling" ]]; then
+  TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null)
+fi
 
 if [ -n "${TAG}" ]; then
   COMMITS_SINCE_TAG=$(git rev-list "${TAG}".. --count)


### PR DESCRIPTION
This PR addresses the problem mentioned in #293 that causes the spec file to be versioned with the 1.38.1 version. 

It adds a condition to the `get_version_from_git.sh` script to avoid appending `rolling` as prefix to the version when the last git tag is `rolling`. It tries to pick up the previous tagged version instead.