### PR TITLE
Forcing refreshing updated_at information of the HostTelemetry

### DIFF
--- a/web/datapipeline/host_telemetry_projector.go
+++ b/web/datapipeline/host_telemetry_projector.go
@@ -79,6 +79,6 @@ func storeHostTelemetry(db *gorm.DB, telemetryReadModel models.HostTelemetry, up
 		Columns: []clause.Column{
 			{Name: "agent_id"},
 		},
-		DoUpdates: clause.AssignmentColumns(updateColumns),
+		DoUpdates: clause.AssignmentColumns(append(updateColumns, "updated_at")),
 	}).Create(&telemetryReadModel).Error
 }


### PR DESCRIPTION
In order to know when a projected read model has been reprojected, even if no changes applied, we force to always update also the `updated_at` property.