### PR TITLE
update install-agent to get agent source from fork

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -205,11 +205,12 @@ function install_trento_tgz() {
     ARCH=$(uname -m | sed "s~x86_64~amd64~" | sed "s~aarch64~arm64~" )
     local bin_dir=${BIN_DIR:-"/usr/bin"}
     local sysd_dir=${SYSD_DIR:-"/usr/lib/systemd/system"}
+    local repo_owner=${TRENTO_REPO_OWNER:-"trento-project"}
 
     if [[ -n "$USE_ROLLING" ]] ; then
-        TRENTO_TGZ_URL=https://github.com/trento-project/trento/releases/download/rolling/trento-${ARCH}.tgz
+        TRENTO_TGZ_URL=https://github.com/${repo_owner}/trento/releases/download/rolling/trento-${ARCH}.tgz
     else
-        TRENTO_TGZ_URL=https://github.com/trento-project/trento/releases/download/${TRENTO_VERSION}/trento-${ARCH}.tgz
+        TRENTO_TGZ_URL=https://github.com/${repo_owner}/trento/releases/download/${TRENTO_VERSION}/trento-${ARCH}.tgz
     fi
 
     echo "* Downloading trento from $TRENTO_TGZ_URL ..."


### PR DESCRIPTION
Allows the CD pipeline to install the agent from the fork where it is running.