### PR TITLE
Add heartbeat to agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/trento-project/trento/agent/discovery"
 	"github.com/trento-project/trento/agent/discovery/collector"
+	"github.com/trento-project/trento/internal"
 	"github.com/trento-project/trento/internal/consul"
 	"github.com/trento-project/trento/internal/hosts"
 	"github.com/trento-project/trento/version"
@@ -196,7 +197,7 @@ func (a *Agent) startHeartbeatTicker() {
 		}
 	}
 
-	repeat(tick, 5*time.Second, a.ctx)
+	repeat(tick, internal.HeartbeatInterval, a.ctx)
 }
 
 func repeat(tick func(), interval time.Duration, ctx context.Context) {

--- a/internal/heartbeat.go
+++ b/internal/heartbeat.go
@@ -1,0 +1,5 @@
+package internal
+
+import "time"
+
+const HeartbeatInterval = 5 * time.Second

--- a/web/services/hosts_next.go
+++ b/web/services/hosts_next.go
@@ -11,7 +11,7 @@ import (
 	"gorm.io/gorm/clause"
 )
 
-const HeartbeatTreshold = 5 * 2 * time.Second
+const HeartbeatTreshold = internal.HeartbeatInterval * 2
 
 var timeSince = time.Since
 


### PR DESCRIPTION
Part 2 of the heartbeat implementation started in #441.
This PR adds a ticker loop that sends an heartbeat to the collector endpoint every `HeartbeatInterval` seconds.
(this can't be configured by the user and probably never will).

We might want to rename the collector endpoint to something like "private api" and have publish and heartbeat client methods in the `/api` folder so let's keep this on the radar, but as for now this is just enough.