### PR TITLE
More ci goodies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
-web/frontend/node_modules
-web/frontend/assets
-trento
+/*.sh
+/.github
+/packaging
+/trento
+/web/frontend/assets
+/web/frontend/node_modules

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -108,16 +108,15 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
-      PUSH: "${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || github.ref_name == 'main' && 'rolling' || github.sha }}"
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v1
       - name: Log in to the Container registry
-        if: ${{ env.PUSH }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: github.event_name == 'release' || github.ref_name == 'main'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -131,18 +130,18 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ env.PUSH }}
+          push: "${{ github.event_name == 'release' || github.ref_name == 'main' }}"
           target: ${{ matrix.image }}
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar
+          outputs: type=docker,dest=/tmp/${{ matrix.image }}-image.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: trento-${{ matrix.image }}
-          path: /tmp/trento-${{ matrix.image }}.tar
+          name: ${{ matrix.image }}-image
+          path: /tmp/${{ matrix.image }}-image.tar
 
   smoke-test-container-images:
     runs-on: ubuntu-20.04
@@ -155,18 +154,18 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.ref_name == 'main' && 'rolling') || github.sha }}"
     steps:
       - uses: docker/setup-buildx-action@v1
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: trento-${{ matrix.image }}
+          name: ${{ matrix.image }}-image
           path: /tmp
       - name: Load image
-        run: docker load --input /tmp/trento-${{ matrix.image }}.tar
+        run: docker load --input /tmp/${{ matrix.image }}-image.tar
       - name: Test CLI
-        run: docker run --rm -ti ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
+        run: docker run --rm ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
 
   test-helm-charts:
     runs-on: ubuntu-20.04
@@ -229,7 +228,7 @@ jobs:
 
   release-rolling:
     needs: build-static-binary
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: github.ref_name == 'main'
     runs-on: ubuntu-20.04
     concurrency: ci-${{ github.ref }}
     steps:
@@ -266,7 +265,7 @@ jobs:
   deploy-server:
     runs-on: [ self-hosted, trento-gh-runner ]
     needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.ref_name == 'main'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
     env:
@@ -289,7 +288,7 @@ jobs:
   deploy-agents:
     runs-on: [ self-hosted, trento-gh-runner ]
     needs: [ deploy-server ]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.ref_name == 'main'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
     env:
@@ -314,7 +313,7 @@ jobs:
   obs-commit:
     needs: [test-binary, test-checks]
     runs-on: ubuntu-20.04
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    if: github.event_name == 'release' || github.ref_name == 'main'
     concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -93,8 +93,83 @@ jobs:
       - name: trento checks ID sanity test
         run: python3 hack/id_checker.py
 
+  build-container-images:
+    runs-on: ubuntu-20.04
+    needs: [test-binary, test-checks]
+    strategy:
+      matrix:
+        image:
+          - trento-web
+          - trento-runner
+    permissions:
+      contents: read
+      packages: write
+    concurrency: ci-${{ github.ref }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
+      PUSH: "${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v1
+      - name: Log in to the Container registry
+        if: ${{ env.PUSH }}
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
+      - name: Build and push container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: ${{ env.PUSH }}
+          target: ${{ matrix.image }}
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: trento-${{ matrix.image }}
+          path: /tmp/trento-${{ matrix.image }}.tar
+
+  smoke-test-container-images:
+    runs-on: ubuntu-20.04
+    needs: build-container-images
+    strategy:
+      matrix:
+        image:
+          - trento-web
+          - trento-runner
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
+    steps:
+      - uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: trento-${{ matrix.image }}
+          path: /tmp
+      - name: Load image
+        run: docker load --input /tmp/trento-${{ matrix.image }}.tar
+      - name: Test CLI
+        run: docker run --rm -ti ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
+
   test-helm-charts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -155,7 +230,7 @@ jobs:
   release-rolling:
     needs: build-static-binary
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-20.04
     concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/download-artifact@v2
@@ -190,7 +265,7 @@ jobs:
 
   deploy-server:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ build-and-push-container-images, release-rolling ]
+    needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
@@ -236,55 +311,9 @@ jobs:
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 
-  build-and-push-container-images:
-    needs: [test-binary, test-checks]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    strategy:
-      matrix:
-        image-target:
-          - trento-web
-          - trento-runner
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    concurrency: ci-${{ github.ref }}
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image-target }}
-      IMAGE_TAG: "${{ github.event_name == 'release' && github.event.release.tag_name || 'rolling' }}"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.IMAGE_REPOSITORY }}
-      - name: Build and push container image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          target: ${{ matrix.image-target }}
-          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   obs-commit:
     needs: [test-binary, test-checks]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     concurrency: ci-${{ github.ref }}
     container:
@@ -318,7 +347,7 @@ jobs:
 
   obs-submit:
     needs: obs-commit
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.release
     concurrency: ci-${{ github.ref }}
     container:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default: clean mod-tidy fmt vet-check web-check test build
 
 .PHONY: build
 build: trento
-trento: web-assets
+trento: web/frontend/assets
 	$(GO_BUILD)
 
 .PHONY: cross-compiled $(ARCHS)


### PR DESCRIPTION
- optimizes `Dockerfile` so that it doesn't need to re-download dependencies for every source code change.
- more entries to `.dockerignore`
- fixes a minor issue with the `make trento` target which wouldn't properly detect when it was up-to-date already
- builds containers at every commit and run the `trento version` as a simple smoke test
- pins all jobs to the same fixed ubuntu version