### PR TITLE
Fix check 2.2.8 updating the sudo calls to not block the runner in k3s

### DIFF
--- a/runner/ansible/roles/checks/2.2.8/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.8/tasks/main.yml
@@ -3,8 +3,8 @@
 - name: "{{ name }}.check"
   shell: |
     #  HANA and SPS versions are compatible
-    sid=$(sudo crm configure show | grep -m1 SID= | sed -e "s/.*SID=\(...\).*/\1/" | tr '[:upper:]' '[:lower:]')
-    full_version=$(sudo -i -u ${sid}adm HDB version | grep "version:" | sed -e "s/^.*:[\ ]*//")
+    sid=$(crm configure show | grep -m1 SID= | sed -e "s/.*SID=\(...\).*/\1/" | tr '[:upper:]' '[:lower:]')
+    full_version=$(su -lc "HDB version" ${sid}adm | grep "version:" | sed -e "s/^.*:[\ ]*//")
     if [[ "$full_version" = "" ]]; then
       echo "0"
     else


### PR DESCRIPTION
The check 2.2.8 (2C2D43) blocks the runner execution completely, staying there forever.
However, it doesn't happen in all the deployment options. I have only been able to reproduce it when the runner is being executed in K3S or as systemd daemon (in these 2 platforms, the issue happens 100% of the times). In a normal execution everyting goes fines.

Changing how the `sudo` calls are used, fixes the issue. 

Fix for: #325 