### PR TITLE
Typo fixes in home.html.tmpl

### DIFF
--- a/web/templates/home.html.tmpl
+++ b/web/templates/home.html.tmpl
@@ -35,8 +35,8 @@
                         This view currently allows to check the status of the all the discovered
                         Pacemaker clusters, including the information of the status of each node and
                         the role associated to each node. This view also allows to see the node's
-                        attributes which reflect detailsfound from their configuration as well as
-                        resources, their type and distributionwithin the cluster nodes.
+                        attributes which reflect details found from their configuration as well as
+                        resources, their type and distribution within the cluster nodes.
                     </p>
                     <div class='d-flex justify-content-end'>
                         <a class='card-link' href='/clusters'>Go to view</a>
@@ -50,10 +50,10 @@
                 <div class='card-body'>
                     <p class='card-text'>
                         In this view are listed the SAP Systems, usually identified by a SID or
-                        `SAP System Idenfication` string such as `PRD`, `DEV`, or `QAS`. These are used
+                        `SAP System Identification` string such as `PRD`, `DEV`, or `QAS`. These are used
                         often to identify productive, development and quality assurance systems.
                         In this view we get an overview of the distribution of each SID, the number of
-                        hosts disvered of each of them and additional details.
+                        hosts discovered of each of them and additional details.
                     </p>
                     <div class='d-flex justify-content-end'>
                         <a class='card-link' href='/sapsystems'>Go to view</a>
@@ -62,7 +62,7 @@
             </div>
         </div>
         <div class='mt-4'>
-            For more information and getting started, plese refer to the
+            For more information and getting started, please refer to the
             <a target='blank'
                href='https://github.com/trento-project/trento/blob/main/docs/scope.md'>scope</a>,
             <a target='blank'


### PR DESCRIPTION
In the file /web/blocks/home.html.tmpl I got rid of the following typos: 
Line 38: Changed "detailsfound" to "details found".
Line 39: Changed "distribuitionwithin" to "distribution within"
Line 53: Changed "Idenfication" to "Identification"
LIne 65: Changed "plese" to "please"