### PR TITLE
Move concurrency to workflow-level

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,4 +1,5 @@
 name: Continous Integration and Demo Deployment
+concurrency: ci-${{ github.ref }}
 on:
   push:
     tags-ignore:
@@ -156,7 +157,6 @@ jobs:
     needs: build-static-binary
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: "ubuntu-latest"
-    concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -193,7 +193,6 @@ jobs:
     needs: [ build-and-push-container-images, release-rolling ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
-    concurrency: ci-${{ github.ref }}
     env:
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
@@ -216,7 +215,6 @@ jobs:
     needs: [ deploy-server ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
-    concurrency: ci-${{ github.ref }}
     env:
       TRENTO_AGENT_HOSTS: ${{ secrets.TRENTO_AGENT_HOSTS }}
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
@@ -245,7 +243,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    concurrency: ci-${{ github.ref }}
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image-target }}
@@ -283,7 +280,6 @@ jobs:
     needs: [test-binary, test-checks]
     runs-on: ubuntu-18.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
-    concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:
@@ -317,7 +313,6 @@ jobs:
     needs: obs-commit
     runs-on: ubuntu-18.04
     if: github.event.release
-    concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
     steps:


### PR DESCRIPTION
This PR addresses an issue that causes jobs to randomly get canceled due to the `concurrency` flag introduced in the CI with commit https://github.com/trento-project/trento/commit/88ed59eccb6b532a8316a9eaba7ffd361fc4e298

It basically moves the concurrency to the workflow level.