### PR TITLE
Project telemetry data

### DIFF
--- a/agent/discovery/collector/client_test.go
+++ b/agent/discovery/collector/client_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
+	_ "github.com/trento-project/trento/test"
 	"github.com/trento-project/trento/test/helpers"
 )
 
@@ -35,9 +36,9 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_NewClientWithTLS() {
 		EnablemTLS:    true,
 		CollectorHost: "localhost",
 		CollectorPort: 8081,
-		Cert:          "../../../test/certs/client-cert.pem",
-		Key:           "../../../test/certs/client-key.pem",
-		CA:            "../../../test/certs/ca-cert.pem",
+		Cert:          "./test/certs/client-cert.pem",
+		Key:           "./test/certs/client-key.pem",
+		CA:            "./test/certs/ca-cert.pem",
 	})
 
 	suite.NoError(err)
@@ -69,9 +70,9 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingSuccess() {
 		EnablemTLS:    true,
 		CollectorHost: "localhost",
 		CollectorPort: 8081,
-		Cert:          "../../../test/certs/client-cert.pem",
-		Key:           "../../../test/certs/client-key.pem",
-		CA:            "../../../test/certs/ca-cert.pem",
+		Cert:          "./test/certs/client-cert.pem",
+		Key:           "./test/certs/client-key.pem",
+		CA:            "./test/certs/ca-cert.pem",
 	})
 
 	suite.NoError(err)

--- a/agent/discovery/collector/publishing_test.go
+++ b/agent/discovery/collector/publishing_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/trento/agent/discovery/mocks"
+	_ "github.com/trento-project/trento/test"
 	"github.com/trento-project/trento/test/helpers"
 )
 
@@ -36,9 +37,9 @@ func (suite *PublishingTestSuite) SetupSuite() {
 		EnablemTLS:    true,
 		CollectorHost: "localhost",
 		CollectorPort: 8443,
-		Cert:          "../../../test/certs/client-cert.pem",
-		Key:           "../../../test/certs/client-key.pem",
-		CA:            "../../../test/certs/ca-cert.pem",
+		Cert:          "./test/certs/client-cert.pem",
+		Key:           "./test/certs/client-key.pem",
+		CA:            "./test/certs/ca-cert.pem",
 	})
 	suite.NoError(err)
 
@@ -52,7 +53,7 @@ func (suite *PublishingTestSuite) TestCollectorClient_PublishingClusterDiscovery
 	discoveredCluster := mocks.NewDiscoveredClusterMock()
 
 	suite.runDiscoveryScenario(discoveryType, discoveredCluster, func(requestBodyAgainstCollector string) {
-		suite.assertJsonMatchesJsonFileContent("../../../test/fixtures/discovery/cluster/expected_published_cluster_discovery.json", requestBodyAgainstCollector)
+		suite.assertJsonMatchesJsonFileContent("./test/fixtures/discovery/cluster/expected_published_cluster_discovery.json", requestBodyAgainstCollector)
 	})
 }
 
@@ -61,7 +62,7 @@ func (suite *PublishingTestSuite) TestCollectorClient_PublishingCloudDiscovery()
 	discoveredCloudInstance := mocks.NewDiscoveredCloudMock()
 
 	suite.runDiscoveryScenario(discoveryType, discoveredCloudInstance, func(requestBodyAgainstCollector string) {
-		suite.assertJsonMatchesJsonFileContent("../../../test/fixtures/discovery/azure/expected_published_cloud_discovery.json", requestBodyAgainstCollector)
+		suite.assertJsonMatchesJsonFileContent("./test/fixtures/discovery/azure/expected_published_cloud_discovery.json", requestBodyAgainstCollector)
 	})
 }
 
@@ -70,7 +71,7 @@ func (suite *PublishingTestSuite) TestCollectorClient_PublishingHostDiscovery() 
 	discoveredHost := mocks.NewDiscoveredHostMock()
 
 	suite.runDiscoveryScenario(discoveryType, discoveredHost, func(requestBodyAgainstCollector string) {
-		suite.assertJsonMatchesJsonFileContent("../../../test/fixtures/discovery/host/expected_published_host_discovery.json", requestBodyAgainstCollector)
+		suite.assertJsonMatchesJsonFileContent("./test/fixtures/discovery/host/expected_published_host_discovery.json", requestBodyAgainstCollector)
 	})
 }
 
@@ -79,7 +80,7 @@ func (suite *PublishingTestSuite) TestCollectorClient_PublishingSubscriptionDisc
 	discoveredSubscriptions := mocks.NewDiscoveredSubscriptionsMock()
 
 	suite.runDiscoveryScenario(discoveryType, discoveredSubscriptions, func(requestBodyAgainstCollector string) {
-		suite.assertJsonMatchesJsonFileContent("../../../test/fixtures/discovery/subscriptions/expected_published_subscriptions_discovery.json", requestBodyAgainstCollector)
+		suite.assertJsonMatchesJsonFileContent("./test/fixtures/discovery/subscriptions/expected_published_subscriptions_discovery.json", requestBodyAgainstCollector)
 	})
 }
 

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -7,7 +7,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/agent/discovery/collector"
-	"github.com/trento-project/trento/agent/discovery/models"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
 	"github.com/trento-project/trento/version"
@@ -50,7 +49,7 @@ func (h HostDiscovery) Discover() (string, error) {
 	var si sysinfo.SysInfo
 	si.GetSysInfo()
 
-	host := models.DiscoveredHost{
+	host := hosts.DiscoveredHost{
 		HostIpAddresses: ipAddresses,
 		HostName:        h.discovery.host,
 		CPUCount:        int(si.CPU.Cpus) * int(si.CPU.Cores),

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -50,6 +50,7 @@ func (h HostDiscovery) Discover() (string, error) {
 	si.GetSysInfo()
 
 	host := hosts.DiscoveredHost{
+		OSVersion:       si.OS.Version,
 		HostIpAddresses: ipAddresses,
 		HostName:        h.discovery.host,
 		CPUCount:        int(si.CPU.Cpus) * int(si.CPU.Cores),

--- a/agent/discovery/mocks/discovered_cloud_mock.go
+++ b/agent/discovery/mocks/discovered_cloud_mock.go
@@ -11,7 +11,7 @@ import (
 func NewDiscoveredCloudMock() cloud.CloudInstance {
 	metadata := &cloud.AzureMetadata{}
 
-	jsonFile, err := os.Open("../../../test/fixtures/discovery/azure/azure_discovery.json")
+	jsonFile, err := os.Open("./test/fixtures/discovery/azure/azure_discovery.json")
 	if err != nil {
 		panic(err)
 	}

--- a/agent/discovery/mocks/discovered_cluster_mock.go
+++ b/agent/discovery/mocks/discovered_cluster_mock.go
@@ -4,11 +4,11 @@ import "github.com/trento-project/trento/internal/cluster"
 
 func NewDiscoveredClusterMock() cluster.Cluster {
 	cluster, _ := cluster.NewClusterWithDiscoveryTools(&cluster.DiscoveryTools{
-		CibAdmPath:      "../../../test/fake_cibadmin.sh",
-		CrmmonAdmPath:   "../../../test/fake_crm_mon.sh",
-		CorosyncKeyPath: "../../../test/authkey",
-		SBDPath:         "../../../test/fake_sbd.sh",
-		SBDConfigPath:   "../../../test/sbd_config",
+		CibAdmPath:      "./test/fake_cibadmin.sh",
+		CrmmonAdmPath:   "./test/fake_crm_mon.sh",
+		CorosyncKeyPath: "./test/authkey",
+		SBDPath:         "./test/fake_sbd.sh",
+		SBDConfigPath:   "./test/sbd_config",
 	})
 
 	return cluster

--- a/agent/discovery/mocks/discovered_host_mock.go
+++ b/agent/discovery/mocks/discovered_host_mock.go
@@ -1,11 +1,9 @@
 package mocks
 
-import (
-	"github.com/trento-project/trento/agent/discovery/models"
-)
+import "github.com/trento-project/trento/internal/hosts"
 
-func NewDiscoveredHostMock() models.DiscoveredHost {
-	return models.DiscoveredHost{
+func NewDiscoveredHostMock() hosts.DiscoveredHost {
+	return hosts.DiscoveredHost{
 		HostIpAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
 		HostName:        "thehostnamewherethediscoveryhappened",
 		CPUCount:        64,

--- a/agent/discovery/mocks/discovered_host_mock.go
+++ b/agent/discovery/mocks/discovered_host_mock.go
@@ -4,6 +4,7 @@ import "github.com/trento-project/trento/internal/hosts"
 
 func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	return hosts.DiscoveredHost{
+		OSVersion:       "15.3",
 		HostIpAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
 		HostName:        "thehostnamewherethediscoveryhappened",
 		CPUCount:        64,

--- a/agent/discovery/mocks/discovered_subscription_mock.go
+++ b/agent/discovery/mocks/discovered_subscription_mock.go
@@ -11,7 +11,7 @@ import (
 func NewDiscoveredSubscriptionsMock() subscription.Subscriptions {
 	var subs subscription.Subscriptions
 
-	jsonFile, err := os.Open("../../../test/fixtures/discovery/subscriptions/subscriptions_discovery.json")
+	jsonFile, err := os.Open("./test/fixtures/discovery/subscriptions/subscriptions_discovery.json")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/hosts/discovered_host.go
+++ b/internal/hosts/discovered_host.go
@@ -1,4 +1,4 @@
-package models
+package hosts
 
 type DiscoveredHost struct {
 	HostIpAddresses []string `json:"ip_addresses"`

--- a/internal/hosts/discovered_host.go
+++ b/internal/hosts/discovered_host.go
@@ -1,6 +1,7 @@
 package hosts
 
 type DiscoveredHost struct {
+	OSVersion       string   `json:"os_version"`
 	HostIpAddresses []string `json:"ip_addresses"`
 	HostName        string   `json:"hostname"`
 	CPUCount        int      `json:"cpu_count"`

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -2,6 +2,7 @@
     "agent_id": "the-machine-id",
     "discovery_type": "host_discovery",
     "payload": {
+        "os_version": "15.3",
         "ip_addresses": [
             "10.1.1.4",
             "10.1.1.5",

--- a/test/testing.go
+++ b/test/testing.go
@@ -1,0 +1,17 @@
+package test
+
+import (
+	"os"
+	"path"
+	"runtime"
+)
+
+// importing _ "github.com/trento-project/trento/test" in tests would set the cwd to the root of the repo
+func init() {
+	_, filename, _, _ := runtime.Caller(0)
+	dir := path.Join(path.Dir(filename), "..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/web/app.go
+++ b/web/app.go
@@ -107,7 +107,8 @@ func DefaultDependencies(config *Config) Dependencies {
 func MigrateDB(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{}, models.CheckRaw{},
-		models.Cluster{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{})
+		models.Cluster{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{}, models.HostTelemetry{})
+
 	if err != nil {
 		return err
 	}

--- a/web/datapipeline/clusters_projector_test.go
+++ b/web/datapipeline/clusters_projector_test.go
@@ -25,7 +25,7 @@ func TestClustersProjector_ClusterDiscoveryHandler(t *testing.T) {
 		ClusterType: models.ClusterTypeUnknown,
 	})
 
-	jsonFile, err := os.Open("../../test/fixtures/cluster_discovery_hana_scale_up.json")
+	jsonFile, err := os.Open("./test/fixtures/cluster_discovery_hana_scale_up.json")
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ func TestClustersProjector_ClusterDiscoveryHandler(t *testing.T) {
 }
 
 func TestTransformClusterListData_HANAScaleUp(t *testing.T) {
-	jsonFile, err := os.Open("../../test/fixtures/cluster_discovery_hana_scale_up.json")
+	jsonFile, err := os.Open("./test/fixtures/cluster_discovery_hana_scale_up.json")
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +76,7 @@ func TestTransformClusterListData_HANAScaleUp(t *testing.T) {
 }
 
 func TestTransformClusterListData_Unknown(t *testing.T) {
-	jsonFile, err := os.Open("../../test/fixtures/cluster_discovery_unknown.json")
+	jsonFile, err := os.Open("./test/fixtures/cluster_discovery_unknown.json")
 	if err != nil {
 		panic(err)
 	}

--- a/web/datapipeline/data_collected_event.go
+++ b/web/datapipeline/data_collected_event.go
@@ -9,8 +9,11 @@ import (
 )
 
 const (
-	ClusterDiscovery   = "ha_cluster_discovery"
-	SAPsystemDiscovery = "sap_system_discovery"
+	ClusterDiscovery      = "ha_cluster_discovery"
+	SAPsystemDiscovery    = "sap_system_discovery"
+	HostDiscovery         = "host_discovery"
+	SubscriptionDiscovery = "subscription_discovery"
+	CloudDiscovery        = "cloud_discovery"
 )
 
 type DataCollectedEvent struct {

--- a/web/datapipeline/host_telemetry_projector.go
+++ b/web/datapipeline/host_telemetry_projector.go
@@ -1,0 +1,106 @@
+package datapipeline
+
+import (
+	"bytes"
+	"encoding/json"
+
+	log "github.com/sirupsen/logrus"
+	discoveryModels "github.com/trento-project/trento/agent/discovery/models"
+	"github.com/trento-project/trento/internal/cloud"
+	"github.com/trento-project/trento/internal/subscription"
+	"github.com/trento-project/trento/web/models"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func NewHostTelemetryProjector(db *gorm.DB) *projector {
+	telemetryProjector := NewProjector("host_telemetry", db)
+
+	telemetryProjector.AddHandler(HostDiscovery, hostTelemetryProjector_HostDiscoveryHandler)
+	telemetryProjector.AddHandler(CloudDiscovery, hostTelemetryProjector_CloudDiscoveryHandler)
+	telemetryProjector.AddHandler(SubscriptionDiscovery, hostTelemetryProjector_SubscriptionDiscoveryHandler)
+
+	return telemetryProjector
+}
+
+func hostTelemetryProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent, db *gorm.DB) error {
+	decoder := payloadDecoder(dataCollectedEvent.Payload)
+
+	var discoveredHost discoveryModels.DiscoveredHost
+	if err := decoder.Decode(&discoveredHost); err != nil {
+		log.Errorf("can't decode data: %s", err)
+		return err
+	}
+
+	telemetryReadModel := models.HostTelemetry{
+		AgentID:       dataCollectedEvent.AgentID,
+		HostName:      discoveredHost.HostName,
+		CPUCount:      discoveredHost.CPUCount,
+		SocketCount:   discoveredHost.SocketCount,
+		TotalMemoryMB: discoveredHost.TotalMemoryMB,
+	}
+
+	return storeHostTelemetry(db, telemetryReadModel,
+		"host_name",
+		"cpu_count",
+		"socket_count",
+		"total_memory_mb",
+	)
+}
+
+func hostTelemetryProjector_CloudDiscoveryHandler(dataCollectedEvent *DataCollectedEvent, db *gorm.DB) error {
+	decoder := payloadDecoder(dataCollectedEvent.Payload)
+
+	var discoveredCloud cloud.CloudInstance
+	if err := decoder.Decode(&discoveredCloud); err != nil {
+		log.Errorf("can't decode data: %s", err)
+		return err
+	}
+
+	telemetryReadModel := models.HostTelemetry{
+		AgentID:       dataCollectedEvent.AgentID,
+		CloudProvider: discoveredCloud.Provider,
+	}
+
+	return storeHostTelemetry(db, telemetryReadModel, "cloud_provider")
+}
+
+func hostTelemetryProjector_SubscriptionDiscoveryHandler(dataCollectedEvent *DataCollectedEvent, db *gorm.DB) error {
+	decoder := payloadDecoder(dataCollectedEvent.Payload)
+
+	var discoveredSubscription subscription.Subscriptions
+
+	if err := decoder.Decode(&discoveredSubscription); err != nil {
+		log.Errorf("can't decode data: %s", err)
+		return err
+	}
+
+	if len(discoveredSubscription) == 0 {
+		return nil
+	}
+
+	telemetryReadModel := models.HostTelemetry{
+		AgentID:     dataCollectedEvent.AgentID,
+		SLESVersion: discoveredSubscription[0].Version,
+	}
+
+	return storeHostTelemetry(db, telemetryReadModel, "sles_version")
+}
+
+func payloadDecoder(payload datatypes.JSON) *json.Decoder {
+	data, _ := payload.MarshalJSON()
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+
+	return decoder
+}
+
+func storeHostTelemetry(db *gorm.DB, telemetryReadModel models.HostTelemetry, updateColumns ...string) error {
+	return db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "agent_id"},
+		},
+		DoUpdates: clause.AssignmentColumns(updateColumns),
+	}).Create(&telemetryReadModel).Error
+}

--- a/web/datapipeline/host_telemetry_projector.go
+++ b/web/datapipeline/host_telemetry_projector.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 
 	log "github.com/sirupsen/logrus"
-	discoveryModels "github.com/trento-project/trento/agent/discovery/models"
 	"github.com/trento-project/trento/internal/cloud"
+	"github.com/trento-project/trento/internal/hosts"
 	"github.com/trento-project/trento/internal/subscription"
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/datatypes"
@@ -27,7 +27,7 @@ func NewHostTelemetryProjector(db *gorm.DB) *projector {
 func hostTelemetryProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent, db *gorm.DB) error {
 	decoder := payloadDecoder(dataCollectedEvent.Payload)
 
-	var discoveredHost discoveryModels.DiscoveredHost
+	var discoveredHost hosts.DiscoveredHost
 	if err := decoder.Decode(&discoveredHost); err != nil {
 		log.Errorf("can't decode data: %s", err)
 		return err

--- a/web/datapipeline/host_telemetry_projector_test.go
+++ b/web/datapipeline/host_telemetry_projector_test.go
@@ -1,0 +1,131 @@
+package datapipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/trento-project/trento/agent/discovery/mocks"
+
+	"github.com/stretchr/testify/suite"
+	_ "github.com/trento-project/trento/test"
+	"github.com/trento-project/trento/test/helpers"
+	"github.com/trento-project/trento/web/models"
+	"gorm.io/gorm"
+)
+
+type HostTelemetryProjectorTestSuite struct {
+	suite.Suite
+	db *gorm.DB
+	tx *gorm.DB
+}
+
+func TestHostTelemetryProjectorTestSuite(t *testing.T) {
+	suite.Run(t, new(HostTelemetryProjectorTestSuite))
+}
+
+func (suite *HostTelemetryProjectorTestSuite) SetupSuite() {
+	suite.db = helpers.SetupTestDatabase(suite.T())
+
+	suite.db.AutoMigrate(&Subscription{}, &models.HostTelemetry{})
+}
+
+func (suite *HostTelemetryProjectorTestSuite) TearDownSuite() {
+	suite.db.Migrator().DropTable(Subscription{}, models.HostTelemetry{})
+}
+
+func (suite *HostTelemetryProjectorTestSuite) SetupTest() {
+	suite.tx = suite.db.Begin()
+}
+
+func (suite *HostTelemetryProjectorTestSuite) TearDownTest() {
+	suite.tx.Rollback()
+}
+
+// Test_HostDiscoveryHandler tests the HostDiscoveryHandler function execution on a HostDiscovery published by an agent
+func (s *HostTelemetryProjectorTestSuite) Test_HostDiscoveryHandler() {
+	discoveredHostMock := mocks.NewDiscoveredHostMock()
+
+	requestBody, _ := json.Marshal(discoveredHostMock)
+
+	hostTelemetryProjector_HostDiscoveryHandler(&DataCollectedEvent{
+		ID:            1,
+		AgentID:       "agent_id",
+		DiscoveryType: HostDiscovery,
+		Payload:       requestBody,
+	}, s.tx)
+
+	var projectedTelemetry models.HostTelemetry
+	s.tx.First(&projectedTelemetry)
+
+	s.Equal(discoveredHostMock.HostName, projectedTelemetry.HostName)
+	s.Equal(discoveredHostMock.CPUCount, projectedTelemetry.CPUCount)
+	s.Equal(discoveredHostMock.SocketCount, projectedTelemetry.SocketCount)
+	s.Equal(discoveredHostMock.TotalMemoryMB, projectedTelemetry.TotalMemoryMB)
+	s.Equal(discoveredHostMock.OSVersion, projectedTelemetry.SLESVersion)
+	s.Equal("", projectedTelemetry.CloudProvider)
+}
+
+// Test_CloudDiscoveryHandler tests the loudDiscoveryHandler function execution on a CloudDiscovery published by an agent
+func (s *HostTelemetryProjectorTestSuite) Test_CloudDiscoveryHandler() {
+	discoveredCloudMock := mocks.NewDiscoveredCloudMock()
+
+	requestBody, _ := json.Marshal(discoveredCloudMock)
+
+	hostTelemetryProjector_CloudDiscoveryHandler(&DataCollectedEvent{
+		ID:            1,
+		AgentID:       "agent_id",
+		DiscoveryType: CloudDiscovery,
+		Payload:       requestBody,
+	}, s.tx)
+
+	var projectedTelemetry models.HostTelemetry
+	s.tx.First(&projectedTelemetry)
+
+	s.Equal("", projectedTelemetry.HostName)
+	s.Equal(0, projectedTelemetry.CPUCount)
+	s.Equal(0, projectedTelemetry.SocketCount)
+	s.Equal(0, projectedTelemetry.TotalMemoryMB)
+	s.Equal("", projectedTelemetry.SLESVersion)
+
+	expectedCloudProvider := discoveredCloudMock.Provider
+	s.Equal(expectedCloudProvider, projectedTelemetry.CloudProvider)
+}
+
+// Test_TelemetryProjector tests the TelemetryProjector projects all of the discoveries it is interested in, resulting in a single telemetry readmodel
+func (s *HostTelemetryProjectorTestSuite) Test_TelemetryProjector() {
+	telemetryProjector := NewHostTelemetryProjector(s.tx)
+
+	discoveredCloudMock := mocks.NewDiscoveredCloudMock()
+	discoveredHostMock := mocks.NewDiscoveredHostMock()
+
+	agentDiscoveries := make(map[string]interface{})
+	agentDiscoveries[CloudDiscovery] = discoveredCloudMock
+	agentDiscoveries[HostDiscovery] = discoveredHostMock
+
+	evtID := int64(1)
+
+	for discoveryType, discoveredData := range agentDiscoveries {
+		requestBody, _ := json.Marshal(discoveredData)
+
+		telemetryProjector.Project(&DataCollectedEvent{
+			ID:            evtID,
+			AgentID:       "agent_id",
+			DiscoveryType: discoveryType,
+			Payload:       requestBody,
+		})
+		evtID++
+	}
+
+	var projectedTelemetry models.HostTelemetry
+	s.tx.First(&projectedTelemetry)
+
+	s.Equal(discoveredHostMock.HostName, projectedTelemetry.HostName)
+	s.Equal(discoveredHostMock.CPUCount, projectedTelemetry.CPUCount)
+	s.Equal(discoveredHostMock.SocketCount, projectedTelemetry.SocketCount)
+	s.Equal(discoveredHostMock.TotalMemoryMB, projectedTelemetry.TotalMemoryMB)
+
+	s.Equal(discoveredHostMock.OSVersion, projectedTelemetry.SLESVersion)
+
+	expectedCloudProvider := discoveredCloudMock.Provider
+	s.Equal(expectedCloudProvider, projectedTelemetry.CloudProvider)
+}

--- a/web/datapipeline/projector_registry.go
+++ b/web/datapipeline/projector_registry.go
@@ -6,8 +6,8 @@ type ProjectorRegistry []Projector
 
 // InitInitProjectorsRegistry initialize the ProjectorRegistry
 func InitProjectorsRegistry(db *gorm.DB) ProjectorRegistry {
-
 	return ProjectorRegistry{
 		NewClustersProjector(db),
+		NewHostTelemetryProjector(db),
 	}
 }

--- a/web/models/host_telemetry.go
+++ b/web/models/host_telemetry.go
@@ -1,0 +1,18 @@
+package models
+
+import "time"
+
+type HostTelemetry struct {
+	AgentID       string    `gorm:"column:agent_id; primaryKey"`
+	HostName      string    `gorm:"column:host_name"`
+	SLESVersion   string    `gorm:"column:sles_version"`
+	CPUCount      int       `gorm:"column:cpu_count"`
+	SocketCount   int       `gorm:"column:socket_count"`
+	TotalMemoryMB int       `gorm:"column:total_memory_mb"`
+	CloudProvider string    `gorm:"column:cloud_provider"`
+	UpdatedAt     time.Time `gorm:"column:updated_at"`
+}
+
+func (HostTelemetry) TableName() string {
+	return "host_telemetry"
+}


### PR DESCRIPTION
This PR adds a Projector for the required Telemetry information.

HostName
SLESVersion
CPUCount
SocketCount
TotalMemoryMB
CloudProvider

This works also as a PoC for projecting the Hosts as a replacement for Consul Catalog.

---
Extra:

By adding a
```
_ "github.com/trento-project/trento/test"
```

we can consider the `cwd` for our tests being the project root, which allows to simplify path specification in tests and allows us to reuse mocks.

Example

`NewDiscoveredCloudMock` in `agent/discovery/mocks/discovered_cloud_mock.go` is used as a source for mocks in two different places

- `agent/discovery/collector/publishing_test.go`
- `web/datapipeline/telemetry_projector_test.go`

Without the trick it would't have been possible to reuse the same `NewDiscoveredCloudMock` because, in respect of the caller executor (`publishing_test.go` or `telemetry_projector_test.go`) it would have required to load the same file from a different relative location.

So,
calling `NewDiscoveredCloudMock` from `agent/discovery/collector/publishing_test.go` would require loading the fixture from `../../../test/fixtures/discovery/azure/azure_discovery.json`

while calling `NewDiscoveredCloudMock` from `web/datapipeline/telemetry_projector_test.go` would require loading the fixture from `../../test/fixtures/discovery/azure/azure_discovery.json`

Note the difference `../../../` vs `../../`

with this trick we can consider the cwd as the root of the project so the path to be loaded would always be the same
`./test/fixtures/discovery/azure/azure_discovery.json`

Hope it makes sense.

---

What's next:
For telemetry: spike with the team on opentelemetry/promscale/timescale
For consul migration: this opens doors for consul Host catalog replacement by projecting hosts and defining Heartbeat and healthcheck