### PR TITLE
Fix docker build and makefile introducing a new go-build target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make web-assets
 FROM golang:1.16 as go-build
 COPY --from=node-build /build /build
 WORKDIR /build
-RUN make build
+RUN make go-build
 
 FROM python:3.7-slim AS trento-runner
 RUN ln -s /usr/local/bin/python /usr/bin/python \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,10 @@ default: clean mod-tidy fmt vet-check web-check test build
 
 .PHONY: build
 build: trento
-trento: web-assets
+trento: web-assets go-build
+
+.PHONY: go-build
+go-build:
 	$(GO_BUILD)
 
 .PHONY: cross-compiled $(ARCHS)


### PR DESCRIPTION
### Rationale
This fixes a tiny incident we had with https://github.com/trento-project/trento/runs/4141850538.

### Incident identification
At 17:51 GMT+2 @nelsonkopliku reported that we were not able to build a Docker image out ot the source tree anymore, linking the broken pipeline as above. This was due to `make build` invoking the `web-assets` target that contained itself a `make target` that was turned to PHONY by me (@dottorblaster) in an earlier PR: #363.

With said target being PHONY, the `make` invocation in the Go container tried to rebuild the web bundles too but it had not `npx` in the `PATH`.

### Remediation
At 18.05 GMT+2 a fix was identified and pushed, switching the make target invoked by the Dockerfile to `go-build`, a newly introduced goal that only builds the Go binary.