### PR TITLE
Trigger `obs-commit` job also for releases

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -231,7 +231,7 @@ jobs:
   obs-commit:
     needs: test
     runs-on: ubuntu-18.04
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:


### PR DESCRIPTION
I just noticed that the latest release didn't generate a new RPM. This commit should fix that by allowing the execution of the `obs-commit` job on a release event