### PR TITLE
Allow install-server script to fetch from different repo owners

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -25,7 +25,7 @@ jobs:
       postgres:
         image: postgres
         env:
-          POSTGRES_PASSWORD: postgres 
+          POSTGRES_PASSWORD: postgres
           POSTGRES_DB: trento_test
         ports:
           - 5432:5432
@@ -168,6 +168,7 @@ jobs:
     env:
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
+      TRENTO_REPO_OWNER: ${{ github.repository_owner }}
     steps:
       - uses: actions/checkout@v2
       - name: Install SSH key
@@ -179,7 +180,7 @@ jobs:
           if_key_exists: replace
           config: ${{ secrets.SSH_CONFIG }}
       - name: deploy trento services on K3S cluster
-        run: ssh "$TRENTO_USER@$TRENTO_SERVER_HOST" "sudo --preserve-env=PATH bash -s" -- < ./install-server.sh -r -p ~/.ssh/id_rsa
+        run: ssh "$TRENTO_USER@$TRENTO_SERVER_HOST" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER bash -s" -- < ./install-server.sh -r -p ~/.ssh/id_rsa
 
   deploy-agents:
     runs-on: [ self-hosted, trento-gh-runner ]
@@ -286,7 +287,7 @@ jobs:
     if: github.event.release
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
-    steps: 
+    steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0

--- a/install-server.sh
+++ b/install-server.sh
@@ -13,10 +13,9 @@ usage() {
     Install Trento Server
 
     OPTIONS:
-       -p --private-key         pre-authorized private SSH key used by the runner to connect to the hosts
-       -r --rolling             Use the rolling-release version instead of the stable one
-       -h --help                show this help
-
+        -p --private-key  <file>         re-authorized private SSH key used by the runner to connect to the hosts
+        -r --rolling                     use the rolling-release version instead of the stable one
+        -h --help                        show this help
 
     Example:
        $PROGNAME --private-key ./id_rsa_runner
@@ -32,15 +31,15 @@ cmdline() {
             --private-key)  args="${args}-p ";;
             --rolling)      args="${args}-r ";;
             --help)         args="${args}-h ";;
-            
+
             # pass through anything else
             *) [[ "${arg:0:1}" == "-" ]] || delim="\""
             args="${args}${delim}${arg}${delim} ";;
         esac
     done
-    
+
     eval set -- "$args"
-    
+
     while getopts "p:rh" OPTION
     do
         case $OPTION in
@@ -60,15 +59,15 @@ cmdline() {
             ;;
         esac
     done
-    
+
     if [[ -z "$PRIVATE_KEY" ]]; then
         read -rp "Please provide the path of the runner private key: " PRIVATE_KEY </dev/tty
     fi
-    
+
     if [[ "$ROLLING" == "true" ]]; then
         TRENTO_VERSION="rolling"
     fi
-    
+
     return 0
 }
 
@@ -117,10 +116,12 @@ update_helm_dependencies() {
 
 install_trento_server_chart() {
     local repo_owner=${TRENTO_REPO_OWNER:-"trento-project"}
+    local runner_image=${TRENTO_RUNNER_IMAGE:-"ghcr.io/$repo_owner/trento-runner"}
+    local web_image=${TRENTO_WEB_IMAGE:-"ghcr.io/$repo_owner/trento-web"}
     local private_key=${PRIVATE_KEY:-"./id_rsa_runner"}
     local trento_source_zip="${TRENTO_VERSION}"
     local trento_packages_url="https://github.com/${repo_owner}/trento/archive/refs/tags"
-    
+
     echo "Installing trento-server chart..."
     pushd -- /tmp >/dev/null
     rm -rf trento-"${trento_source_zip}"
@@ -128,13 +129,16 @@ install_trento_server_chart() {
     curl -f -sS -O -L "${trento_packages_url}/${trento_source_zip}.zip" >/dev/null
     unzip -o "${trento_source_zip}.zip" >/dev/null
     popd >/dev/null
-    
+
     pushd -- /tmp/trento-"${trento_source_zip}"/packaging/helm/trento-server >/dev/null
     helm dep update >/dev/null
     helm upgrade --install trento-server . \
     --set-file trento-runner.privateKey="${private_key}" \
     --set trento-web.image.tag="${TRENTO_VERSION}" \
-    --set trento-runner.image.tag="${TRENTO_VERSION}"
+    --set trento-runner.image.tag="${TRENTO_VERSION}" \
+    --set trento-runner.image.repository="${runner_image}" \
+    --set trento-web.image.repository="${web_image}"
+
     popd >/dev/null
 }
 


### PR DESCRIPTION
This PR improves the CD on a forked `trento` repo as it causes to fetch the images from the same fork instead of fetching them from the main `trento-project`. 

Previously, one would have to manually edit the deployment to specify the images uris if he wanted to test a change in e.g. the trento-runner or the trento-web images.