### PR TITLE
Refactor version checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make build
 FROM python:3.7-slim AS trento-runner
 RUN ln -s /usr/local/bin/python /usr/bin/python \
     && /usr/bin/python -m venv /venv \
-    && /venv/bin/pip install 'ansible~=4.6.0' 'ara~=1.5.7' \
+    && /venv/bin/pip install 'ansible~=4.6.0' 'ara~=1.5.7' 'rpm~=0.0.2' \
     && apt-get update && apt-get install -y --no-install-recommends \
       ssh \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \

--- a/runner/ansible/roles/checks/2.2.1/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.1/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    #
-    readlink /etc/products.d/baseproduct | grep -i "{{ expected [name] }}" || exit 1
-    exit 0
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.rc != 0
-  failed_when: config_updated.rc > 1
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ ansible_distribution is version(expected[name], '==') }}"

--- a/runner/ansible/roles/checks/2.2.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.2/tasks/main.yml
@@ -1,10 +1,8 @@
 ---
 
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{  ansible_distribution_version is version(expected[name], '>=') }}"
+    status: "{{ ansible_distribution_version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/checks/2.2.3/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.3/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    # Check the pacemaker version IS
-    # If not installed, exit with error
-    rpm -q --qf "%{VERSION}\n" pacemaker || exit 2
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.stdout is version(expected[name], '<')
-  failed_when: config_updated.rc > 1
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ 'pacemaker' in ansible_facts.packages and ansible_facts.packages['pacemaker'][0].version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/checks/2.2.4/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.4/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    # Check the corosync version IS
-    # If not installed, exit with error
-    rpm -q --qf "%{VERSION}\n" corosync || exit 2
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.stdout is version(expected[name], '<')
-  failed_when: config_updated.rc > 1
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ 'corosync' in ansible_facts.packages and ansible_facts.packages['corosync'][0].version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/checks/2.2.5/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.5/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    # Check the sbd version IS
-    # If not installed, exit with error
-    rpm -q --qf "%{VERSION}\n" sbd || exit 2
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.stdout is version(expected[name], '<')
-  failed_when: config_updated.rc > 1
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ 'sbd' in ansible_facts.packages and ansible_facts.packages['sbd'][0].version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/checks/2.2.6/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.6/tasks/main.yml
@@ -1,20 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    # Check the SAPHanaSR version is at least
-    # If not installed, exit with error
-    rpm -q --qf "%{VERSION}\n" SAPHanaSR || exit 2
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.stdout is version(expected[name], '<')
-  failed_when: config_updated.rc > 1
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ 'SAPHanaSR' in ansible_facts.packages and ansible_facts.packages['SAPHanaSR'][0].version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/checks/2.2.7/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.7/tasks/main.yml
@@ -1,19 +1,8 @@
 ---
 
-- name: "{{ name }}.check"
-  shell: |
-    #  Check python version
-    python3 --version | cut -d" " -f2
-  check_mode: false
-  register: config_updated
-  changed_when: config_updated.stdout is version(expected[name], '<')
-  failed_when: config_updated.rc !=0
-
 - block:
-    - name: Post results
+    - name: "{{ name }} Post results"
       import_role:
         name: post-results
-  when:
-    - ansible_check_mode
   vars:
-    status: "{{ config_updated is not changed }}"
+    status: "{{ 'python3' in ansible_facts.packages and ansible_facts.packages['python3'][0].version is version(expected[name], '>=') }}"

--- a/runner/ansible/roles/load_facts/tasks/main.yml
+++ b/runner/ansible/roles/load_facts/tasks/main.yml
@@ -9,6 +9,10 @@
   delegate_to: localhost
   run_once: true
 
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
 - name: set default value to cluster_selected_checks_list
   set_fact:
     cluster_selected_checks_list: "{{ cluster_selected_checks|default('')|split(',') }}"

--- a/runner/ansible/vars/azure_env.yml
+++ b/runner/ansible/vars/azure_env.yml
@@ -60,7 +60,7 @@ expected:
   "2.1.7.path": "/usr/share/SAPHanaSR"
   "2.1.7.execution_order": "1"
   "2.1.7.ha_dr_saphanasr": "info"
-  "2.2.1": "sles_sap.prod"
+  "2.2.1": "SLES_SAP"
   "2.2.2": "15.1"
   "2.2.3": "2.0.3"
   "2.2.3.exclude": "2.0.3+20200511.2b248d828"

--- a/runner/ansible/vars/dev_env.yml
+++ b/runner/ansible/vars/dev_env.yml
@@ -60,7 +60,7 @@ expected:
   "2.1.7.path": "/usr/share/SAPHanaSR"
   "2.1.7.execution_order": "1"
   "2.1.7.ha_dr_saphanasr": "info"
-  "2.2.1": "sles_sap.prod"
+  "2.2.1": "SLES_SAP"
   "2.2.2": "15.1"
   "2.2.3": "2.0.3"
   "2.2.3.exclude": "2.0.3+20200511.2b248d828"


### PR DESCRIPTION
Use ansible.builtin.package_facts instead of shell.

I think the PR is self explaining. There is still a minor improvement that should be done:
There is a repeating block
```
- name: Gather the package facts
  ansible.builtin.package_facts:
    manager: auto
```
in the checks 2.2.3 ... 2.2.7. However if I put this block in  the `runner/ansible/roles/load_facts/tasks/main.yml` like here https://github.com/trento-project/trento/pull/344/files#diff-1c2ed1309d3811de445241b2d87823d1e5b0df3e383c4d6a4f7a39996dacf107, the trento-runner container simply fails to start.

@arbulu89 @brett060102 what do you think about this?