### PR TITLE
Remove /api prefix from swagger api docstrings

### DIFF
--- a/docs/api/docs.go
+++ b/docs/api/docs.go
@@ -31,7 +31,7 @@ var doc = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
-        "/api/checks/catalog": {
+        "/checks/catalog": {
             "get": {
                 "produces": [
                     "application/json"
@@ -90,7 +90,7 @@ var doc = `{
                 }
             }
         },
-        "/api/checks/{id}/settings": {
+        "/checks/{id}/settings": {
             "get": {
                 "consumes": [
                     "application/json"
@@ -171,7 +171,7 @@ var doc = `{
                 }
             }
         },
-        "/api/clusters/{cluster_id}/results": {
+        "/clusters/{cluster_id}/results": {
             "get": {
                 "produces": [
                     "application/json"
@@ -206,7 +206,7 @@ var doc = `{
                 }
             }
         },
-        "/api/clusters/{id}/tags": {
+        "/clusters/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -270,7 +270,7 @@ var doc = `{
                 }
             }
         },
-        "/api/clusters/{id}/tags/{tag}": {
+        "/clusters/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -306,7 +306,7 @@ var doc = `{
                 }
             }
         },
-        "/api/databases/{id}/tags": {
+        "/databases/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -370,7 +370,7 @@ var doc = `{
                 }
             }
         },
-        "/api/databases/{id}/tags/{tag}": {
+        "/databases/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -406,7 +406,7 @@ var doc = `{
                 }
             }
         },
-        "/api/hosts/{name}/tags": {
+        "/hosts/{name}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -470,7 +470,7 @@ var doc = `{
                 }
             }
         },
-        "/api/hosts/{name}/tags/{tag}": {
+        "/hosts/{name}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -506,7 +506,7 @@ var doc = `{
                 }
             }
         },
-        "/api/sapsystems/{id}/tags": {
+        "/sapsystems/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -570,7 +570,7 @@ var doc = `{
                 }
             }
         },
-        "/api/sapsystems/{id}/tags/{tag}": {
+        "/sapsystems/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -606,7 +606,7 @@ var doc = `{
                 }
             }
         },
-        "/api/tags": {
+        "/tags": {
             "get": {
                 "consumes": [
                     "application/json"

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -19,7 +19,7 @@
     },
     "basePath": "/api",
     "paths": {
-        "/api/checks/catalog": {
+        "/checks/catalog": {
             "get": {
                 "produces": [
                     "application/json"
@@ -78,7 +78,7 @@
                 }
             }
         },
-        "/api/checks/{id}/settings": {
+        "/checks/{id}/settings": {
             "get": {
                 "consumes": [
                     "application/json"
@@ -159,7 +159,7 @@
                 }
             }
         },
-        "/api/clusters/{cluster_id}/results": {
+        "/clusters/{cluster_id}/results": {
             "get": {
                 "produces": [
                     "application/json"
@@ -194,7 +194,7 @@
                 }
             }
         },
-        "/api/clusters/{id}/tags": {
+        "/clusters/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -258,7 +258,7 @@
                 }
             }
         },
-        "/api/clusters/{id}/tags/{tag}": {
+        "/clusters/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -294,7 +294,7 @@
                 }
             }
         },
-        "/api/databases/{id}/tags": {
+        "/databases/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -358,7 +358,7 @@
                 }
             }
         },
-        "/api/databases/{id}/tags/{tag}": {
+        "/databases/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -394,7 +394,7 @@
                 }
             }
         },
-        "/api/hosts/{name}/tags": {
+        "/hosts/{name}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -458,7 +458,7 @@
                 }
             }
         },
-        "/api/hosts/{name}/tags/{tag}": {
+        "/hosts/{name}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -494,7 +494,7 @@
                 }
             }
         },
-        "/api/sapsystems/{id}/tags": {
+        "/sapsystems/{id}/tags": {
             "post": {
                 "consumes": [
                     "application/json"
@@ -558,7 +558,7 @@
                 }
             }
         },
-        "/api/sapsystems/{id}/tags/{tag}": {
+        "/sapsystems/{id}/tags/{tag}": {
             "delete": {
                 "consumes": [
                     "application/json"
@@ -594,7 +594,7 @@
                 }
             }
         },
-        "/api/tags": {
+        "/tags": {
             "get": {
                 "consumes": [
                     "application/json"

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -124,7 +124,7 @@ info:
   title: Trento API
   version: "1.0"
 paths:
-  /api/checks/{id}/settings:
+  /checks/{id}/settings:
     get:
       consumes:
       - application/json
@@ -177,7 +177,7 @@ paths:
               type: string
             type: object
       summary: Create the check settings
-  /api/checks/catalog:
+  /checks/catalog:
     get:
       produces:
       - application/json
@@ -215,7 +215,7 @@ paths:
               type: string
             type: object
       summary: Create/Updates the checks catalog
-  /api/clusters/{cluster_id}/results:
+  /clusters/{cluster_id}/results:
     get:
       parameters:
       - description: Cluster Id
@@ -238,7 +238,7 @@ paths:
               type: string
             type: object
       summary: Get a specific cluster's check results
-  /api/clusters/{id}/tags:
+  /clusters/{id}/tags:
     post:
       consumes:
       - application/json
@@ -280,7 +280,7 @@ paths:
               type: string
             type: object
       summary: Add tag to Cluster
-  /api/clusters/{id}/tags/{tag}:
+  /clusters/{id}/tags/{tag}:
     delete:
       consumes:
       - application/json
@@ -304,7 +304,7 @@ paths:
             additionalProperties: true
             type: object
       summary: Delete a specific tag that belongs to a cluster
-  /api/databases/{id}/tags:
+  /databases/{id}/tags:
     post:
       consumes:
       - application/json
@@ -346,7 +346,7 @@ paths:
               type: string
             type: object
       summary: Add tag to a HANA database
-  /api/databases/{id}/tags/{tag}:
+  /databases/{id}/tags/{tag}:
     delete:
       consumes:
       - application/json
@@ -370,7 +370,7 @@ paths:
             additionalProperties: true
             type: object
       summary: Delete a specific tag that belongs to a HANA database
-  /api/hosts/{name}/tags:
+  /hosts/{name}/tags:
     post:
       consumes:
       - application/json
@@ -412,7 +412,7 @@ paths:
               type: string
             type: object
       summary: Add tag to host
-  /api/hosts/{name}/tags/{tag}:
+  /hosts/{name}/tags/{tag}:
     delete:
       consumes:
       - application/json
@@ -436,7 +436,7 @@ paths:
             additionalProperties: true
             type: object
       summary: Delete a specific tag that belongs to a host
-  /api/sapsystems/{id}/tags:
+  /sapsystems/{id}/tags:
     post:
       consumes:
       - application/json
@@ -478,7 +478,7 @@ paths:
               type: string
             type: object
       summary: Add tag to SAPSystem
-  /api/sapsystems/{id}/tags/{tag}:
+  /sapsystems/{id}/tags/{tag}:
     delete:
       consumes:
       - application/json
@@ -502,7 +502,7 @@ paths:
             additionalProperties: true
             type: object
       summary: Delete a specific tag that belongs to a SAPSystem
-  /api/tags:
+  /tags:
     get:
       consumes:
       - application/json

--- a/web/checks_api.go
+++ b/web/checks_api.go
@@ -45,7 +45,7 @@ type JSONChecksGroupedCatalog []*JSONChecksGroup
 // @Produce json
 // @Success 200 {object} JSONChecksGroupedCatalog
 // @Error 500
-// @Router /api/checks/catalog [get]
+// @Router /checks/catalog [get]
 func ApiChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var groupedCatalog JSONChecksGroupedCatalog
@@ -70,7 +70,7 @@ func ApiChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 // @Param cluster_id path string true "Cluster Id"
 // @Success 200 {object} map[string]interface{}
 // @Failure 500 {object} map[string]string
-// @Router /api/clusters/{cluster_id}/results [get]
+// @Router /clusters/{cluster_id}/results [get]
 func ApiClusterCheckResultsHandler(client consul.Client, s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		clusterId := c.Param("cluster_id")
@@ -91,7 +91,7 @@ func ApiClusterCheckResultsHandler(client consul.Client, s services.ChecksServic
 // @Param Body body JSONChecksCatalog true "Checks catalog"
 // @Success 200 {object} JSONChecksCatalog
 // @Failure 500 {object} map[string]string
-// @Router /api/checks/catalog [put]
+// @Router /checks/catalog [put]
 func ApiCreateChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
@@ -135,7 +135,7 @@ func ApiCreateChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 // @Param id path string true "Resource id"
 // @Success 200 {object} JSONChecksSettings
 // @Failure 404 {object} map[string]string
-// @Router /api/checks/{id}/settings [get]
+// @Router /checks/{id}/settings [get]
 func ApiCheckGetSettingsByIdHandler(consul consul.Client, s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		resourceId := c.Param("id")
@@ -199,7 +199,7 @@ func ApiCheckGetSettingsByIdHandler(consul consul.Client, s services.ChecksServi
 // @Param Body body JSONChecksSettings true "Checks settings"
 // @Success 201 {object} JSONChecksSettings
 // @Failure 500 {object} map[string]string
-// @Router /api/checks/{id}/settings [post]
+// @Router /checks/{id}/settings [post]
 func ApiCheckCreateSettingsByIdHandler(s services.ChecksService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		resourceId := c.Param("id")

--- a/web/tags_api.go
+++ b/web/tags_api.go
@@ -22,7 +22,7 @@ type JSONTag struct {
 // @Param resource_type query string false "Filter by resource type"
 // @Success 200 {object} []string
 // @Failure 500 {object} map[string]string
-// @Router /api/tags [get]
+// @Router /tags [get]
 func ApiListTag(tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		query := c.Request.URL.Query()
@@ -53,7 +53,7 @@ func ApiListTag(tagsService services.TagsService) gin.HandlerFunc {
 // @Failure 404 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
-// @Router /api/hosts/{name}/tags [post]
+// @Router /hosts/{name}/tags [post]
 func ApiHostCreateTagHandler(client consul.Client, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -94,7 +94,7 @@ func ApiHostCreateTagHandler(client consul.Client, tagsService services.TagsServ
 // @Param name path string true "Host name"
 // @Param tag path string true "Tag"
 // @Success 204 {object} map[string]interface{}
-// @Router /api/hosts/{name}/tags/{tag} [delete]
+// @Router /hosts/{name}/tags/{tag} [delete]
 func ApiHostDeleteTagHandler(client consul.Client, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
@@ -131,7 +131,7 @@ func ApiHostDeleteTagHandler(client consul.Client, tagsService services.TagsServ
 // @Failure 404 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
-// @Router /api/clusters/{id}/tags [post]
+// @Router /clusters/{id}/tags [post]
 func ApiClusterCreateTagHandler(client consul.Client, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
@@ -172,7 +172,7 @@ func ApiClusterCreateTagHandler(client consul.Client, tagsService services.TagsS
 // @Param id path string true "Cluster id"
 // @Param tag path string true "Tag"
 // @Success 204 {object} map[string]interface{}
-// @Router /api/clusters/{id}/tags/{tag} [delete]
+// @Router /clusters/{id}/tags/{tag} [delete]
 func ApiClusterDeleteTagHandler(client consul.Client, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
@@ -209,7 +209,7 @@ func ApiClusterDeleteTagHandler(client consul.Client, tagsService services.TagsS
 // @Failure 404 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
-// @Router /api/sapsystems/{id}/tags [post]
+// @Router /sapsystems/{id}/tags [post]
 func ApiSAPSystemCreateTagHandler(sapSystemsService services.SAPSystemsService, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
@@ -250,7 +250,7 @@ func ApiSAPSystemCreateTagHandler(sapSystemsService services.SAPSystemsService, 
 // @Param id path string true "SAPSystem id"
 // @Param tag path string true "Tag"
 // @Success 204 {object} map[string]interface{}
-// @Router /api/sapsystems/{id}/tags/{tag} [delete]
+// @Router /sapsystems/{id}/tags/{tag} [delete]
 func ApiSAPSystemDeleteTagHandler(sapSystemsService services.SAPSystemsService, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
@@ -287,7 +287,7 @@ func ApiSAPSystemDeleteTagHandler(sapSystemsService services.SAPSystemsService, 
 // @Failure 404 {object} map[string]string
 // @Failure 400 {object} map[string]string
 // @Failure 500 {object} map[string]string
-// @Router /api/databases/{id}/tags [post]
+// @Router /databases/{id}/tags [post]
 func ApiDatabaseCreateTagHandler(sapSystemsService services.SAPSystemsService, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")
@@ -328,7 +328,7 @@ func ApiDatabaseCreateTagHandler(sapSystemsService services.SAPSystemsService, t
 // @Param id path string true "Database id"
 // @Param tag path string true "Tag"
 // @Success 204 {object} map[string]interface{}
-// @Router /api/databases/{id}/tags/{tag} [delete]
+// @Router /databases/{id}/tags/{tag} [delete]
 func ApiDatabaseDeleteTagHandler(sapSystemsService services.SAPSystemsService, tagsService services.TagsService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		id := c.Param("id")


### PR DESCRIPTION
Fix for: https://github.com/trento-project/trento/issues/453

I guess the error was introduced in: https://github.com/trento-project/trento/pull/411

PD: I don't know why it has introduced the `github.com/alecthomas/template"` package honestly. I'm using the swag:
```
trento> swag --version
swag version v1.7.0
```