### PR TITLE
Fix selected checks in settings endpoint being deserialized to null

### DIFF
--- a/web/checks_api.go
+++ b/web/checks_api.go
@@ -176,7 +176,13 @@ func ApiCheckGetSettingsByIdHandler(consul consul.Client, s services.ChecksServi
 		var jsonCheckSetting JSONChecksSettings
 		jsonCheckSetting.ConnectionSettings = make(map[string]string)
 
-		jsonCheckSetting.SelectedChecks = selectedChecks.SelectedChecks
+		if len(selectedChecks.SelectedChecks) == 0 {
+			jsonCheckSetting.SelectedChecks = make([]string, 0)
+
+		} else {
+			jsonCheckSetting.SelectedChecks = selectedChecks.SelectedChecks
+		}
+
 		jsonCheckSetting.Hosts = nodes
 		for node, settings := range connSettings {
 			jsonCheckSetting.ConnectionSettings[node] = settings.User


### PR DESCRIPTION
We always want an empty array to be sent to the frontend, especially when we don't have selected checks for a HANA cluster.