### PR TITLE
Get correct version to OBS using git release tags

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -251,7 +251,7 @@ jobs:
         /scripts/init_osc_creds.sh
         mkdir -p $HOME/.config/osc
         cp /root/.config/osc/oscrc $HOME/.config/osc
-    - name: prepare tranto.changes file
+    - name: Prepare trento.changes file
       run: |
         VERSION=$(./hack/get_version_from_git.sh)
         TAG=$(echo $VERSION | cut -f1 -d+)
@@ -271,7 +271,7 @@ jobs:
     if: github.event.release
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
-    steps:
+    steps: 
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/hack/get_version_from_git.sh
+++ b/hack/get_version_from_git.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-TAG=$(git describe --tags --abbrev=0 2>/dev/null)
-if [[ "$TAG" == "rolling" ]]; then
-  TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null)
-fi
+TAG=$( git tag | grep -E "[0-9]\.[0-9]\.[0-9]" | sort -rn | head -n1 )
 
 if [ -n "${TAG}" ]; then
   COMMITS_SINCE_TAG=$(git rev-list "${TAG}".. --count)


### PR DESCRIPTION
This PR should fix the issues with the automated RPM generation on OBS by making sure the `rolling` tag doesn't get picked up.

We could probably use a similar approach to get rid of the `get_version_from_git.sh` script