### PR TITLE
Restablish consul-config-dir usage

### DIFF
--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -48,6 +48,7 @@ func LoadConfig() (*agent.Config, error) {
 			Key:           key,
 			CA:            ca,
 		},
+		ConsulConfigDir: viper.GetString("consul-config-dir"),
 		InstanceName:    hostname,
 		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Minute,
 	}, nil


### PR DESCRIPTION
Fix for root cause of the `sapsystems page doesn't work!` issue in our demo environment.
During some previous refactor, we missed to bypass this `consul-config-dir`.
This flag value was used by `consul-template` to know where to put the consul meta fields, which are used pretty often in the web part.

Without passing this flag, the `trento-metadata.json` file with the metadata was being created in the same folder of the executable (`/root` folder in our case). 

With this change, the trento and consul deamon file use the same folder to store and read the content of the file, fixing the issue.

We have been carrying this issue for some time, but as we were not introducing any change that modified the meta file, it was statically there, and that's why it worked. 
For some reason that I unknown, this file was removed in the `vmhana01` creating the issue, and subsequent fixes on top of fixes hehe (which they are required in any case).

Once we remove consul for all, all of this black-box kind of things will go away (hopefully XD)

Related:
https://github.com/trento-project/trento/pull/407
https://github.com/trento-project/trento/pull/408