### PR TITLE
Moved tags to the right side

### DIFF
--- a/web/templates/blocks/sapsystems_table.html.tmpl
+++ b/web/templates/blocks/sapsystems_table.html.tmpl
@@ -12,7 +12,7 @@
                 <th scope='col'>Tenant</th>
                 <th scope='col'>DB address</th>
                 {{- end }}
-                <th scope='col'>Tags</th>
+                <th scope='col' style="float: right">Tags</th>
             </tr>
             </thead>
             <tbody>
@@ -29,7 +29,7 @@
                 <td>{{ $value.Profile.dbs.hdb.dbname }}</td>
                 <td>{{ $value.Profile.SAPDBHOST }}</td>
                 {{- end }}
-                <td>
+                <td style="float: right">
                     <input class="tags-input"
                         value="{{- range .Tags }}{{ . }},{{- end }}"
                         data-resource-type="{{ $resource }}"


### PR DESCRIPTION
When looking at the databases in trento, the tags
were in the middle and it looked bad. This commit moves
the tags to the right side to make it look more appealing.