### PR TITLE
Use Agent UUID from machine id

### DIFF
--- a/agent/discovery/collector/client_test.go
+++ b/agent/discovery/collector/client_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/trento-project/trento/test/helpers"
 )
 
+const (
+	DummyMachineID = "dummy-machine-id"
+	DummyAgentID   = "779cdd70-e9e2-58ca-b18a-bf3eb3f71244"
+)
+
 type CollectorClientTestSuite struct {
 	suite.Suite
 }
@@ -25,7 +30,7 @@ func TestCollectorClientTestSuite(t *testing.T) {
 func (suite *CollectorClientTestSuite) SetupSuite() {
 	fileSystem = afero.NewMemMapFs()
 
-	afero.WriteFile(fileSystem, machineIdPath, []byte("the-machine-id"), 0644)
+	afero.WriteFile(fileSystem, machineIdPath, []byte(DummyMachineID), 0644)
 
 	// this is read by an env variable called TRENTO_COLLECTOR_ENABLED
 	viper.Set("collector-enabled", true)
@@ -84,11 +89,10 @@ func (suite *CollectorClientTestSuite) TestCollectorClient_PublishingSuccess() {
 	}
 
 	discoveryType := "the_discovery_type"
-	agentID := "the-machine-id"
 
 	collectorClient.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
 		requestBody, _ := json.Marshal(map[string]interface{}{
-			"agent_id":       agentID,
+			"agent_id":       DummyAgentID,
 			"discovery_type": discoveryType,
 			"payload":        discoveredDataPayload,
 		})

--- a/agent/discovery/collector/publishing_test.go
+++ b/agent/discovery/collector/publishing_test.go
@@ -28,7 +28,7 @@ func TestPublishingTestSuite(t *testing.T) {
 func (suite *PublishingTestSuite) SetupSuite() {
 	fileSystem = afero.NewMemMapFs()
 
-	afero.WriteFile(fileSystem, machineIdPath, []byte("the-machine-id"), 0644)
+	afero.WriteFile(fileSystem, machineIdPath, []byte(DummyMachineID), 0644)
 
 	// this is read by an env variable called TRENTO_COLLECTOR_ENABLED
 	viper.Set("collector-enabled", true)
@@ -87,13 +87,11 @@ func (suite *PublishingTestSuite) TestCollectorClient_PublishingSubscriptionDisc
 type AssertionFunc func(requestBodyAgainstCollector string)
 
 func (suite *PublishingTestSuite) runDiscoveryScenario(discoveryType string, payload interface{}, assertion AssertionFunc) {
-	agentID := "the-machine-id"
-
 	collectorClient := suite.configuredClient
 
 	collectorClient.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
 		requestBody, _ := json.Marshal(map[string]interface{}{
-			"agent_id":       agentID,
+			"agent_id":       DummyAgentID,
 			"discovery_type": discoveryType,
 			"payload":        payload,
 		})

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/consul-template v0.25.2
 	github.com/hashicorp/consul/api v1.4.0
 	github.com/hooklift/gowsdl v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,7 @@ github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -110,6 +111,7 @@ github.com/frankban/quicktest v1.4.0/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/gzip v0.0.1 h1:ezvKOL6jH+jlzdHNE4h9h8q8uMpDQjyl0NN0Jd7jozc=
 github.com/gin-contrib/gzip v0.0.1/go.mod h1:fGBJBCdt6qCZuCAOwWuFhBB4OOq9EFqlo5dEaFhhu5w=
@@ -206,6 +208,8 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
@@ -560,6 +564,7 @@ github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OK
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
 github.com/rs/zerolog v1.18.0 h1:CbAm3kP2Tptby1i9sYy2MGRg0uxIN9cyDb59Ys7W8z8=
 github.com/rs/zerolog v1.18.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -573,6 +578,7 @@ github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9Nz
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -645,7 +651,9 @@ github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLY
 github.com/ugorji/go/codec v1.1.13 h1:013LbFhocBoIqgHeIHKlV4JWYhqogATYWZhIcH0WHn4=
 github.com/ugorji/go/codec v1.1.13/go.mod h1:oNVt3Dq+FO91WNQ/9JnHKQP2QJxTzoN7wCBFCq1OeuU=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.1 h1:+mkCCcOFKPnCmVYVcURKps1Xe+3zP90gSYGNfRkjoIY=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/vektra/mockery/v2 v2.9.0 h1:+3FhCL3EviR779mTzXwUuhPNnqFUA7sDnt9OFkXaFd4=
 github.com/vektra/mockery/v2 v2.9.0/go.mod h1:2gU4Cf/f8YyC8oEaSXfCnZBMxMjMl/Ko205rlP0fO90=

--- a/internal/uuid.go
+++ b/internal/uuid.go
@@ -1,0 +1,5 @@
+package internal
+
+import "github.com/google/uuid"
+
+var TrentoNamespace = uuid.Must(uuid.Parse("fb92284e-aa5e-47f6-a883-bf9469e7a0dc"))

--- a/test/fixtures/discovery/azure/expected_published_cloud_discovery.json
+++ b/test/fixtures/discovery/azure/expected_published_cloud_discovery.json
@@ -1,5 +1,5 @@
 {
-    "agent_id":"the-machine-id",
+    "agent_id":"779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type":"cloud_discovery",
     "payload":{
        "Provider":"azure",

--- a/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
+++ b/test/fixtures/discovery/cluster/expected_published_cluster_discovery.json
@@ -1,5 +1,5 @@
 {
-    "agent_id": "the-machine-id",
+    "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type": "ha_cluster_discovery",
     "payload": {
         "Cib": {

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -1,5 +1,5 @@
 {
-    "agent_id": "the-machine-id",
+    "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type": "host_discovery",
     "payload": {
         "os_version": "15.3",

--- a/test/fixtures/discovery/subscriptions/expected_published_subscriptions_discovery.json
+++ b/test/fixtures/discovery/subscriptions/expected_published_subscriptions_discovery.json
@@ -1,5 +1,5 @@
 {
-    "agent_id": "the-machine-id",
+    "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type": "subscription_discovery",
     "payload": [
         {


### PR DESCRIPTION
With this PR we create anAgentID which is a UUID ceated from the content in `/etc/machine-id`.

The created UUID will be the same for the same machineID content given.

We have uuid and uniqueness of agent identifier.

Closes https://github.com/trento-project/trento/issues/425