### PR TITLE
Allow Agent rpm to run with config file

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -222,7 +222,6 @@ jobs:
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_REPO_OWNER: ${{ github.repository_owner }}
-      TRENTO_COLLECTOR_ENABLED: ${{ secrets.TRENTO_COLLECTOR_ENABLED }}
     steps:
       - uses: actions/checkout@v2
       - name: install and enable agents
@@ -230,8 +229,6 @@ jobs:
           set -ex
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
           do
-            ssh "$TRENTO_USER@$target_host" "sudo systemctl set-environment TRENTO_COLLECTOR_ENABLED=$TRENTO_COLLECTOR_ENABLED"
-            ssh "$TRENTO_USER@$target_host" "sudo systemctl set-environment TRENTO_COLLECTOR_HOST=$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--agent-bind-ip" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ of existing clusters, rather than deploying new one.
       - [Setting up and starting ARA](#setting-up-and-starting-ara)
       - [Starting the Trento Runner](#starting-the-trento-runner)
     + [Trento Web UI](#trento-web-ui)
+- [Configuration](#configuration)
 - [Development](#development)
   * [Helm development chart](#helm-development-chart)
   * [Build system](#build-system)
@@ -444,6 +445,89 @@ At this point, we can start the web application as follows:
 ```
 
 Please consult the `help` CLI command for more insights on the various options.
+
+
+# Configuration
+
+Trento can be run with a config file in replacement of command-line arguments.
+
+## Locations
+Configuration, if not otherwise specified by the `--config=/path/to/config.yaml` option, would be searched in following locations:
+
+Note that order represents priority
+
+- `/etc/trento/` <-- first location looked
+- `/usr/etc/trento/` <-- fallback here if config not found in previous location
+- `~/.config/trento/` aka user's home <-- fallback here
+
+## Formats
+
+`yaml` is the only supported format at the moment.
+
+
+## Naming conventions
+Each component of trento supports its own configuration, so the expected config files in the chosen location must be called after the component it is supporting.
+
+So supported names are `(agent|web|runner).yaml`
+
+Example locations:
+
+`/etc/trento/agent.yaml`
+
+`/etc/trento/web.yaml`
+
+`/etc/trento/runner.yaml`
+
+or 
+
+`/usr/etc/trento/agent.yaml`
+
+`/usr/etc/trento/web.yaml`
+
+`/usr/etc/trento/runner.yaml`
+
+**Note**: `runner` still not supported for now
+
+## Examples
+
+```
+# /etc/trento/agent.yaml
+
+enable-mtls: true
+cert: /path/to/certs/client-cert.pem
+key: /path/to/certs/client-key.pem
+ca: /path/to/certs/ca-cert.pem
+collector-host: localhost
+collector-port: 8443
+```
+
+```
+# /etc/trento/web.yaml
+
+db-port: 5432
+
+collector-port: 8443
+enable-mtls: true
+cert: /path/to/certs/server-cert.pem
+key: /path/to/certs/server-key.pem
+ca: /path/to/certs/ca-cert.pem
+```
+
+## Environment Variables
+
+All of the options supported by the command line and configuration file can be provided as environment variables as well.
+
+The rule is: get the option name eg. `enable-mtls`, replace dashes `-` with underscores `_`, make it uppercase and add a `TRENTO_` prefix.
+
+Examples:
+
+`enable-mtls` -> `TRENTO_ENABLE_MTLS=true ./trento agent start`
+
+`collector-host` -> `TRENTO_COLLECTOR_HOST=localhost ./trento web serve`
+
+`cert` -> `TRENTO_CERT=/path/to/certs/server-cert.pem ./trento web serve`
+
+
 
 # Development
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -12,20 +12,20 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/trento-project/trento/agent"
+	"github.com/trento-project/trento/internal"
 )
 
-var consulConfigDir string
-var discoveryPeriod int
-
-var collectorHost string
-var collectorPort int
-
-var enablemTLS bool
-var cert string
-var key string
-var ca string
-
 func NewAgentCmd() *cobra.Command {
+	var consulConfigDir string
+	var discoveryPeriod int
+
+	var collectorHost string
+	var collectorPort int
+
+	var enablemTLS bool
+	var cert string
+	var key string
+	var ca string
 
 	agentCmd := &cobra.Command{
 		Use:   "agent",
@@ -36,6 +36,9 @@ func NewAgentCmd() *cobra.Command {
 		Use:   "start",
 		Short: "Start the agent",
 		Run:   start,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return internal.InitConfig("agent")
+		},
 	}
 	startCmd.Flags().StringVarP(&consulConfigDir, "consul-config-dir", "", "consul.d", "Consul configuration directory used to store node meta-data")
 	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 2, "Discovery mechanism loop period on minutes")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,23 +1,15 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"strings"
-
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/viper"
 
 	"github.com/trento-project/trento/cmd/agent"
 	"github.com/trento-project/trento/cmd/runner"
 	"github.com/trento-project/trento/cmd/web"
-	"github.com/trento-project/trento/internal"
 )
-
-var cfgFile string
-var logLevel string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -34,41 +26,18 @@ func Execute() {
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
+	var cfgFile string
+	var logLevel string
+
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.trento.yaml)")
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "then minimum severity (error, warn, info, debug) of logs to output")
 
-	// Make log-level available in the children commands
-	viper.BindPFlag("log-level", rootCmd.PersistentFlags().Lookup("log-level"))
+	// Make global flags available in the children commands
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		viper.BindPFlag(f.Name, f)
+	})
 
 	rootCmd.AddCommand(web.NewWebCmd())
 	rootCmd.AddCommand(agent.NewAgentCmd())
 	rootCmd.AddCommand(runner.NewRunnerCmd())
-}
-
-// initConfig reads in config file and ENV variables if set.
-func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		cobra.CheckErr(err)
-
-		// Search config in home directory with name ".trento" (without extension).
-		viper.AddConfigPath(home)
-		viper.SetConfigName(".trento")
-	}
-
-	internal.SetLogLevel(logLevel)
-	internal.SetLogFormatter("2006-01-02 15:04:05")
-	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
-	viper.SetEnvPrefix("TRENTO")
-	viper.AutomaticEnv() // read in environment variables that match
-
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err == nil {
-		_, _ = fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
 }

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -11,12 +11,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"github.com/trento-project/trento/internal"
 	"github.com/trento-project/trento/internal/db"
 	"github.com/trento-project/trento/web"
 	"github.com/trento-project/trento/web/datapipeline"
 )
 
 func NewWebCmd() *cobra.Command {
+
 	var dbHost string
 	var dbPort string
 	var dbUser string
@@ -26,6 +28,9 @@ func NewWebCmd() *cobra.Command {
 	webCmd := &cobra.Command{
 		Use:   "web",
 		Short: "Command tree related to the web application component",
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			return internal.InitConfig("web")
+		},
 	}
 
 	webCmd.PersistentFlags().StringVar(&dbHost, "db-host", "localhost", "The database host")

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -113,6 +113,11 @@ Type=notify
 [Install]
 WantedBy=multi-user.target'
 
+AGENT_CONFIG_PATH="/etc/trento/agent.yaml"
+AGENT_CONFIG_TEMPLATE='
+collector-host: @COLLECTOR_HOST@
+'
+
 . /etc/os-release
 if [[ ! $PRETTY_NAME =~ "SUSE" ]]; then
     echo "Warning: non-SUSE operating system, forcing --use-tgz"
@@ -224,11 +229,20 @@ function install_trento_tgz() {
     rm trento-${ARCH}.tgz
 }
 
+function setup_trento() {
+    echo "* Generating trento-agent config..."
+
+    echo "$AGENT_CONFIG_TEMPLATE" |
+        sed "s|@COLLECTOR_HOST@|${SERVER_IP}|g" \
+            > ${AGENT_CONFIG_PATH}
+}
+
 check_installer_deps
 configure_installation
 install_consul
 setup_consul
 install_trento
+setup_trento
 
 echo -e "\e[92mDone.\e[97m"
 echo -e "Now you can start trento-agent with: \033[1msystemctl start trento-agent\033[0m"

--- a/internal/config.go
+++ b/internal/config.go
@@ -1,0 +1,68 @@
+package internal
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/viper"
+)
+
+// InitConfig intializes the config for the application
+// If no config file is provided with the --config flag
+// it will look for a config in following locations:
+//
+// ${context} being one of the supported components: agent|web|runner
+//
+// Order represents priority
+// /etc/trento/${context}.yaml
+// /usr/etc/trento/${context}.yaml
+// $HOME/.config/trento/${context}.yaml
+func InitConfig(configName string) error {
+	viper.SetConfigType("yaml")
+	SetLogLevel(viper.GetString("log-level"))
+	SetLogFormatter("2006-01-02 15:04:05")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	viper.SetEnvPrefix("TRENTO")
+	viper.AutomaticEnv() // read in environment variables that match
+
+	cfgFile := viper.GetString("config")
+	if cfgFile != "" {
+		_, err := os.Stat(cfgFile)
+
+		if err != nil {
+			// if a config file has been explicitly provided by --config flag,
+			// then we should break if that file does not exist
+			return fmt.Errorf("cannot load configuration file: %s %s", cfgFile, err)
+		}
+
+		// Use config file from the flag.
+		viper.SetConfigFile(cfgFile)
+	} else {
+		// Find home directory.
+		home, err := homedir.Dir()
+
+		if err != nil {
+			return err
+		}
+
+		// if no configuration file was explicitly provided,
+		// we should look for a config in the expected locations
+		viper.AddConfigPath("/etc/trento/")
+		viper.AddConfigPath("/usr/etc/trento/")
+		viper.AddConfigPath(path.Join(home, ".config", "trento"))
+		viper.SetConfigName(configName)
+	}
+
+	err := viper.ReadInConfig()
+
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -1,0 +1,64 @@
+################################################################################
+##                                                                            ##
+##                    $ Trento: Agent configuration $                         ##
+##                                                                            ##
+## This is the configuration for trento when running the agent.               ##
+##                                                                            ##
+## Launching ./trento agent start                                             ##
+##                                                                            ##
+## Looks for the configuration file in one of the following locations.        ##
+##                                                                            ##
+## /etc/trento/       <-- first location looked                               ##
+## /usr/etc/trento/   <-- fallback here if no file in previous location       ##
+## ~/.config/trento/  <-- fallback here if no file in previous location       ##
+##                                                                            ##
+## Priority goes from top to bottom.                                          ##
+## First found file is used, others, if any, are ignored.                     ##
+##                                                                            ##
+## Note: in this case the file must be named agent.yaml                       ##
+##                                                                            ##
+## Otherwise the config file can be explicitly provided via the command line  ##
+##                                                                            ##
+## ./trento agent start --config=/path/to/trento/agent-config.yaml            ##
+##                                                                            ##
+## Note: in this case there is no file name constraint.                       ##
+##                                                                            ##
+################################################################################
+
+
+## Path where Consul auto-loads configuration files: the node meta-data will be stored there as `trento-metadata.json`
+## Legacy, it will be removed in the future
+## defaults to ./consul.d
+
+# consul-config-dir: /srv/consul/consul.d
+
+###############################################################################
+
+## Discovery period configures the tick interval for the discovery loops.
+## Time unit is minutes
+## Defaults to 2.
+
+# discovery-period: 2
+
+###############################################################################
+
+## Application log level
+## Allowed values: error, warn, info, debug
+## defaults to info
+
+# log-level: info
+
+###############################################################################
+
+## Discovered Data Collector endpoint
+
+# collector-host: localhost
+# collector-port: 8081
+
+## Configure whether the communication with the Data Collector should be secured with mTLS
+## defaults to false, if true is provided, certificate configuration is required
+
+# enable-mtls: true
+# cert: /path/to/certs/client-cert.pem
+# key: /path/to/certs/client-key.pem
+# ca: /path/to/certs/ca-cert.pem

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -70,6 +70,9 @@ install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{shortname}"
 # Install the systemd unit
 install -D -m 0644 packaging/systemd/trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
 
+# Install the default configuration files
+install -D -m 0640 packaging/config/agent.yaml %{buildroot}%{_distconfdir}/trento/agent.yaml
+
 %pre
 %service_add_pre trento-agent.service
 
@@ -89,5 +92,8 @@ install -D -m 0644 packaging/systemd/trento-agent.service %{buildroot}%{_unitdir
 %license LICENSE
 %{_bindir}/%{shortname}
 %{_unitdir}/trento-agent.service
+
+%dir %_distconfdir/trento
+%_distconfdir/trento/agent.yaml
 
 %changelog

--- a/packaging/systemd/trento-agent.service
+++ b/packaging/systemd/trento-agent.service
@@ -4,7 +4,7 @@ Requires=consul.service
 After=consul.service
 
 [Service]
-ExecStart=/usr/bin/trento agent start --consul-config-dir=/srv/consul/consul.d
+ExecStart=/usr/bin/trento agent start
 Type=simple
 User=root
 Restart=on-failure


### PR DESCRIPTION
Okay here we go.

This PR introduces usage of configuration files.
FTR: trento was already able to do so thanks to [Viper](https://github.com/spf13/viper) :snake: , now we're starting to leverage it.

What's in here:
- example `agent.yaml` (see following section `On single vs multiple config files`)
- RPM update to bundle this new file
- trento is able to load different config for different contexts (`agent`, `web`, `runner`, ...)
- `install-server.sh` ~~supports a `--generate-config` flag (`false` by default)~~ generates a configuration file in `/usr/etc/trento/agent.yaml`
- pipeline cleanup
- some documentation

<details>
  <summary><b>On single vs multiple config files</b></summary>
     
in relation to having one single config file with namespace here's a thought.
Such a file would be something like:

```
# /usr/etc/trento/trento.yaml

web:
    db-port: 5432
    ...

agent:
    enable-mtls: true
    cert: ./path/to/certs/client-cert.pem
    key: ./path/to/certs/client-key.pem
    ca: ./path/to/certs/ca-cert.pem
    collector-host: localhost
    collector-port: 8443

runner:
    ...
```

If we want to also keep supporting cli flags we're required to:
detect whether a configuration file has been providedor not
access options either by `viper.GetString("collector-host")`  or `viper.GetString("agent.collector-host")`  given the previous condition
If, otherwise, we have different config files they would look like this:

```
# /usr/etc/trento/trento-agent.yaml

enable-mtls: true
cert: ./path/to/certs/client-cert.pem
key: ./path/to/certs/client-key.pem
ca: ./path/to/certs/ca-cert.pem
collector-host: localhost
collector-port: 8443
```
with this, we transparently access to `viper.GetString("collector-host")`  and we do not really care where it comes from, cli or config.
We'd also get clear boundaries.
</details>