### PR TITLE
Revert 435

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make web-assets
 FROM golang:1.16 as go-build
 COPY --from=node-build /build /build
 WORKDIR /build
-RUN make go-build
+RUN make build
 
 FROM python:3.7-slim AS trento-runner
 RUN ln -s /usr/local/bin/python /usr/bin/python \

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,19 @@ clean-binary:
 	rm -rf build
 
 .PHONY: clean-frontend
-clean-frontend:
+clean-frontend: clean-web-assets clean-web-deps
+
+.PHONY: clean-web-assets
+clean-web-assets:
 	rm -rf web/frontend/assets
+
+.PHONY: clean-web-deps
+clean-web-deps:
 	rm -rf web/frontend/node_modules
+
+.PHONY: clean-web-assets-js
+clean-web-assets-js:
+	rm -rf web/frontend/assets/js
 
 .PHONY: fmt
 fmt:
@@ -100,6 +110,10 @@ web-lint:
 
 .PHONY: web-assets
 web-assets: web/frontend/assets
+
+# shortcut to always retrigger webpack
+.PHONY: webpack
+webpack: clean-web-assets-js web/frontend/assets/js
 
 web/frontend/assets: web/frontend/assets/js web/frontend/assets/stylesheets web/frontend/assets/images
 

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ default: clean mod-tidy fmt vet-check web-check test build
 
 .PHONY: build
 build: trento
-trento: web-assets go-build
-
-.PHONY: go-build
-go-build:
+trento: web-assets
 	$(GO_BUILD)
 
 .PHONY: cross-compiled $(ARCHS)

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,6 @@ web-assets: web/frontend/assets
 
 web/frontend/assets: web/frontend/assets/js web/frontend/assets/stylesheets web/frontend/assets/images
 
-.PHONY: web/frontend/assets/js
 web/frontend/assets/js: web/frontend/node_modules
 	mkdir -p web/frontend/assets/js/eos-ds
 	cp web/frontend/javascripts/*.js web/frontend/assets/js/

--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,6 @@ web-lint:
 .PHONY: web-assets
 web-assets: web/frontend/assets
 
-# shortcut to always retrigger webpack
-.PHONY: webpack
-webpack: clean-web-assets-js web/frontend/assets/js
-
 web/frontend/assets: web/frontend/assets/js web/frontend/assets/stylesheets web/frontend/assets/images
 
 web/frontend/assets/js: web/frontend/node_modules


### PR DESCRIPTION
Long-term alternative solution to #435.
Pending an update to the CI jobs so that we attempt to build docker images on every commit, to avoid further regressions in the make targets dependency graph.

To explicitly rerun webpack, you can now run `make clean-web-assets-js build`.
Symmetrically, if you wanted to rebuild just the go binary without re-running webpack, you could already run `make clean-binary build`.