### PR TITLE
Small improvement of CI

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -200,9 +200,9 @@ jobs:
           set -ex
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
           do
-            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--agent-bind-ip" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl set-environment DATA_COLLECTOR_ENABLED=$DATA_COLLECTOR_ENABLED"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl set-environment COLLECTOR_HOST=$TRENTO_SERVER_HOST"
+            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--agent-bind-ip" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -221,7 +221,6 @@ function install_trento_tgz() {
     mv trento ${bin_dir}/trento
     mv packaging/systemd/trento-agent.service ${sysd_dir}/trento-agent.service
     systemctl daemon-reload
-    systemctl enable --now trento-agent.service
     rm trento-${ARCH}.tgz
 }
 


### PR DESCRIPTION
Removes `systemctl enable --now trento-agent.service` from `install-agent.sh` to leave that responsibility to the user.