### PR TITLE
Using correct mocked value for discovered cloud

### DIFF
--- a/agent/discovery/mocks/discovered_cloud_mock.go
+++ b/agent/discovery/mocks/discovered_cloud_mock.go
@@ -20,7 +20,7 @@ func NewDiscoveredCloudMock() cloud.CloudInstance {
 	json.Unmarshal(byteValue, metadata)
 
 	return cloud.CloudInstance{
-		Provider: "7783-7084-3265-9085-8269-3286-77",
+		Provider: cloud.Azure,
 		Metadata: metadata,
 	}
 }

--- a/test/fixtures/discovery/azure/expected_published_cloud_discovery.json
+++ b/test/fixtures/discovery/azure/expected_published_cloud_discovery.json
@@ -2,7 +2,7 @@
     "agent_id":"the-machine-id",
     "discovery_type":"cloud_discovery",
     "payload":{
-       "Provider":"7783-7084-3265-9085-8269-3286-77",
+       "Provider":"azure",
        "Metadata":{
           "compute":{
              "azEnvironment":"AzurePublicCloud",


### PR DESCRIPTION
Fixing overlooked transformation that is happening in the agent side, related to Cloud discovery.

What is being published by the agent is `azure` instead of `some-weird-id`