### PR TITLE
Add conditional in the spec file to detect TW and otherwise avoid missing macro

### DIFF
--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -71,7 +71,11 @@ install -D -m 0755 %{shortname} "%{buildroot}%{_bindir}/%{shortname}"
 install -D -m 0644 packaging/systemd/trento-agent.service %{buildroot}%{_unitdir}/trento-agent.service
 
 # Install the default configuration files
+%if 0%{?suse_version} > 1500
 install -D -m 0640 packaging/config/agent.yaml %{buildroot}%{_distconfdir}/trento/agent.yaml
+%else
+install -D -m 0640 packaging/config/agent.yaml %{buildroot}%{_sysconfdir}/trento/agent.yaml
+%endif
 
 %pre
 %service_add_pre trento-agent.service
@@ -93,7 +97,12 @@ install -D -m 0640 packaging/config/agent.yaml %{buildroot}%{_distconfdir}/trent
 %{_bindir}/%{shortname}
 %{_unitdir}/trento-agent.service
 
+%if 0%{?suse_version} > 1500
 %dir %_distconfdir/trento
 %_distconfdir/trento/agent.yaml
+%else
+%dir %{_sysconfdir}/trento
+%config (noreplace) %{_sysconfdir}/trento/agent.yaml
+%endif
 
 %changelog


### PR DESCRIPTION
This PR addresses the failing RPM builds in the build service due to the missing `%_distconfdir` macro for `/usr/etc/` that only exists in TW. Following [this](https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto) guide we've introduced a if that conditionally builds the package using the new config file directory for packages or falls back to the classic `/etc/`.

Notice that the macro itself could be added easily but still, we are not allowed to own `/usr/etc` so we wouldn't be able to make an RPM package that creates `/usr/etc`.

