### PR TITLE
Compare corosync.conf across the nodes

### DIFF
--- a/runner/ansible/roles/checks/1.1.10/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.1.10/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+
+name: 1.1.10
+group: Corosync
+labels: generic
+description: |
+  Test if corosync.conf files are identical across all nodes
+remediation: |
+  ## Abstract
+  It is required that the corosync.conf files are identical across all nodes in the cluster.
+
+  ## References
+  - T.B.D
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: BA215C

--- a/runner/ansible/roles/checks/1.1.10/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.10/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+
+- name:  "{{ name }} get corosync configuration file content"
+  command: md5sum /etc/corosync/corosync.conf
+  register: corosync_md5_content
+  check_mode: false
+  changed_when: false
+
+- name: "{{ name }} set corosync configuration file content"
+  set_fact:
+    corosync_file_md5: "{{ corosync_md5_content.stdout }}"
+  delegate_facts: true
+
+- name: "{{ name }}.check"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='corosync_file_md5') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ config_updated is not changed }}"


### PR DESCRIPTION
The check compares corosync.conf files across nodes and fails if they are different. It shows green and red, but there are some issues:

1. the command should be `ansible-playbook ansible/check.yml --inventory=ansible_hosts`. It would always be green if there is `--check` flag. (`ansible-playbook ansible/check.yml --inventory=ansible_hosts --check`)

2. The same if 
```
  #when:
  #  - ansible_check_mode
```
is uncommented.

3. I'm not aware where we recommend the corosync.conf files to be identical. 