### PR TITLE
Detect aws and gcp clouds in the agent

### DIFF
--- a/internal/cloud/metadata.go
+++ b/internal/cloud/metadata.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	Azure = "azure"
+	Aws = "aws"
 	// DMI chassis asset tag for Azure machines, needed to identify wether or not we are running on Azure
 	// This is actually ASCII-encoded, the decoding into a string results in "MSFT AZURE VM"
 	azureDmiTag = "7783-7084-3265-9085-8269-3286-77"
@@ -23,25 +24,31 @@ type CustomCommand func(name string, arg ...string) *exec.Cmd
 
 var customExecCommand CustomCommand = exec.Command
 
-func IdentifyCloudProvider() (string, error) {
-	log.Info("Identifying if the VM is running in a cloud environment...")
+func identifyAzure() (bool, error) {
+	log.Debug("Checking if the VM is running on Azure...")
 	output, err := customExecCommand("dmidecode", "-s", "chassis-asset-tag").Output()
 	if err != nil {
-		return "", err
+		return false, err
 	}
 
 	provider := strings.TrimSpace(string(output))
 	log.Debugf("dmidecode output: %s", provider)
 
-	switch string(provider) {
-	case azureDmiTag:
+	return provider == azureDmiTag, nil
+}
+
+func IdentifyCloudProvider() (string, error) {
+	log.Info("Identifying if the VM is running in a cloud environment...")
+
+	if result, err := identifyAzure(); err != nil {
+		return "", err
+	} else if result {
 		log.Infof("VM is running on %s", Azure)
 		return Azure, nil
-	default:
-		log.Info("VM is not running in any recognized cloud provider")
-		return "", nil
 	}
 
+	log.Info("VM is not running in any recognized cloud provider")
+	return "", nil
 }
 
 func NewCloudInstance() (*CloudInstance, error) {

--- a/internal/cloud/metadata_test.go
+++ b/internal/cloud/metadata_test.go
@@ -73,6 +73,33 @@ func TestIdentifyCloudProviderAws(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func mockDmidecodeGcp() *exec.Cmd {
+	return exec.Command("echo", "Google")
+}
+
+func TestIdentifyCloudProviderGcp(t *testing.T) {
+	mockCommand := new(mocks.CustomCommand)
+
+	customExecCommand = mockCommand.Execute
+
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
+		mockDmidecodeGcp(),
+	)
+
+	provider, err := IdentifyCloudProvider()
+
+	assert.Equal(t, "gcp", provider)
+	assert.NoError(t, err)
+}
+
 func mockDmidecodeNoCloud() *exec.Cmd {
 	return exec.Command("echo", "")
 }
@@ -87,6 +114,10 @@ func TestIdentifyCloudProviderNoCloud(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
 		mockDmidecodeNoCloud(),
 	)
 
@@ -138,6 +169,10 @@ func TestNewCloudInstanceNoCloud(t *testing.T) {
 	)
 
 	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "bios-vendor").Return(
 		mockDmidecodeNoCloud(),
 	)
 

--- a/internal/cloud/metadata_test.go
+++ b/internal/cloud/metadata_test.go
@@ -50,6 +50,29 @@ func TestIdentifyCloudProviderAzure(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func mockDmidecodeAws() *exec.Cmd {
+	return exec.Command("echo", "4.11.amazon")
+}
+
+func TestIdentifyCloudProviderAws(t *testing.T) {
+	mockCommand := new(mocks.CustomCommand)
+
+	customExecCommand = mockCommand.Execute
+
+	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
+		mockDmidecodeAws(),
+	)
+
+	provider, err := IdentifyCloudProvider()
+
+	assert.Equal(t, "aws", provider)
+	assert.NoError(t, err)
+}
+
 func mockDmidecodeNoCloud() *exec.Cmd {
 	return exec.Command("echo", "")
 }
@@ -60,6 +83,10 @@ func TestIdentifyCloudProviderNoCloud(t *testing.T) {
 	customExecCommand = mockCommand.Execute
 
 	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
 		mockDmidecodeNoCloud(),
 	)
 
@@ -107,6 +134,10 @@ func TestNewCloudInstanceNoCloud(t *testing.T) {
 	customExecCommand = mockCommand.Execute
 
 	mockCommand.On("Execute", "dmidecode", "-s", "chassis-asset-tag").Return(
+		mockDmidecodeNoCloud(),
+	)
+
+	mockCommand.On("Execute", "dmidecode", "-s", "system-version").Return(
 		mockDmidecodeNoCloud(),
 	)
 


### PR DESCRIPTION
Add `AWS` and `GCP` clouds autodetection in the agent. This data will be used in the server side and sent in telemetry.

The code is based on `crmsh`, as we have been refining there (together with the cloud providers themselves) the cloud auto-detection: https://github.com/ClusterLabs/crmsh/blob/master/crmsh/utils.py#L2055

This is how it looks like;
AWS:
![image](https://user-images.githubusercontent.com/36370954/142204967-fe7b9a7d-1342-43a3-97c2-6705dbd7f6f4.png)
![image](https://user-images.githubusercontent.com/36370954/142204976-050f85d7-7f4d-4cec-bd92-ea679f095633.png)

GCP:
![image](https://user-images.githubusercontent.com/36370954/142204988-7db9fa24-a992-45d9-ac28-eefbe988c732.png)
![image](https://user-images.githubusercontent.com/36370954/142205001-8569b3d1-b9d7-48c8-bc8e-3be77f9515ed.png)
