### PR TITLE
Cleanup clusters service

### DIFF
--- a/web/app.go
+++ b/web/app.go
@@ -97,7 +97,7 @@ func DefaultDependencies(config *Config) Dependencies {
 	hostsService := services.NewHostsService(consulClient)
 	hostsServiceNext := services.NewHostsNextService(db)
 	sapSystemsService := services.NewSAPSystemsService(consulClient)
-	clustersService := services.NewClustersService(db, checksService, tagsService)
+	clustersService := services.NewClustersService(db, checksService)
 	collectorService := services.NewCollectorService(db, projectorWorkersPool.GetChannel())
 
 	return Dependencies{
@@ -117,8 +117,8 @@ func NewNamedEngine(instance string) *gin.Engine {
 func MigrateDB(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{}, models.CheckRaw{},
-		models.Cluster{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{}, models.HostTelemetry{},
-		entities.Host{}, entities.HostHeartbeat{},
+		datapipeline.DataCollectedEvent{}, datapipeline.Subscription{}, models.HostTelemetry{},
+		entities.Cluster{}, entities.Host{}, entities.HostHeartbeat{},
 	)
 
 	if err != nil {

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -293,7 +293,24 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 		query := c.Request.URL.Query()
 
 		clusterList, err := clustersService.GetAll(query)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
 
+		filterClusterTypes, err := clustersService.GetAllClusterTypes()
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		filterSIDs, err := clustersService.GetAllSIDs()
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		filterTags, err := clustersService.GetAllTags()
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -308,10 +325,13 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 		firstElem, lastElem := pagination.GetSliceNumbers()
 
 		c.HTML(http.StatusOK, "clusters.html.tmpl", gin.H{
-			"ClustersTable":   clusterList[firstElem:lastElem],
-			"AppliedFilters":  query,
-			"Pagination":      pagination,
-			"HealthContainer": healthContainer,
+			"ClustersTable":      clusterList[firstElem:lastElem],
+			"AppliedFilters":     query,
+			"FilterClusterTypes": filterClusterTypes,
+			"FilterSIDs":         filterSIDs,
+			"FilterTags":         filterTags,
+			"Pagination":         pagination,
+			"HealthContainer":    healthContainer,
 		})
 	}
 }

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -491,7 +491,7 @@ func TestClustersListHandler(t *testing.T) {
 		{
 			ID:                "47d1190ffb4f781974c8356d7f863b03",
 			Name:              "hana_cluster",
-			ClusterType:       ClusterTypeScaleUp,
+			ClusterType:       models.ClusterTypeScaleUp,
 			SIDs:              []string{"PRD"},
 			ResourcesNumber:   5,
 			HostsNumber:       3,
@@ -502,7 +502,7 @@ func TestClustersListHandler(t *testing.T) {
 		{
 			ID:                "a615a35f65627be5a757319a0741127f",
 			Name:              "other_cluster",
-			ClusterType:       ClusterTypeUnknown,
+			ClusterType:       models.ClusterTypeUnknown,
 			SIDs:              []string{},
 			Tags:              []string{"tag1"},
 			Health:            models.CheckCritical,
@@ -511,7 +511,7 @@ func TestClustersListHandler(t *testing.T) {
 		{
 			ID:                "e2f2eb50aef748e586a7baa85e0162cf",
 			Name:              "netweaver_cluster",
-			ClusterType:       ClusterTypeUnknown,
+			ClusterType:       models.ClusterTypeUnknown,
 			SIDs:              []string{},
 			ResourcesNumber:   10,
 			HostsNumber:       2,
@@ -522,7 +522,7 @@ func TestClustersListHandler(t *testing.T) {
 		{
 			ID:                "e27d313a674375b2066777a89ee346b9",
 			Name:              "netweaver_cluster",
-			ClusterType:       ClusterTypeUnknown,
+			ClusterType:       models.ClusterTypeUnknown,
 			SIDs:              []string{},
 			Tags:              []string{"tag1"},
 			Health:            models.CheckUndefined,
@@ -532,7 +532,12 @@ func TestClustersListHandler(t *testing.T) {
 
 	mockClusterService := new(services.MockClustersService)
 	mockClusterService.On("GetAll", mock.Anything).Return(clustersList, nil)
-
+	mockClusterService.On("GetAllClusterTypes", mock.Anything).Return(
+		[]string{models.ClusterTypeScaleUp, models.ClusterTypeUnknown},
+		nil,
+	)
+	mockClusterService.On("GetAllSIDs", mock.Anything).Return([]string{"PRD"}, nil)
+	mockClusterService.On("GetAllTags", mock.Anything).Return([]string{"tag1"}, nil)
 	deps := setupTestDependencies()
 	deps.clustersService = mockClusterService
 

--- a/web/datapipeline/clusters_projector.go
+++ b/web/datapipeline/clusters_projector.go
@@ -7,6 +7,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/internal/cluster"
+	"github.com/trento-project/trento/web/entities"
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -43,12 +44,12 @@ func clustersProjector_ClusterDiscoveryHandler(event *DataCollectedEvent, db *go
 }
 
 // transformClusterData transforms the cluster data into the read model
-func transformClusterData(cluster *cluster.Cluster) (*models.Cluster, error) {
+func transformClusterData(cluster *cluster.Cluster) (*entities.Cluster, error) {
 	if cluster.Id == "" {
 		return nil, fmt.Errorf("no cluster ID found")
 	}
 
-	return &models.Cluster{
+	return &entities.Cluster{
 		ID:          cluster.Id,
 		Name:        cluster.Name,
 		ClusterType: detectClusterType(cluster),

--- a/web/entities/cluster.go
+++ b/web/entities/cluster.go
@@ -1,0 +1,37 @@
+package entities
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/trento-project/trento/web/models"
+)
+
+type Cluster struct {
+	ID              string `gorm:"primaryKey"`
+	Name            string
+	ClusterType     string
+	SIDs            pq.StringArray `gorm:"column:sids; type:text[]"`
+	ResourcesNumber int
+	HostsNumber     int
+	Tags            []models.Tag `gorm:"polymorphic:Resource;polymorphicValue:clusters"`
+	UpdatedAt       time.Time
+}
+
+func (h *Cluster) ToModel() *models.Cluster {
+	// TODO: move to Tags entity when we will have it
+	var tags []string
+	for _, tag := range h.Tags {
+		tags = append(tags, tag.Value)
+	}
+
+	return &models.Cluster{
+		ID:              h.ID,
+		Name:            h.Name,
+		ClusterType:     h.ClusterType,
+		SIDs:            h.SIDs,
+		ResourcesNumber: h.ResourcesNumber,
+		HostsNumber:     h.HostsNumber,
+		Tags:            tags,
+	}
+}

--- a/web/models/cluster.go
+++ b/web/models/cluster.go
@@ -1,7 +1,5 @@
 package models
 
-import "github.com/lib/pq"
-
 const (
 	ClusterTypeScaleUp  = "HANA scale-up"
 	ClusterTypeScaleOut = "HANA scale-out"
@@ -9,70 +7,16 @@ const (
 )
 
 type Cluster struct {
-	ID                string
-	Name              string
-	ClusterType       string
-	SIDs              pq.StringArray `gorm:"column:sids; type:text[]"`
-	ResourcesNumber   int
-	HostsNumber       int
-	Health            string   `gorm:"-"`
-	Tags              []string `gorm:"-"`
-	HasDuplicatedName bool     `gorm:"-"`
+	ID              string
+	Name            string
+	ClusterType     string
+	SIDs            []string
+	ResourcesNumber int
+	HostsNumber     int
+	Health          string
+	Tags            []string
+	// TODO: this is frontend specific, should be removed
+	HasDuplicatedName bool
 }
 
 type ClusterList []*Cluster
-
-// GetAllSIDs returns all the deduplicated
-// and non empty sids in the cluster used by the frontend to show selectable filters
-func (clusterList ClusterList) GetAllSIDs() []string {
-	var sids []string
-	set := make(map[string]struct{})
-
-	for _, c := range clusterList {
-		for _, sid := range c.SIDs {
-			if sid == "" {
-				continue
-			}
-
-			_, ok := set[sid]
-			if !ok {
-				set[sid] = struct{}{}
-				sids = append(sids, sid)
-			}
-		}
-	}
-
-	return sids
-}
-
-func (clusterList ClusterList) GetAllTags() []string {
-	var tags []string
-	set := make(map[string]struct{})
-
-	for _, c := range clusterList {
-		for _, tag := range c.Tags {
-			_, ok := set[tag]
-			if !ok {
-				set[tag] = struct{}{}
-				tags = append(tags, tag)
-			}
-		}
-	}
-
-	return tags
-}
-
-func (clusterList ClusterList) GetAllClusterTypes() []string {
-	var clusterTypes []string
-	set := make(map[string]struct{})
-
-	for _, c := range clusterList {
-		_, ok := set[c.ClusterType]
-		if !ok {
-			set[c.ClusterType] = struct{}{}
-			clusterTypes = append(clusterTypes, c.ClusterType)
-		}
-	}
-
-	return clusterTypes
-}

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -58,7 +58,7 @@ func (s *clustersService) GetAll(filters map[string][]string) (models.ClusterLis
 		}
 	}
 
-	err := db.Find(&clusters).Error
+	err := db.Order("name").Order("id").Find(&clusters).Error
 	if err != nil {
 		return nil, err
 	}

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/trento-project/trento/internal"
+	"github.com/trento-project/trento/web/entities"
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/gorm"
 )
@@ -13,27 +14,36 @@ import (
 
 type ClustersService interface {
 	GetAll(filters map[string][]string) (models.ClusterList, error)
+	GetAllClusterTypes() ([]string, error)
+	GetAllSIDs() ([]string, error)
+	GetAllTags() ([]string, error)
 }
 
 type clustersService struct {
 	db            *gorm.DB
 	checksService ChecksService
-	tagsService   TagsService
 }
 
-func NewClustersService(db *gorm.DB, checksService ChecksService, tagsService TagsService) *clustersService {
+func NewClustersService(db *gorm.DB, checksService ChecksService) *clustersService {
 	return &clustersService{
 		db:            db,
 		checksService: checksService,
-		tagsService:   tagsService,
 	}
 }
 
 func (s *clustersService) GetAll(filters map[string][]string) (models.ClusterList, error) {
-	var clusterList models.ClusterList
-	db := s.db
+	var clusters []entities.Cluster
+	db := s.db.Preload("Tags")
 
-	if sids, ok := filters["sid"]; ok {
+	if tags, ok := filters["tags"]; ok {
+		db = db.Where("id IN (?)", s.db.Model(&models.Tag{}).
+			Select("resource_id").
+			Where("resource_type = ?", models.TagClusterResourceType).
+			Where("value IN ?", tags),
+		)
+	}
+
+	if sids, ok := filters["sids"]; ok {
 		if len(sids) > 0 {
 			db = s.db.Where("sids && ?", pq.Array(sids))
 		}
@@ -48,9 +58,14 @@ func (s *clustersService) GetAll(filters map[string][]string) (models.ClusterLis
 		}
 	}
 
-	err := db.Find(&clusterList).Error
+	err := db.Find(&clusters).Error
 	if err != nil {
 		return nil, err
+	}
+
+	var clusterList models.ClusterList
+	for _, cluster := range clusters {
+		clusterList = append(clusterList, cluster.ToModel())
 	}
 
 	err = s.enrichClusterData(clusterList)
@@ -58,16 +73,59 @@ func (s *clustersService) GetAll(filters map[string][]string) (models.ClusterLis
 		return nil, err
 	}
 
-	if tagsFilter, ok := filters["tags"]; ok {
-		clusterList = filterByTags(clusterList, tagsFilter)
-	}
-
 	if healthFilter, ok := filters["health"]; ok {
 		clusterList = filterByHealth(clusterList, healthFilter)
 	}
 
-	//db.Model(&User{}).Where("name = ?", "jinzhu").Count(&count) > 0
 	return clusterList, nil
+}
+
+func (s *clustersService) GetAllClusterTypes() ([]string, error) {
+	var clusterTypes []string
+
+	err := s.db.Model(&entities.Cluster{}).
+		Distinct().
+		Pluck("cluster_type", &clusterTypes).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterTypes, nil
+}
+
+func (s *clustersService) GetAllSIDs() ([]string, error) {
+	var sids pq.StringArray
+
+	err := s.db.Model(&entities.Cluster{}).
+		Where("sids IS NOT NULL").
+		Distinct().
+		Pluck("unnest(sids)", &sids).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return []string(sids), nil
+}
+
+func (s *clustersService) GetAllTags() ([]string, error) {
+	var tags []string
+
+	err := s.db.
+		Model(&models.Tag{ResourceType: models.TagClusterResourceType}).
+		Distinct().
+		Pluck("value", &tags).
+		Error
+
+	if err != nil {
+		return nil, err
+
+	}
+
+	return tags, nil
 }
 
 func (s *clustersService) enrichClusterData(clusterList models.ClusterList) error {
@@ -82,30 +140,9 @@ func (s *clustersService) enrichClusterData(clusterList models.ClusterList) erro
 		}
 		health, _ := s.checksService.GetAggregatedChecksResultByCluster(c.ID)
 		c.Health = health.String()
-
-		tags, err := s.tagsService.GetAllByResource(models.TagClusterResourceType, c.ID)
-		if err != nil {
-			return err
-		}
-		c.Tags = tags
 	}
 
 	return nil
-}
-
-func filterByTags(clusterList models.ClusterList, tags []string) models.ClusterList {
-	var filteredClusterList models.ClusterList
-
-	for _, c := range clusterList {
-		for _, t := range tags {
-			if internal.Contains(c.Tags, t) {
-				filteredClusterList = append(filteredClusterList, c)
-				break
-			}
-		}
-	}
-
-	return filteredClusterList
 }
 
 func filterByHealth(clusterList models.ClusterList, health []string) models.ClusterList {

--- a/web/services/clusters_mock.go
+++ b/web/services/clusters_mock.go
@@ -34,3 +34,72 @@ func (_m *MockClustersService) GetAll(filters map[string][]string) (models.Clust
 
 	return r0, r1
 }
+
+// GetAllClusterTypes provides a mock function with given fields:
+func (_m *MockClustersService) GetAllClusterTypes() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetAllSIDs provides a mock function with given fields:
+func (_m *MockClustersService) GetAllSIDs() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetAllTags provides a mock function with given fields:
+func (_m *MockClustersService) GetAllTags() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/web/services/clusters_test.go
+++ b/web/services/clusters_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/trento/test/helpers"
+	"github.com/trento-project/trento/web/entities"
 	"github.com/trento-project/trento/web/models"
 	"gorm.io/gorm"
 )
@@ -14,7 +15,6 @@ type ClustersServiceTestSuite struct {
 	db              *gorm.DB
 	tx              *gorm.DB
 	clustersService *clustersService
-	tagsService     *MockTagsService
 	checksService   *MockChecksService
 }
 
@@ -25,19 +25,18 @@ func TestClustersServiceTestSuite(t *testing.T) {
 func (suite *ClustersServiceTestSuite) SetupSuite() {
 	suite.db = helpers.SetupTestDatabase(suite.T())
 
-	suite.db.AutoMigrate(models.Cluster{})
+	suite.db.AutoMigrate(entities.Cluster{}, models.Tag{})
 	loadClustersFixtures(suite.db)
 }
 
 func (suite *ClustersServiceTestSuite) TearDownSuite() {
-	suite.db.Migrator().DropTable(models.Cluster{})
+	suite.db.Migrator().DropTable(entities.Cluster{}, models.Tag{})
 }
 
 func (suite *ClustersServiceTestSuite) SetupTest() {
 	suite.tx = suite.db.Begin()
 	suite.checksService = new(MockChecksService)
-	suite.tagsService = new(MockTagsService)
-	suite.clustersService = NewClustersService(suite.tx, suite.checksService, suite.tagsService)
+	suite.clustersService = NewClustersService(suite.tx, suite.checksService)
 }
 
 func (suite *ClustersServiceTestSuite) TearDownTest() {
@@ -45,29 +44,50 @@ func (suite *ClustersServiceTestSuite) TearDownTest() {
 }
 
 func loadClustersFixtures(db *gorm.DB) {
-	db.Create(&models.Cluster{
+	db.Create(&entities.Cluster{
 		ID:              "1",
 		Name:            "cluster1",
 		ClusterType:     models.ClusterTypeScaleUp,
 		SIDs:            []string{"DEV"},
 		ResourcesNumber: 10,
 		HostsNumber:     2,
+		Tags: []models.Tag{
+			{
+				ResourceID:   "1",
+				ResourceType: models.TagClusterResourceType,
+				Value:        "tag1",
+			},
+		},
 	})
-	db.Create(&models.Cluster{
+	db.Create(&entities.Cluster{
 		ID:              "2",
 		Name:            "cluster2",
 		ClusterType:     models.ClusterTypeScaleOut,
 		SIDs:            []string{"QAS"},
 		ResourcesNumber: 11,
 		HostsNumber:     2,
+		Tags: []models.Tag{
+			{
+				ResourceID:   "2",
+				ResourceType: models.TagClusterResourceType,
+				Value:        "tag2",
+			},
+		},
 	})
-	db.Create(&models.Cluster{
+	db.Create(&entities.Cluster{
 		ID:              "3",
 		Name:            "cluster3",
 		ClusterType:     models.ClusterTypeUnknown,
 		SIDs:            []string{"PRD", "PRD2"},
 		ResourcesNumber: 3,
 		HostsNumber:     5,
+		Tags: []models.Tag{
+			{
+				ResourceID:   "3",
+				ResourceType: models.TagClusterResourceType,
+				Value:        "tag3",
+			},
+		},
 	})
 }
 
@@ -75,10 +95,6 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetAll() {
 	suite.checksService.On("GetAggregatedChecksResultByCluster", "1").Return(&AggregatedCheckData{PassingCount: 1}, nil)
 	suite.checksService.On("GetAggregatedChecksResultByCluster", "2").Return(&AggregatedCheckData{WarningCount: 1}, nil)
 	suite.checksService.On("GetAggregatedChecksResultByCluster", "3").Return(&AggregatedCheckData{CriticalCount: 1}, nil)
-
-	suite.tagsService.On("GetAllByResource", models.TagClusterResourceType, "1").Return([]string{"tag1", "tag2"}, nil)
-	suite.tagsService.On("GetAllByResource", models.TagClusterResourceType, "2").Return([]string{"tag3", "tag4"}, nil)
-	suite.tagsService.On("GetAllByResource", models.TagClusterResourceType, "3").Return([]string{"tag5", "tag6"}, nil)
 
 	clusters, _ := suite.clustersService.GetAll(map[string][]string{})
 
@@ -91,7 +107,7 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetAll() {
 			ResourcesNumber: 10,
 			HostsNumber:     2,
 			Health:          models.CheckPassing,
-			Tags:            []string{"tag1", "tag2"},
+			Tags:            []string{"tag1"},
 		},
 		&models.Cluster{
 			ID:              "2",
@@ -101,7 +117,7 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetAll() {
 			ResourcesNumber: 11,
 			HostsNumber:     2,
 			Health:          models.CheckWarning,
-			Tags:            []string{"tag3", "tag4"},
+			Tags:            []string{"tag2"},
 		},
 		&models.Cluster{
 			ID:              "3",
@@ -111,7 +127,39 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetAll() {
 			ResourcesNumber: 3,
 			HostsNumber:     5,
 			Health:          models.CheckCritical,
-			Tags:            []string{"tag5", "tag6"},
+			Tags:            []string{"tag3"},
 		},
 	}, clusters)
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAll_Filter() {
+	suite.checksService.On("GetAggregatedChecksResultByCluster", "1").Return(&AggregatedCheckData{PassingCount: 1}, nil)
+
+	clusters, _ := suite.clustersService.GetAll(map[string][]string{
+		"health":       {models.CheckPassing},
+		"cluster_type": {models.ClusterTypeScaleUp},
+		"sids":         {"DEV"},
+		"tags":         {"tag1"},
+	})
+
+	suite.Equal(1, len(clusters))
+	suite.Equal(clusters[0].ID, "1")
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllClusterTypes() {
+	clusterTypes, _ := suite.clustersService.GetAllClusterTypes()
+	suite.ElementsMatch(
+		[]string{models.ClusterTypeScaleUp,
+			models.ClusterTypeScaleOut,
+			models.ClusterTypeUnknown}, clusterTypes)
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllTags() {
+	tags, _ := suite.clustersService.GetAllTags()
+	suite.ElementsMatch([]string{"tag1", "tag2", "tag3"}, tags)
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllSIDs() {
+	sids, _ := suite.clustersService.GetAllSIDs()
+	suite.ElementsMatch([]string{"DEV", "QAS", "PRD", "PRD2"}, sids)
 }

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -38,23 +38,23 @@
                 {{- end }}
             {{- end}}
         </select>
-        <select name="sid" id="sid_filter" class="selectpicker" multiple
+        <select name="sids" id="sid_filter" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true" title="SID">
-            {{- range .ClustersTable.GetAllSIDs }}
+            {{- range .FilterSIDs }}
                 <option value="{{ . }}">{{ . }}</option>
             {{- end }}
         </select>
         <select name="cluster_type" id="cluster_type_filter" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                 title="Cluster type">
-            {{- range .ClustersTable.GetAllClusterTypes }}
+            {{- range .FilterClusterTypes }}
                 <option value="{{ . }}">{{ . }}</option>
             {{- end}}
         </select>
         <select name="tags" id="tags_filter" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                 title="Tags">
-            {{- range .ClustersTable.GetAllTags }}
+            {{- range .FilterTags }}
                 <option value="{{ . }}">{{ . }}</option>
             {{- end}}
         </select>


### PR DESCRIPTION
Iterating on the hosts projectors we introduced the separation between persistence related structs and models.
Also we managed to use polymorphic associations for tags.
This PR refactors the clusters service with this concepts.

Next iterations will introduce variadic functional options for filtering and pagination.