### PR TITLE
Add heartbeat endpoint

### DIFF
--- a/docs/api/docs.go
+++ b/docs/api/docs.go
@@ -43,7 +43,7 @@ var doc = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.GroupedChecks"
+                                "$ref": "#/definitions/web.JSONChecksGroup"
                             }
                         }
                     }
@@ -679,20 +679,6 @@ var doc = `{
                 }
             }
         },
-        "models.GroupedChecks": {
-            "type": "object",
-            "properties": {
-                "checks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Check"
-                    }
-                },
-                "group": {
-                    "type": "string"
-                }
-            }
-        },
         "web.JSONCheck": {
             "type": "object",
             "required": [
@@ -720,6 +706,20 @@ var doc = `{
                     "type": "string"
                 },
                 "remediation": {
+                    "type": "string"
+                }
+            }
+        },
+        "web.JSONChecksGroup": {
+            "type": "object",
+            "properties": {
+                "checks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Check"
+                    }
+                },
+                "group": {
                     "type": "string"
                 }
             }

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -31,7 +31,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.GroupedChecks"
+                                "$ref": "#/definitions/web.JSONChecksGroup"
                             }
                         }
                     }
@@ -667,20 +667,6 @@
                 }
             }
         },
-        "models.GroupedChecks": {
-            "type": "object",
-            "properties": {
-                "checks": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Check"
-                    }
-                },
-                "group": {
-                    "type": "string"
-                }
-            }
-        },
         "web.JSONCheck": {
             "type": "object",
             "required": [
@@ -708,6 +694,20 @@
                     "type": "string"
                 },
                 "remediation": {
+                    "type": "string"
+                }
+            }
+        },
+        "web.JSONChecksGroup": {
+            "type": "object",
+            "properties": {
+                "checks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Check"
+                    }
+                },
+                "group": {
                     "type": "string"
                 }
             }

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -21,15 +21,6 @@ definitions:
       selected:
         type: boolean
     type: object
-  models.GroupedChecks:
-    properties:
-      checks:
-        items:
-          $ref: '#/definitions/models.Check'
-        type: array
-      group:
-        type: string
-    type: object
   web.JSONCheck:
     properties:
       description:
@@ -50,6 +41,15 @@ definitions:
     - group
     - id
     - name
+    type: object
+  web.JSONChecksGroup:
+    properties:
+      checks:
+        items:
+          $ref: '#/definitions/models.Check'
+        type: array
+      group:
+        type: string
     type: object
   web.JSONChecksSettings:
     properties:
@@ -186,7 +186,7 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/models.GroupedChecks'
+              $ref: '#/definitions/web.JSONChecksGroup'
             type: array
       summary: Get the whole checks' catalog
     put:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -23,7 +23,12 @@ func InitDB(config *Config) (*gorm.DB, error) {
 		config.Password,
 		config.DBName)
 
-	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{})
+	// TODO: since we are dealing with eventual consistency, we can't enforce foreign key constraints in our projected models.
+	// This disables foreign key constraints enforcement at global level.
+	// In a future we will enable this on a per-model basis via dedicated migrations and disabling the automigration feature.
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/web/app.go
+++ b/web/app.go
@@ -118,7 +118,7 @@ func MigrateDB(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{}, models.CheckRaw{},
 		models.Cluster{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{}, models.HostTelemetry{},
-		entities.Host{},
+		entities.Host{}, entities.HostHeartbeat{},
 	)
 
 	if err != nil {
@@ -181,6 +181,7 @@ func NewAppWithDeps(config *Config, deps Dependencies) (*App, error) {
 
 	collectorEngine := deps.collectorEngine
 	collectorEngine.POST("/api/collect", ApiCollectDataHandler(deps.collectorService))
+	collectorEngine.POST("/api/hosts/heartbeat", ApiHostHeartbeatHandler(deps.hostsNextService))
 	collectorEngine.GET("/api/ping", ApiPingHandler)
 
 	return app, nil

--- a/web/app.go
+++ b/web/app.go
@@ -181,7 +181,7 @@ func NewAppWithDeps(config *Config, deps Dependencies) (*App, error) {
 
 	collectorEngine := deps.collectorEngine
 	collectorEngine.POST("/api/collect", ApiCollectDataHandler(deps.collectorService))
-	collectorEngine.POST("/api/hosts/heartbeat", ApiHostHeartbeatHandler(deps.hostsNextService))
+	collectorEngine.POST("/api/hosts/:id/heartbeat", ApiHostHeartbeatHandler(deps.hostsNextService))
 	collectorEngine.GET("/api/ping", ApiPingHandler)
 
 	return app, nil

--- a/web/datapipeline/hosts_projector.go
+++ b/web/datapipeline/hosts_projector.go
@@ -2,6 +2,7 @@ package datapipeline
 
 import (
 	"fmt"
+	"net"
 
 	log "github.com/sirupsen/logrus"
 
@@ -37,7 +38,7 @@ func hostsProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent,
 	host := entities.Host{
 		AgentID:      dataCollectedEvent.AgentID,
 		Name:         discoveredHost.HostName,
-		IPAddresses:  discoveredHost.HostIpAddresses,
+		IPAddresses:  filterIPAddresses(discoveredHost.HostIpAddresses),
 		AgentVersion: discoveredHost.AgentVersion,
 	}
 
@@ -113,4 +114,17 @@ func storeHost(db *gorm.DB, host entities.Host, updateColumns ...string) error {
 		},
 		DoUpdates: clause.AssignmentColumns(append(updateColumns, "updated_at")),
 	}).Create(&host).Error
+}
+
+func filterIPAddresses(ipAddresses []string) []string {
+	var filtered []string
+	for _, ipAddress := range ipAddresses {
+		ip := net.ParseIP(ipAddress)
+		if ip == nil || ip.IsLoopback() || ip.To4() == nil {
+			continue
+		}
+
+		filtered = append(filtered, ipAddress)
+	}
+	return filtered
 }

--- a/web/datapipeline/hosts_projector.go
+++ b/web/datapipeline/hosts_projector.go
@@ -116,6 +116,7 @@ func storeHost(db *gorm.DB, host entities.Host, updateColumns ...string) error {
 	}).Create(&host).Error
 }
 
+// filterIPAddresses filters out non-IPv4, loopback or invalid IP addresses
 func filterIPAddresses(ipAddresses []string) []string {
 	var filtered []string
 	for _, ipAddress := range ipAddresses {

--- a/web/datapipeline/hosts_projector_test.go
+++ b/web/datapipeline/hosts_projector_test.go
@@ -186,6 +186,7 @@ func (s *HostsProjectorTestSuite) Test_filterIPAddresses() {
 		"10.1.74.5",
 		"::1",
 		"fe80::6245:bdff:fe8b:5896",
+		"not_valid",
 	}
 
 	s.EqualValues([]string{"10.1.74.5"}, filterIPAddresses(ipAddresses))

--- a/web/datapipeline/hosts_projector_test.go
+++ b/web/datapipeline/hosts_projector_test.go
@@ -178,5 +178,15 @@ func (s *HostsProjectorTestSuite) Test_TelemetryProjector() {
 	for _, m := range discoveredSAPSystemMock {
 		s.Contains(projectedHost.SIDs, m.SID)
 	}
+}
 
+func (s *HostsProjectorTestSuite) Test_filterIPAddresses() {
+	ipAddresses := []string{
+		"127.0.0.1",
+		"10.1.74.5",
+		"::1",
+		"fe80::6245:bdff:fe8b:5896",
+	}
+
+	s.EqualValues([]string{"10.1.74.5"}, filterIPAddresses(ipAddresses))
 }

--- a/web/entities/host.go
+++ b/web/entities/host.go
@@ -16,8 +16,14 @@ type Host struct {
 	ClusterName   string
 	SIDs          pq.StringArray `gorm:"column:sids; type:text[]"`
 	AgentVersion  string
-	Tags          []models.Tag `gorm:"polymorphic:Resource;polymorphicValue:hosts"`
+	Heartbeat     *HostHeartbeat `gorm:"foreignKey:AgentID"`
+	Tags          []*models.Tag  `gorm:"polymorphic:Resource;polymorphicValue:hosts"`
 	UpdatedAt     time.Time
+}
+
+type HostHeartbeat struct {
+	AgentID   string `gorm:"primaryKey"`
+	UpdatedAt time.Time
 }
 
 func (h *Host) ToModel() *models.Host {

--- a/web/hosts_next.go
+++ b/web/hosts_next.go
@@ -43,3 +43,27 @@ func NewHostListNextHandler(hostsService services.HostsNextService) gin.HandlerF
 		})
 	}
 }
+
+type SendHeartBeat struct {
+	AgentID string `json:"agent_id"`
+}
+
+func ApiHostHeartbeatHandler(hostService services.HostsNextService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var sendHeartBeat SendHeartBeat
+
+		err := c.BindJSON(&sendHeartBeat)
+		if err != nil {
+			_ = c.Error(BadRequestError("problems parsing JSON"))
+			return
+		}
+
+		err = hostService.Heartbeat(sendHeartBeat.AgentID)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		c.JSON(http.StatusNoContent, gin.H{})
+	}
+}

--- a/web/hosts_next.go
+++ b/web/hosts_next.go
@@ -4,8 +4,24 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/trento-project/trento/web/models"
 	"github.com/trento-project/trento/web/services"
 )
+
+func NewHostsNextHealthContainer(hostList models.HostList) *HealthContainer {
+	h := &HealthContainer{}
+	for _, host := range hostList {
+		switch host.Health {
+		case models.HostHealthPassing:
+			h.PassingCount += 1
+		case models.HostHealthWarning:
+			h.WarningCount += 1
+		case models.HostHealthCritical:
+			h.CriticalCount += 1
+		}
+	}
+	return h
+}
 
 func NewHostListNextHandler(hostsService services.HostsNextService) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -34,12 +50,16 @@ func NewHostListNextHandler(hostsService services.HostsNextService) gin.HandlerF
 		pagination := NewPaginationWithStrings(len(hostList), page, perPage)
 		firstElem, lastElem := pagination.GetSliceNumbers()
 
+		hContainer := NewHostsNextHealthContainer(hostList)
+		hContainer.Layout = "horizontal"
+
 		c.HTML(http.StatusOK, "hosts_next.html.tmpl", gin.H{
-			"Hosts":          hostList[firstElem:lastElem],
-			"AppliedFilters": query,
-			"FilterSIDs":     filterSIDs,
-			"FilterTags":     filterTags,
-			"Pagination":     pagination,
+			"Hosts":           hostList[firstElem:lastElem],
+			"AppliedFilters":  query,
+			"FilterSIDs":      filterSIDs,
+			"FilterTags":      filterTags,
+			"Pagination":      pagination,
+			"HealthContainer": hContainer,
 		})
 	}
 }

--- a/web/hosts_next.go
+++ b/web/hosts_next.go
@@ -64,21 +64,11 @@ func NewHostListNextHandler(hostsService services.HostsNextService) gin.HandlerF
 	}
 }
 
-type SendHeartBeat struct {
-	AgentID string `json:"agent_id"`
-}
-
 func ApiHostHeartbeatHandler(hostService services.HostsNextService) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		var sendHeartBeat SendHeartBeat
+		agentID := c.Param("id")
 
-		err := c.BindJSON(&sendHeartBeat)
-		if err != nil {
-			_ = c.Error(BadRequestError("problems parsing JSON"))
-			return
-		}
-
-		err = hostService.Heartbeat(sendHeartBeat.AgentID)
+		err := hostService.Heartbeat(agentID)
 		if err != nil {
 			_ = c.Error(err)
 			return

--- a/web/hosts_next_test.go
+++ b/web/hosts_next_test.go
@@ -1,8 +1,7 @@
 package web
 
 import (
-	"bytes"
-	"encoding/json"
+	"fmt"
 	"net/http/httptest"
 	"regexp"
 	"testing"
@@ -101,34 +100,11 @@ func TestApiHostHeartbeat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	body, _ := json.Marshal(&SendHeartBeat{AgentID: agentID})
 	resp := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/hosts/heartbeat", bytes.NewBuffer(body))
+	url := fmt.Sprintf("/api/hosts/%s/heartbeat", agentID)
+	req := httptest.NewRequest("POST", url, nil)
 
 	app.collectorEngine.ServeHTTP(resp, req)
 
 	assert.Equal(t, 204, resp.Code)
-}
-
-func TestApiHostHeartbeat400(t *testing.T) {
-	agentID := "agent_id"
-
-	mockHostsService := new(services.MockHostsNextService)
-	mockHostsService.On("Heartbeat", agentID).Return(nil)
-
-	deps := setupTestDependencies()
-	deps.hostsNextService = mockHostsService
-
-	app, err := NewAppWithDeps(setupTestConfig(), deps)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	malformedJSON := []byte{}
-	resp := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/hosts/heartbeat", bytes.NewBuffer(malformedJSON))
-
-	app.collectorEngine.ServeHTTP(resp, req)
-
-	assert.Equal(t, 400, resp.Code)
 }

--- a/web/models/host.go
+++ b/web/models/host.go
@@ -1,5 +1,12 @@
 package models
 
+const (
+	HostHealthPassing  = "passing"
+	HostHealthWarning  = "warning"
+	HostHealthCritical = "critical"
+	HostHealthUnknown  = ""
+)
+
 type Host struct {
 	ID            string
 	Name          string

--- a/web/services/hosts_next.go
+++ b/web/services/hosts_next.go
@@ -49,7 +49,7 @@ func (s *hostsNextService) GetAll(filters map[string][]string) (models.HostList,
 		}
 	}
 
-	err := db.Find(&hosts).Error
+	err := db.Find(&hosts).Order("name").Error
 	if err != nil {
 		return nil, err
 	}

--- a/web/services/hosts_next.go
+++ b/web/services/hosts_next.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/trento-project/trento/internal"
 	"github.com/trento-project/trento/web/entities"
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/gorm"
@@ -58,6 +59,12 @@ func (s *hostsNextService) GetAll(filters map[string][]string) (models.HostList,
 		host := h.ToModel()
 		host.Health = computeHealth(&h)
 
+		health, ok := filters["health"]
+		if ok && len(health) > 0 {
+			if !internal.Contains(health, host.Health) {
+				continue
+			}
+		}
 		hostList = append(hostList, host)
 	}
 

--- a/web/services/hosts_next_mock.go
+++ b/web/services/hosts_next_mock.go
@@ -80,3 +80,17 @@ func (_m *MockHostsNextService) GetAllTags() ([]string, error) {
 
 	return r0, r1
 }
+
+// Heartbeat provides a mock function with given fields: agentID
+func (_m *MockHostsNextService) Heartbeat(agentID string) error {
+	ret := _m.Called(agentID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(agentID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/web/services/hosts_next_test.go
+++ b/web/services/hosts_next_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/suite"
@@ -10,6 +11,49 @@ import (
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/gorm"
 )
+
+func hostsFixtures() []entities.Host {
+	return []entities.Host{
+		{
+			AgentID:       "1",
+			Name:          "host1",
+			ClusterID:     "cluster_id_1",
+			ClusterName:   "cluster_1",
+			CloudProvider: "azure",
+			IPAddresses:   pq.StringArray{"10.74.1.5"},
+			SIDs:          pq.StringArray{"DEV"},
+			AgentVersion:  "rolling1337",
+			Heartbeat: &entities.HostHeartbeat{
+				AgentID:   "1",
+				UpdatedAt: time.Date(2020, 11, 01, 00, 00, 00, 0, time.UTC),
+			},
+			Tags: []*models.Tag{{
+				Value:        "tag1",
+				ResourceID:   "1",
+				ResourceType: models.TagHostResourceType,
+			}},
+		},
+		{
+			AgentID:       "2",
+			Name:          "host2",
+			ClusterID:     "cluster_id_2",
+			ClusterName:   "cluster_2",
+			CloudProvider: "azure",
+			IPAddresses:   pq.StringArray{"10.74.1.10"},
+			SIDs:          pq.StringArray{"QAS"},
+			AgentVersion:  "stable",
+			Heartbeat: &entities.HostHeartbeat{
+				AgentID:   "2",
+				UpdatedAt: time.Date(2020, 11, 01, 00, 00, 00, 0, time.UTC),
+			},
+			Tags: []*models.Tag{{
+				Value:        "tag2",
+				ResourceID:   "2",
+				ResourceType: models.TagHostResourceType,
+			}},
+		},
+	}
+}
 
 type HostsNextServiceTestSuite struct {
 	suite.Suite
@@ -25,12 +69,16 @@ func TestHostsNextServiceTestSuite(t *testing.T) {
 func (suite *HostsNextServiceTestSuite) SetupSuite() {
 	suite.db = helpers.SetupTestDatabase(suite.T())
 
-	suite.db.AutoMigrate(&entities.Host{}, &models.Tag{})
-	loadHostsFixtures(suite.db)
+	suite.db.AutoMigrate(&entities.Host{}, &entities.HostHeartbeat{}, &models.Tag{})
+	hosts := hostsFixtures()
+	err := suite.db.Create(&hosts).Error
+	suite.NoError(err)
 }
 
 func (suite *HostsNextServiceTestSuite) TearDownSuite() {
-	suite.db.Migrator().DropTable(&entities.Host{}, &models.Tag{})
+	suite.db.Migrator().DropTable(&entities.Host{},
+		&entities.HostHeartbeat{},
+		&models.Tag{})
 }
 
 func (suite *HostsNextServiceTestSuite) SetupTest() {
@@ -43,13 +91,18 @@ func (suite *HostsNextServiceTestSuite) TearDownTest() {
 }
 
 func (suite *HostsNextServiceTestSuite) TestHostsNextService_GetAll() {
-	hosts, _ := suite.hostsNextService.GetAll(map[string][]string{})
+	timeSince = func(_ time.Time) time.Duration {
+		return time.Duration(0)
+	}
+
+	hosts, err := suite.hostsNextService.GetAll(map[string][]string{})
+	suite.NoError(err)
 
 	suite.ElementsMatch(models.HostList{
 		{
 			ID:            "1",
 			Name:          "host1",
-			Health:        "",
+			Health:        "passing",
 			IPAddresses:   []string{"10.74.1.5"},
 			CloudProvider: "azure",
 			ClusterID:     "cluster_id_1",
@@ -61,7 +114,7 @@ func (suite *HostsNextServiceTestSuite) TestHostsNextService_GetAll() {
 		{
 			ID:            "2",
 			Name:          "host2",
-			Health:        "",
+			Health:        "passing",
 			IPAddresses:   []string{"10.74.1.10"},
 			CloudProvider: "azure",
 			ClusterID:     "cluster_id_2",
@@ -92,37 +145,29 @@ func (suite *HostsNextServiceTestSuite) TestHostsNextService_GetAllSIDs() {
 	suite.ElementsMatch([]string{"DEV", "QAS"}, hosts)
 }
 
-func loadHostsFixtures(db *gorm.DB) {
-	db.Create(&[]entities.Host{
-		{
-			AgentID:       "1",
-			Name:          "host1",
-			ClusterID:     "cluster_id_1",
-			ClusterName:   "cluster_1",
-			CloudProvider: "azure",
-			IPAddresses:   pq.StringArray{"10.74.1.5"},
-			SIDs:          pq.StringArray{"DEV"},
-			AgentVersion:  "rolling1337",
-			Tags: []models.Tag{{
-				Value:        "tag1",
-				ResourceID:   "1",
-				ResourceType: models.TagHostResourceType,
-			}},
-		},
-		{
-			AgentID:       "2",
-			Name:          "host2",
-			ClusterID:     "cluster_id_2",
-			ClusterName:   "cluster_2",
-			CloudProvider: "azure",
-			IPAddresses:   pq.StringArray{"10.74.1.10"},
-			SIDs:          pq.StringArray{"QAS"},
-			AgentVersion:  "stable",
-			Tags: []models.Tag{{
-				Value:        "tag2",
-				ResourceID:   "2",
-				ResourceType: models.TagHostResourceType,
-			}},
-		},
-	})
+func (suite *HostsNextServiceTestSuite) TestHostsNextService_Heartbeat() {
+	err := suite.hostsNextService.Heartbeat("1")
+	suite.NoError(err)
+
+	var heartbeat entities.HostHeartbeat
+	suite.tx.First(&heartbeat)
+	suite.Equal("1", heartbeat.AgentID)
+}
+
+func (suite *HostsNextServiceTestSuite) TestHostsNextService_computeHealth() {
+	host := hostsFixtures()[0]
+
+	timeSince = func(_ time.Time) time.Duration {
+		return time.Duration(0)
+	}
+	suite.Equal(models.HostHealthPassing, computeHealth(&host))
+
+	timeSince = func(_ time.Time) time.Duration {
+		return time.Duration(HeartbeatTreshold + 1)
+	}
+	suite.Equal(models.HostHealthCritical, computeHealth(&host))
+
+	host.Heartbeat = nil
+	suite.Equal(models.HostHealthUnknown, computeHealth(&host))
+
 }

--- a/web/services/hosts_next_test.go
+++ b/web/services/hosts_next_test.go
@@ -127,9 +127,14 @@ func (suite *HostsNextServiceTestSuite) TestHostsNextService_GetAll() {
 }
 
 func (suite *HostsNextServiceTestSuite) TestHostsNextService_GetAll_Filters() {
+	timeSince = func(_ time.Time) time.Duration {
+		return time.Duration(0)
+	}
+
 	hosts, _ := suite.hostsNextService.GetAll(map[string][]string{
-		"tags": {"tag1"},
-		"sids": {"DEV"},
+		"tags":   {"tag1"},
+		"sids":   {"DEV"},
+		"health": {"passing", "unknown"},
 	})
 	suite.Equal(1, len(hosts))
 	suite.Equal("1", hosts[0].ID)

--- a/web/templates/hosts_next.html.tmpl
+++ b/web/templates/hosts_next.html.tmpl
@@ -16,7 +16,7 @@
             </div>
         </div>
         <hr class="margin-10px"/>
-        {{/* {{ template "health_container" .HealthContainer }} */}}
+        {{ template "health_container" .HealthContainer }}
         <h5>Filters</h5>
 
         <div class="horizontal-container">


### PR DESCRIPTION
This PR adds the heartbeat endpoint and an initial health business logic of the hosts health.
If we didn't receive a ping in `HeartbeatTreshold = <heartbeatRate> * 2` we mark the host health as critical.

This is one step further on removing consul, following PR will take care of the agent side. 