### PR TITLE
Use the correct test request constructor

### DIFF
--- a/web/about_test.go
+++ b/web/about_test.go
@@ -30,9 +30,6 @@ func TestAboutHandlerPremium(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/about", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -73,9 +70,6 @@ func TestAboutHandlerFree(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/about", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 

--- a/web/about_test.go
+++ b/web/about_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
@@ -30,7 +29,7 @@ func TestAboutHandlerPremium(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/about", nil)
+	req := httptest.NewRequest("GET", "/about", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +72,7 @@ func TestAboutHandlerFree(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/about", nil)
+	req := httptest.NewRequest("GET", "/about", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/checks_api_test.go
+++ b/web/checks_api_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -73,7 +72,7 @@ func TestApiClusterCheckResultsHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
+	req := httptest.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,7 +141,7 @@ func TestApiClusterCheckResultsHandler500(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
+	req := httptest.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +210,7 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	body, _ := json.Marshal(&sendData)
-	req, err := http.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
+	req := httptest.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +224,7 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 
 	sendData = JSONChecksCatalog{}
 	body, _ = json.Marshal(&sendData)
-	req, err = http.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
+	req = httptest.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -269,7 +268,7 @@ func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	// 200 scenario
 	resp := httptest.NewRecorder()
 
-	req, err := http.NewRequest("GET", "/api/checks/group1/settings", nil)
+	req := httptest.NewRequest("GET", "/api/checks/group1/settings", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -293,7 +292,7 @@ func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	// 404 scenario
 	resp = httptest.NewRecorder()
 
-	req, err = http.NewRequest("GET", "/api/checks/otherId/settings", nil)
+	req = httptest.NewRequest("GET", "/api/checks/otherId/settings", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -340,7 +339,7 @@ func TestApiCheckCreateConnectionByIdHandler(t *testing.T) {
 	}
 	resp := httptest.NewRecorder()
 	body, _ := json.Marshal(&sendData)
-	req, err := http.NewRequest("POST", "/api/checks/group1/settings", bytes.NewBuffer(body))
+	req := httptest.NewRequest("POST", "/api/checks/group1/settings", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +355,7 @@ func TestApiCheckCreateConnectionByIdHandler(t *testing.T) {
 	// 500 scenario
 	resp = httptest.NewRecorder()
 
-	req, err = http.NewRequest("POST", "/api/checks/otherId/settings", bytes.NewBuffer(body))
+	req = httptest.NewRequest("POST", "/api/checks/otherId/settings", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/checks_api_test.go
+++ b/web/checks_api_test.go
@@ -73,9 +73,6 @@ func TestApiClusterCheckResultsHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	req := httptest.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -142,9 +139,6 @@ func TestApiClusterCheckResultsHandler500(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	req := httptest.NewRequest("GET", "/api/clusters/47d1190ffb4f781974c8356d7f863b03/results", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -211,9 +205,6 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 	body, _ := json.Marshal(&sendData)
 	req := httptest.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -225,9 +216,6 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 	sendData = JSONChecksCatalog{}
 	body, _ = json.Marshal(&sendData)
 	req = httptest.NewRequest("PUT", "/api/checks/catalog", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -269,9 +257,6 @@ func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 
 	req := httptest.NewRequest("GET", "/api/checks/group1/settings", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -293,9 +278,6 @@ func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	resp = httptest.NewRecorder()
 
 	req = httptest.NewRequest("GET", "/api/checks/otherId/settings", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -340,9 +322,6 @@ func TestApiCheckCreateConnectionByIdHandler(t *testing.T) {
 	resp := httptest.NewRecorder()
 	body, _ := json.Marshal(&sendData)
 	req := httptest.NewRequest("POST", "/api/checks/group1/settings", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -356,9 +335,6 @@ func TestApiCheckCreateConnectionByIdHandler(t *testing.T) {
 	resp = httptest.NewRecorder()
 
 	req = httptest.NewRequest("POST", "/api/checks/otherId/settings", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 

--- a/web/checks_catalog_test.go
+++ b/web/checks_catalog_test.go
@@ -71,9 +71,6 @@ func TestChecksCatalogHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/catalog", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -110,9 +107,6 @@ func TestChecksCatalogHandlerError(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/catalog", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)

--- a/web/checks_catalog_test.go
+++ b/web/checks_catalog_test.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"strings"
@@ -71,7 +70,7 @@ func TestChecksCatalogHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/catalog", nil)
+	req := httptest.NewRequest("GET", "/catalog", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +109,7 @@ func TestChecksCatalogHandlerError(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/catalog", nil)
+	req := httptest.NewRequest("GET", "/catalog", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/clusters_next_test.go
+++ b/web/clusters_next_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
@@ -72,7 +71,7 @@ func TestClustersListNextHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters-next", nil)
+	req := httptest.NewRequest("GET", "/clusters-next", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/clusters_next_test.go
+++ b/web/clusters_next_test.go
@@ -72,9 +72,6 @@ func TestClustersListNextHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters-next", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -527,9 +527,6 @@ func TestClustersListHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -619,9 +616,6 @@ func TestClusterHandlerHANA(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -739,9 +733,6 @@ func TestClusterHandlerUnreachableNodes(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -823,9 +814,6 @@ func TestClusterHandlerAlert(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -878,9 +866,6 @@ func TestClusterHandlerGeneric(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters/e2f2eb50aef748e586a7baa85e0162cf", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -914,9 +899,6 @@ func TestClusterHandler404Error(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/clusters/foobar", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -950,9 +932,6 @@ func TestSaveChecksHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/clusters/foobar/settings", strings.NewReader(data.Encode()))
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Content-Length", strconv.Itoa(len(data.Encode())))

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"path"
@@ -527,7 +526,7 @@ func TestClustersListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters", nil)
+	req := httptest.NewRequest("GET", "/clusters", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +618,7 @@ func TestClusterHandlerHANA(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters/"+clusterId, nil)
+	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -739,7 +738,7 @@ func TestClusterHandlerUnreachableNodes(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters/"+clusterId, nil)
+	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -823,7 +822,7 @@ func TestClusterHandlerAlert(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters/"+clusterId, nil)
+	req := httptest.NewRequest("GET", "/clusters/"+clusterId, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -878,7 +877,7 @@ func TestClusterHandlerGeneric(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters/e2f2eb50aef748e586a7baa85e0162cf", nil)
+	req := httptest.NewRequest("GET", "/clusters/e2f2eb50aef748e586a7baa85e0162cf", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -914,7 +913,7 @@ func TestClusterHandler404Error(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/clusters/foobar", nil)
+	req := httptest.NewRequest("GET", "/clusters/foobar", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -950,7 +949,7 @@ func TestSaveChecksHandler(t *testing.T) {
 	data.Set("username-host2", "myuser2")
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/clusters/foobar/settings", strings.NewReader(data.Encode()))
+	req := httptest.NewRequest("POST", "/clusters/foobar/settings", strings.NewReader(data.Encode()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/collector_test.go
+++ b/web/collector_test.go
@@ -32,9 +32,6 @@ func TestApiCollectDataHandler(t *testing.T) {
 		Payload:       []byte("{}"),
 	})
 	req := httptest.NewRequest("POST", "/api/collect", bytes.NewBuffer(body))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.collectorEngine.ServeHTTP(resp, req)
 

--- a/web/collector_test.go
+++ b/web/collector_test.go
@@ -3,7 +3,6 @@ package web
 import (
 	"bytes"
 	"encoding/json"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestApiCollectDataHandler(t *testing.T) {
 		DiscoveryType: "discovery",
 		Payload:       []byte("{}"),
 	})
-	req, err := http.NewRequest("POST", "/api/collect", bytes.NewBuffer(body))
+	req := httptest.NewRequest("POST", "/api/collect", bytes.NewBuffer(body))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/errors_test.go
+++ b/web/errors_test.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"errors"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +17,7 @@ func TestErrorHandler(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	engine.ServeHTTP(w, req)
 
 	assert.Equal(t, 500, w.Code)
@@ -35,7 +34,7 @@ func TestErrorHandlerContentNegotiation(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	req.Header.Set("Accept", "text/html")
 
 	engine.ServeHTTP(w, req)
@@ -54,7 +53,7 @@ func TestErrorHandlerWithHttpError(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	engine.ServeHTTP(w, req)
 
 	assert.Equal(t, 404, w.Code)

--- a/web/home_test.go
+++ b/web/home_test.go
@@ -18,9 +18,7 @@ func TestHomeHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	app.webEngine.ServeHTTP(resp, req)
 
 	assert.Equal(t, 200, resp.Code)

--- a/web/home_test.go
+++ b/web/home_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -18,7 +17,7 @@ func TestHomeHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/", nil)
+	req := httptest.NewRequest("GET", "/", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
@@ -158,7 +157,7 @@ func TestHostsListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/hosts", nil)
+	req := httptest.NewRequest("GET", "/hosts", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +316,7 @@ func TestHostHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/hosts/test_host", nil)
+	req := httptest.NewRequest("GET", "/hosts/test_host", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -438,7 +437,7 @@ func TestHostHandlerAzure(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/hosts/test_host", nil)
+	req := httptest.NewRequest("GET", "/hosts/test_host", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +482,7 @@ func TestHostHandler404Error(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/hosts/foobar", nil)
+	req := httptest.NewRequest("GET", "/hosts/foobar", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -158,9 +158,6 @@ func TestHostsListHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/hosts", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -317,9 +314,6 @@ func TestHostHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/hosts/test_host", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -438,9 +432,6 @@ func TestHostHandlerAzure(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/hosts/test_host", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)
@@ -483,9 +474,6 @@ func TestHostHandler404Error(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/hosts/foobar", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)

--- a/web/sapsystems_test.go
+++ b/web/sapsystems_test.go
@@ -210,9 +210,6 @@ func TestSAPSystemsListHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/sapsystems", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -263,9 +260,6 @@ func TestSAPDatabaseListHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/databases", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	app.webEngine.ServeHTTP(resp, req)
 
@@ -462,10 +456,9 @@ func TestSAPResourceHandler(t *testing.T) {
 
 	resp := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/sapsystems/systemId", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	app.webEngine.ServeHTTP(resp, req)
+
 	assert.Equal(t, 200, resp.Code)
 	responseBody := minifyHtml(resp.Body.String())
 

--- a/web/sapsystems_test.go
+++ b/web/sapsystems_test.go
@@ -1,7 +1,6 @@
 package web
 
 import (
-	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"testing"
@@ -210,7 +209,7 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/sapsystems", nil)
+	req := httptest.NewRequest("GET", "/sapsystems", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +262,7 @@ func TestSAPDatabaseListHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/databases", nil)
+	req := httptest.NewRequest("GET", "/databases", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +461,7 @@ func TestSAPResourceHandler(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/sapsystems/systemId", nil)
+	req := httptest.NewRequest("GET", "/sapsystems/systemId", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,7 +497,7 @@ func TestSAPResourceHandler404Error(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/sapsystems/foobar", nil)
+	req := httptest.NewRequest("GET", "/sapsystems/foobar", nil)
 	req.Header.Set("Accept", "text/html")
 
 	app.webEngine.ServeHTTP(resp, req)

--- a/web/tags_api_test.go
+++ b/web/tags_api_test.go
@@ -176,9 +176,6 @@ func TestApiResourceTag(t *testing.T) {
 			body, _ := json.Marshal(&JSONTag{tag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
 			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -195,9 +192,6 @@ func TestApiResourceTag(t *testing.T) {
 			body, _ := json.Marshal(&JSONTag{tag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, notFoundResourceID)
 			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -210,9 +204,6 @@ func TestApiResourceTag(t *testing.T) {
 			invalidJSON := []byte("ABC€")
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
 			req := httptest.NewRequest("POST", url, bytes.NewBuffer(invalidJSON))
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -225,9 +216,6 @@ func TestApiResourceTag(t *testing.T) {
 			body, _ := json.Marshal(&JSONTag{errorTag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
 			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -239,9 +227,6 @@ func TestApiResourceTag(t *testing.T) {
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, resourceID, tag)
 			req := httptest.NewRequest("DELETE", url, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -253,9 +238,6 @@ func TestApiResourceTag(t *testing.T) {
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, notFoundResourceID, tag)
 			req := httptest.NewRequest("DELETE", url, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 
@@ -267,9 +249,6 @@ func TestApiResourceTag(t *testing.T) {
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, resourceID, errorTag)
 			req := httptest.NewRequest("DELETE", url, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
 
 			app.webEngine.ServeHTTP(resp, req)
 

--- a/web/tags_api_test.go
+++ b/web/tags_api_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -55,7 +54,7 @@ func TestApiListTag(t *testing.T) {
 	}
 
 	resp := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/tags", nil)
+	req := httptest.NewRequest("GET", "/api/tags", nil)
 	app.webEngine.ServeHTTP(resp, req)
 
 	expectedBody, _ := json.Marshal(tags)
@@ -63,7 +62,7 @@ func TestApiListTag(t *testing.T) {
 	assert.Equal(t, expectedBody, resp.Body.Bytes())
 
 	resp = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/api/tags?resource_type=hosts", nil)
+	req = httptest.NewRequest("GET", "/api/tags?resource_type=hosts", nil)
 	app.webEngine.ServeHTTP(resp, req)
 
 	expectedBody, _ = json.Marshal([]string{
@@ -75,7 +74,7 @@ func TestApiListTag(t *testing.T) {
 	assert.Equal(t, expectedBody, resp.Body.Bytes())
 
 	resp = httptest.NewRecorder()
-	req, _ = http.NewRequest("GET", "/api/tags?resource_type=sapsystems", nil)
+	req = httptest.NewRequest("GET", "/api/tags?resource_type=sapsystems", nil)
 	app.webEngine.ServeHTTP(resp, req)
 
 	expectedBody, _ = json.Marshal([]string{})
@@ -176,7 +175,7 @@ func TestApiResourceTag(t *testing.T) {
 
 			body, _ := json.Marshal(&JSONTag{tag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
-			req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -195,7 +194,7 @@ func TestApiResourceTag(t *testing.T) {
 
 			body, _ := json.Marshal(&JSONTag{tag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, notFoundResourceID)
-			req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -210,7 +209,7 @@ func TestApiResourceTag(t *testing.T) {
 
 			invalidJSON := []byte("ABC€")
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
-			req, err := http.NewRequest("POST", url, bytes.NewBuffer(invalidJSON))
+			req := httptest.NewRequest("POST", url, bytes.NewBuffer(invalidJSON))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -225,7 +224,7 @@ func TestApiResourceTag(t *testing.T) {
 
 			body, _ := json.Marshal(&JSONTag{errorTag})
 			url := fmt.Sprintf("/api/%s/%s/tags", tc.resourceType, resourceID)
-			req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+			req := httptest.NewRequest("POST", url, bytes.NewBuffer(body))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -239,7 +238,7 @@ func TestApiResourceTag(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, resourceID, tag)
-			req, err := http.NewRequest("DELETE", url, nil)
+			req := httptest.NewRequest("DELETE", url, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -253,7 +252,7 @@ func TestApiResourceTag(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, notFoundResourceID, tag)
-			req, err := http.NewRequest("DELETE", url, nil)
+			req := httptest.NewRequest("DELETE", url, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -267,7 +266,7 @@ func TestApiResourceTag(t *testing.T) {
 			resp := httptest.NewRecorder()
 
 			url := fmt.Sprintf("/api/%s/%s/tags/%s", tc.resourceType, resourceID, errorTag)
-			req, err := http.NewRequest("DELETE", url, nil)
+			req := httptest.NewRequest("DELETE", url, nil)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
As mentioned in Slack, `http.NewRequest()` is the client request constructor and it doesn't trigger the parsing of a lot of internal fields which some server handlers might rely on, so they would fail tests that should actually be passing.

I spotted such a false negative when testing the swagger handler, which does this kind of things:
https://github.com/swaggo/gin-swagger/blob/5ef0958c325e56d022effff2081e02430e573856/swagger.go#L82
Step debugging showed `c.Request.RequestURI` was empty during the test run, but the handler was actually working correctly when running the application in a real environment.

The correct method to create simulated server requests is `httptest.NewRequest()` as documented here:
https://pkg.go.dev/net/http/httptest#NewRequest