### PR TITLE
Change postgresql trento dev default port from 32432 to 5432

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -62,8 +62,6 @@ jobs:
       - name: install-mockery
         run: go install github.com/vektra/mockery/v2
       - name: test
-        env:
-          TRENTO_DB_PORT: 5432
         run: make test
       - name: static analysis
         run: make vet-check

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ helm install trento-dev .
 ```
 
 Since integration tests require a running PostgreSQL instance, please make sure the chart is installed prior to running the integration tests.
-The PostgreSQL instance will be accessible at port `localhost:32432`.
+The PostgreSQL instance will be accessible at port `localhost:5432`.
 
 If you want to skip database integration tests, you can use a dedicated environment variable as follows:
 ```shell

--- a/hack/helm/trento-dev/values.yaml
+++ b/hack/helm/trento-dev/values.yaml
@@ -1,8 +1,7 @@
 trento-server:
   postgresql:
     service:
-      type: NodePort
-      nodePort: 32432
+      type: LoadBalancer
     initdbScripts:
       init.sql: |
         CREATE DATABASE trento_test;

--- a/test/helpers/config.go
+++ b/test/helpers/config.go
@@ -9,7 +9,7 @@ import (
 func init() {
 	viper.SetDefault("db-integration-tests", true)
 	viper.SetDefault("db-host", "localhost")
-	viper.SetDefault("db-port", "32432")
+	viper.SetDefault("db-port", "5432")
 	viper.SetDefault("db-user", "postgres")
 	viper.SetDefault("db-password", "postgres")
 	viper.SetDefault("db-name", "trento_test")


### PR DESCRIPTION
Realized we can expose the pgsql port 5432 through a `LoadBalancer` in the trento-dev helm chart, so we don't use exotic default ports in our tests.