### PR TITLE
Opened Resource cleanup in fixtures

### DIFF
--- a/agent/discovery/mocks/discovered_cloud_mock.go
+++ b/agent/discovery/mocks/discovered_cloud_mock.go
@@ -15,6 +15,7 @@ func NewDiscoveredCloudMock() cloud.CloudInstance {
 	if err != nil {
 		panic(err)
 	}
+	defer jsonFile.Close()
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 
 	json.Unmarshal(byteValue, metadata)

--- a/agent/discovery/mocks/discovered_subscription_mock.go
+++ b/agent/discovery/mocks/discovered_subscription_mock.go
@@ -15,6 +15,7 @@ func NewDiscoveredSubscriptionsMock() subscription.Subscriptions {
 	if err != nil {
 		panic(err)
 	}
+	defer jsonFile.Close()
 	byteValue, _ := ioutil.ReadAll(jsonFile)
 
 	json.Unmarshal(byteValue, &subs)


### PR DESCRIPTION
Added some `defer thing.Close()` in our fixtures.
I am not completely sure it's a big issue, but I wanted to have it at least in these mocks I wrote.