### PR TITLE
Fix cloud os user name retrieval in the runner side

### DIFF
--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -92,7 +92,7 @@ var getCloudUserName = func(client consul.Client, node string) (string, error) {
 
 	switch cloudData.Provider {
 	case cloud.Azure:
-		azureData := cloudData.Metadata.(cloud.AzureMetadata)
+		azureData := cloudData.Metadata.(*cloud.AzureMetadata)
 		return azureData.Compute.OsProfile.AdminUserName, nil
 	default:
 		return DefaultUser, nil


### PR DESCRIPTION
I have noticed the runner is not working properly in the demo environment, and it fails because I is running in Azure...
I broke this during some of the recent changes on the consul removal transition.

This fixes the issue. And I have added a "just in case test". We will remove this temporary code sooner than later, but well, let's try to avoid these regressions hehe

The current error log by the way:
```
time="2021-11-02 13:36:41" level=info msg="Ansible playbook /tmp/trento/ansible/meta.yml"
time="2021-11-02 13:37:38" level=info msg="Ansible playbook execution finished successfully"
time="2021-11-02 13:37:38" level=info msg="Starting the runner loop..."
time="2021-11-02 13:37:38" level=info msg="Loading ARA plugins..."
time="2021-11-02 13:37:38" level=info msg="ARA plugins loaded successfully"
panic: interface conversion: interface {} is *cloud.AzureMetadata, not cloud.AzureMetadata

```