### PR TITLE
Remove duplicated tags in getTags function

### DIFF
--- a/web/services/tags.go
+++ b/web/services/tags.go
@@ -63,7 +63,7 @@ func (r *tagsService) Delete(value string, resourceType string, resourceId strin
 
 func getTags(db *gorm.DB) ([]string, error) {
 	var tags []models.Tag
-	result := db.Find(&tags)
+	result := db.Distinct("value").Find(&tags)
 
 	if result.Error != nil {
 		return nil, result.Error

--- a/web/services/tags_test.go
+++ b/web/services/tags_test.go
@@ -91,8 +91,13 @@ func TestTagsService_Delete(t *testing.T) {
 	var tags []models.Tag
 	tx.Find(&tags)
 
-	assert.Equal(t, 2, len(tags))
+	assert.Equal(t, 3, len(tags))
 	assert.ElementsMatch(t, []models.Tag{
+		{
+			ResourceType: models.TagSAPSystemResourceType,
+			ResourceId:   "HA2",
+			Value:        "tag1",
+		},
 		{
 			ResourceType: models.TagClusterResourceType,
 			ResourceId:   "cluster_id",
@@ -109,6 +114,11 @@ func loadTagsFixtures(db *gorm.DB) {
 	db.Create(&models.Tag{
 		ResourceType: models.TagSAPSystemResourceType,
 		ResourceId:   "HA1",
+		Value:        "tag1",
+	})
+	db.Create(&models.Tag{
+		ResourceType: models.TagSAPSystemResourceType,
+		ResourceId:   "HA2",
 		Value:        "tag1",
 	})
 	db.Create(&models.Tag{


### PR DESCRIPTION
Fix duplicated tags in autocomplete: https://github.com/trento-project/trento/issues/317
![duplicated_tags](https://user-images.githubusercontent.com/36370954/136364917-40c9599c-414d-4885-864e-70aa80ca78b0.gif)


