### PR TITLE
Add annotation to always roll deployments

### DIFF
--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "trento-runner.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -13,8 +13,9 @@ spec:
       {{- include "trento-web.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
Added a `rollme` annotation to always roll deployments , see:
https://helm.sh/docs/howto/charts_tips_and_tricks/

Before it was working randomly because helm wasn't always updating the deployment so kubernetes wasn't rolling.

This is the official way to fix it, as the helm community also confirmed in the #helm-users channel of slack.

Thanks to @rtorrero for pointing me out to the solution.