### PR TITLE
Use ElementsMatch to avoid randomly ordered maps in test

### DIFF
--- a/runner/inventory_test.go
+++ b/runner/inventory_test.go
@@ -225,5 +225,5 @@ func TestNewClusterInventoryContent(t *testing.T) {
 	}
 
 	assert.NoError(t, err)
-	assert.Equal(t, expectedContent, content)
+	assert.ElementsMatch(t, expectedContent.Groups, content.Groups)
 }


### PR DESCRIPTION
Fix a test in the `inventory_test.go` file to avoid errors as golang randomize the map orders