### PR TITLE
Ci goodies 2: The Comeback

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,6 @@
-web/frontend/node_modules
-web/frontend/assets
-trento
+/*.sh
+/.github
+/packaging
+/trento
+/web/frontend/assets
+/web/frontend/node_modules

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -93,6 +93,80 @@ jobs:
       - name: trento checks ID sanity test
         run: python3 hack/id_checker.py
 
+  build-container-images:
+    runs-on: ubuntu-20.04
+    needs: [test-binary, test-checks]
+    strategy:
+      matrix:
+        image:
+          - trento-web
+          - trento-runner
+    permissions:
+      contents: read
+      packages: write
+    concurrency: ci-${{ github.ref }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || github.ref_name == 'main' && 'rolling' || github.sha }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        if: github.event_name == 'release' || github.ref_name == 'main'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
+      - name: Build and push container image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: "${{ github.event_name == 'release' || github.ref_name == 'main' }}"
+          target: ${{ matrix.image }}
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          outputs: type=docker,dest=/tmp/${{ matrix.image }}-image.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.image }}-image
+          path: /tmp/${{ matrix.image }}-image.tar
+
+  smoke-test-container-images:
+    runs-on: ubuntu-20.04
+    needs: build-container-images
+    strategy:
+      matrix:
+        image:
+          - trento-web
+          - trento-runner
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.ref_name == 'main' && 'rolling') || github.sha }}"
+    steps:
+      - uses: docker/setup-buildx-action@v1
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.image }}-image
+          path: /tmp
+      - name: Load image
+        run: docker load --input /tmp/${{ matrix.image }}-image.tar
+      - name: Test CLI
+        run: docker run --rm ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
+
   test-helm-charts:
     runs-on: ubuntu-latest
     steps:
@@ -154,8 +228,8 @@ jobs:
 
   release-rolling:
     needs: build-static-binary
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    runs-on: "ubuntu-latest"
+    if: github.ref_name == 'main'
+    runs-on: ubuntu-20.04
     concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/download-artifact@v2
@@ -190,8 +264,8 @@ jobs:
 
   deploy-server:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ build-and-push-container-images, release-rolling ]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
+    if: github.ref_name == 'main'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
     env:
@@ -214,7 +288,7 @@ jobs:
   deploy-agents:
     runs-on: [ self-hosted, trento-gh-runner ]
     needs: [ deploy-server ]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.ref_name == 'main'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
     env:
@@ -281,8 +355,8 @@ jobs:
 
   obs-commit:
     needs: [test-binary, test-checks]
-    runs-on: ubuntu-18.04
-    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
+    runs-on: ubuntu-20.04
+    if: github.event_name == 'release' || github.ref_name == 'main'
     concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -137,7 +137,13 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar
+      - name: Create image artifact
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar          
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -142,6 +142,7 @@ jobs:
         with:
           context: .
           push: false
+          target: ${{ matrix.image }}
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
           outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar          
       - name: Upload artifact

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -94,7 +94,7 @@ jobs:
       - name: trento checks ID sanity test
         run: python3 hack/id_checker.py
 
-  build-container-images:
+  build-and-push-container-images:
     runs-on: ubuntu-20.04
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
     needs: [test-binary, test-checks]
@@ -137,7 +137,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build-container-assets:
+  build-and-export-container-images:
     runs-on: ubuntu-20.04
     needs: [test-binary, test-checks]
     strategy:
@@ -179,7 +179,7 @@ jobs:
 
   smoke-test-container-images:
     runs-on: ubuntu-20.04
-    needs: build-container-images
+    needs: build-and-export-container-images
     strategy:
       matrix:
         image:
@@ -297,7 +297,7 @@ jobs:
 
   deploy-server:
     runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
+    needs: [ smoke-test-container-images, build-and-push-container-images, test-helm-charts, release-rolling ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     env:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -172,7 +172,7 @@ jobs:
       - name: Load image
         run: docker load --input /tmp/trento-${{ matrix.image }}.tar
       - name: Test CLI
-        run: docker run --rm -ti ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
+        run: docker run --rm ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
 
   test-helm-charts:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,4 +1,5 @@
 name: Continous Integration and Demo Deployment
+concurrency: ci-${{ github.ref }}
 on:
   push:
     tags-ignore:
@@ -104,7 +105,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    concurrency: ci-${{ github.ref }}
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
@@ -237,7 +237,6 @@ jobs:
     needs: build-static-binary
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-20.04
-    concurrency: ci-${{ github.ref }}
     steps:
       - uses: actions/download-artifact@v2
         with:
@@ -274,7 +273,6 @@ jobs:
     needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
-    concurrency: ci-${{ github.ref }}
     env:
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
@@ -297,7 +295,6 @@ jobs:
     needs: [ deploy-server ]
     if: github.ref_name == 'main'
     environment: AZURE_DEMO
-    concurrency: ci-${{ github.ref }}
     env:
       TRENTO_AGENT_HOSTS: ${{ secrets.TRENTO_AGENT_HOSTS }}
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
@@ -318,7 +315,6 @@ jobs:
     needs: [test-binary, test-checks]
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main' || github.event_name == 'release'
-    concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:
@@ -352,7 +348,6 @@ jobs:
     needs: obs-commit
     runs-on: ubuntu-20.04
     if: github.event.release
-    concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
     steps:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -108,15 +108,16 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || github.ref_name == 'main' && 'rolling' || github.sha }}"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
+      PUSH: "${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}"
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v1
       - name: Log in to the Container registry
+        if: ${{ env.PUSH }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        if: github.event_name == 'release' || github.ref_name == 'main'
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -130,18 +131,18 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: "${{ github.event_name == 'release' || github.ref_name == 'main' }}"
+          push: ${{ env.PUSH }}
           target: ${{ matrix.image }}
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          outputs: type=docker,dest=/tmp/${{ matrix.image }}-image.tar
+          outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.image }}-image
-          path: /tmp/${{ matrix.image }}-image.tar
+          name: trento-${{ matrix.image }}
+          path: /tmp/trento-${{ matrix.image }}.tar
 
   smoke-test-container-images:
     runs-on: ubuntu-20.04
@@ -154,21 +155,21 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.ref_name == 'main' && 'rolling') || github.sha }}"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
     steps:
       - uses: docker/setup-buildx-action@v1
       - name: Download artifact
         uses: actions/download-artifact@v2
         with:
-          name: ${{ matrix.image }}-image
+          name: trento-${{ matrix.image }}
           path: /tmp
       - name: Load image
-        run: docker load --input /tmp/${{ matrix.image }}-image.tar
+        run: docker load --input /tmp/trento-${{ matrix.image }}.tar
       - name: Test CLI
-        run: docker run --rm ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
+        run: docker run --rm -ti ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }} version
 
   test-helm-charts:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -228,7 +229,7 @@ jobs:
 
   release-rolling:
     needs: build-static-binary
-    if: github.ref_name == 'main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-20.04
     concurrency: ci-${{ github.ref }}
     steps:
@@ -265,7 +266,7 @@ jobs:
   deploy-server:
     runs-on: [ self-hosted, trento-gh-runner ]
     needs: [ smoke-test-container-images, test-helm-charts, release-rolling ]
-    if: github.ref_name == 'main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     concurrency: ci-${{ github.ref }}
     env:
@@ -307,56 +308,10 @@ jobs:
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 
-  build-and-push-container-images:
-    needs: [test-binary, test-checks]
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || github.event_name == 'workflow_dispatch'
-    strategy:
-      matrix:
-        image-target:
-          - trento-web
-          - trento-runner
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    concurrency: ci-${{ github.ref }}
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image-target }}
-      IMAGE_TAG: "${{ github.event_name == 'release' && github.event.release.tag_name || 'rolling' }}"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.IMAGE_REPOSITORY }}
-      - name: Build and push container image
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: true
-          target: ${{ matrix.image-target }}
-          tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   obs-commit:
     needs: [test-binary, test-checks]
     runs-on: ubuntu-20.04
-    if: github.event_name == 'release' || github.ref_name == 'main'
+    if: github.ref == 'refs/heads/main' || github.event_name == 'release'
     concurrency: ci-${{ github.ref }}
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
@@ -389,7 +344,7 @@ jobs:
 
   obs-submit:
     needs: obs-commit
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     if: github.event.release
     concurrency: ci-${{ github.ref }}
     container:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -96,6 +96,7 @@ jobs:
 
   build-container-images:
     runs-on: ubuntu-20.04
+    if: github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
     needs: [test-binary, test-checks]
     strategy:
       matrix:
@@ -108,15 +109,13 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
-      PUSH: "${{ github.event_name == 'release' || (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch' }}"
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"      
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - uses: docker/setup-buildx-action@v1
       - name: Log in to the Container registry
-        if: ${{ env.PUSH }}
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
@@ -131,12 +130,38 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          push: ${{ env.PUSH }}
+          push: true
           target: ${{ matrix.image }}
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  build-container-assets:
+    runs-on: ubuntu-20.04
+    needs: [test-binary, test-checks]
+    strategy:
+      matrix:
+        image:
+          - trento-web
+          - trento-runner
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+      IMAGE_TAG: "${{ (github.event_name == 'release' && github.event.release.tag_name) || (github.event_name == 'push' && github.ref_name == 'main' && 'rolling') || github.sha }}"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: docker/setup-buildx-action@v1
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.IMAGE_REPOSITORY }}
       - name: Create image artifact
         uses: docker/build-push-action@v2
         with:
@@ -144,6 +169,7 @@ jobs:
           push: false
           target: ${{ matrix.image }}
           tags: ${{ env.IMAGE_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          labels: ${{ steps.meta.outputs.labels }}
           outputs: type=docker,dest=/tmp/trento-${{ matrix.image }}.tar          
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default: clean mod-tidy fmt vet-check web-check test build
 
 .PHONY: build
 build: trento
-trento: web-assets
+trento: web/frontend/assets
 	$(GO_BUILD)
 
 .PHONY: cross-compiled $(ARCHS)


### PR DESCRIPTION
This PR brings back https://github.com/trento-project/trento/pull/438 which had to be reverted due to failing builds. It should fix the issue by splitting the docker push & asset creation into two separate tasks.

Additionally, It was also required to remove the `-ti` arguments from the `docker` command line as it wasn't able to allocate a TTY when running from the GH action