### PR TITLE
Compare versions across nodes

### DIFF
--- a/runner/ansible/roles/checks/2.2.2.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.2.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.2.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if the OS version identical on all nodes
+remediation: |
+  ## Abstract
+  You need identical SUSE Linux Enterprise Server for SAP Applications 15 SP1 on all nodes of the cluster
+
+  ## Remediation
+  Please install identical OS version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: D028BA

--- a/runner/ansible/roles/checks/2.2.2.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.2.identical/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: "{{ name }}.check"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='ansible_distribution_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.3.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.3.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.3.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed Pacemaker version is identical on all nodes
+remediation: |
+  ## Abstract
+  Installed Pacemaker version must be identical on all nodes of the cluster
+
+  ## Remediation
+  Install identical Pacemaker version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: 9FEFB1

--- a/runner/ansible/roles/checks/2.2.3.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.3.identical/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "{{ name }} get the pacemaker version"
+  set_fact:
+    pacemaker_version: "{{ ansible_facts.packages['pacemaker'][0].version }}"
+  delegate_facts: true
+  when: "'pacemaker' in ansible_facts.packages"
+
+- name: "{{ name }} compare pacemaker versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='pacemaker_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "pacemaker_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ pacemaker_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.3.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.3.identical/tasks/main.yml
@@ -7,14 +7,12 @@
   when: "'pacemaker' in ansible_facts.packages"
 
 - name: "{{ name }} compare pacemaker versions across nodes"
-  assert:
-    that:
-      - "{{ groups[item] | map('extract', hostvars) | map(attribute='pacemaker_version') | list | unique | length }} == 1"
-    quiet: true
-  loop: "{{ group_names }}"
-  register: config_updated
-  changed_when: config_updated.failed
-  when: "pacemaker_version is defined"
+  import_role:
+    name: load_facts
+    tasks_from: compare
+  vars:
+    fact_to_compare: "{{ pacemaker_version }}"
+    config_updated: "{{ config_updated }}"
 
 - block:
     - name: Post results

--- a/runner/ansible/roles/checks/2.2.4.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.4.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.4.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed Corosync version is identical on all nodes
+remediation: |
+  ## Abstract
+  Installed Corosync version must be identical on all nodes of the cluster
+
+  ## Remediation
+  Install identical Corosync version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: DC542A

--- a/runner/ansible/roles/checks/2.2.4.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.4.identical/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "{{ name }} get the corosync version"
+  set_fact:
+    corosync_version: "{{ ansible_facts.packages['corosync'][0].version }}"
+  delegate_facts: true
+  when: "'corosync' in ansible_facts.packages"
+
+- name: "{{ name }} compare corosync versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='corosync_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "corosync_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ corosync_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.5.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.5.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.5.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed SBD version is identical on all nodes
+remediation: |
+  ## Abstract
+  Installed SBD version must be identical on all nodes of the cluster
+
+  ## Remediation
+  Install identicel SBD version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: 222A58

--- a/runner/ansible/roles/checks/2.2.5.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.5.identical/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "{{ name }} get the sbd version"
+  set_fact:
+    sbd_version: "{{ ansible_facts.packages['sbd'][0].version }}"
+  delegate_facts: true
+  when: "'sbd' in ansible_facts.packages"
+
+- name: "{{ name }} compare sbd versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='sbd_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "sbd_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ sbd_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.6.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.6.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.6.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed SAPHanaSR version is identical on all nodes
+remediation: |
+  ## Abstract
+  Installed SAPHanaSR version must be identical on all nodes of the cluster
+
+  ## Remediation
+  Install identical SAPHanaSR version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: 31BDCC

--- a/runner/ansible/roles/checks/2.2.6.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.6.identical/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "{{ name }} get the SAPHanaSR version"
+  set_fact:
+    saphanasr_version: "{{ ansible_facts.packages['SAPHanaSR'][0].version }}"
+  delegate_facts: true
+  when: "'SAPHanaSR' in ansible_facts.packages"
+
+- name: "{{ name }} compare SAPHanaSR versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='saphanasr_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "saphanasr_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ saphanasr_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.7.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.7.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.7.identical
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed Python3 version is identical on all nodes
+remediation: |
+  ## Abstract
+  Installed Python3 version must be identical on all nodes of the cluster
+
+  ## Remediation
+  Install identical Python3 version on all nodes of the cluster
+
+  ## Reference
+  - https://documentation.suse.com/en-us/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: F50AF6

--- a/runner/ansible/roles/checks/2.2.7.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.7.identical/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+
+- name: "{{ name }} get the python3 version"
+  set_fact:
+    python3_version: "{{ ansible_facts.packages['python3'][0].version }}"
+  delegate_facts: true
+  when: "'python3' in ansible_facts.packages"
+
+- name: "{{ name }} compare python3 versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='python3_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "python3_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ python3_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/checks/2.2.8.identical/defaults/main.yml
+++ b/runner/ansible/roles/checks/2.2.8.identical/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+
+name: 2.2.8
+group: OS and package versions
+labels: hana
+description: |
+  Test if installed HANA and SPS versions are identical on all nodes
+remediation: |
+  ## Abstract
+  SAP HANA versions must be idenical on all nodes of the cluster.
+
+  ## Remediation
+  Install identical versions of SAP HANA on all nodes of the cluster.
+
+  ## References
+  - Section 2 in https://documentation.suse.com/sbp/all/single-html/SLES4SAP-hana-sr-guide-PerfOpt-15/#cha.hana-sr.scenario
+implementation: "{{ lookup('file', 'roles/checks/'+name+'/tasks/main.yml') }}"
+
+# check id. This value must not be changed over the life of this check
+id: 2C2D44

--- a/runner/ansible/roles/checks/2.2.8.identical/tasks/main.yml
+++ b/runner/ansible/roles/checks/2.2.8.identical/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: "{{ name }} get HANA and SPS versions"
+  shell: |
+    #  HANA and SPS versions are compatible
+    sid=$(crm configure show | grep -m1 SID= | sed -e "s/.*SID=\(...\).*/\1/" | tr '[:upper:]' '[:lower:]')
+    full_version=$(su -lc "HDB version" ${sid}adm | grep "version:" | sed -e "s/^.*:[\ ]*//")
+    echo "$full_version"
+  register: spshana_version_reg
+  check_mode: false
+  changed_when: false
+  
+- name: "{{ name }} store HANA and SPS version as a fact"
+  set_fact:
+    spshana_version: "{{ spshana_version_reg.stdout }}"
+  delegate_facts: true
+
+- name: "{{ name }} compare HANA and SPS versions across nodes"
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute='spshana_version') | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "spshana_version is defined"
+
+- block:
+    - name: Post results
+      import_role:
+        name: post-results
+  vars:
+    status: "{{ spshana_version is defined and config_updated is not changed }}"

--- a/runner/ansible/roles/load_facts/tasks/compare.yml
+++ b/runner/ansible/roles/load_facts/tasks/compare.yml
@@ -1,0 +1,9 @@
+- name: compare facts among nodes
+  assert:
+    that:
+      - "{{ groups[item] | map('extract', hostvars) | map(attribute=fact_to_compare) | list | unique | length }} == 1"
+    quiet: true
+  loop: "{{ group_names }}"
+  register: config_updated
+  changed_when: config_updated.failed
+  when: "fact_to_compare is defined"


### PR DESCRIPTION
Compare versions across nodes

This PR implements the draft #344 . There are two commits. The first commit (the one with the comment "Check versions across nodes") is ready to merge. There is, however, even after polishings, a lot of repeating text. It would be nice to have something like in the second commit (the one with the comment "It would be nice if it was working like this"). The second commit unfortunately doesn't work.

@arbulu89 @brett060102 what do you think?