### PR TITLE
Pin pyparsing to ~2.0 version to avoid issues in runner container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN make build
 FROM python:3.7-slim AS trento-runner
 RUN ln -s /usr/local/bin/python /usr/bin/python \
     && /usr/bin/python -m venv /venv \
-    && /venv/bin/pip install 'ansible~=4.6.0' 'ara~=1.5.7' 'rpm==0.0.2' \
+    && /venv/bin/pip install 'ansible~=4.6.0' 'ara~=1.5.7' 'rpm==0.0.2' 'pyparsing~=2.0' \
     && apt-get update && apt-get install -y --no-install-recommends \
       ssh \
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \


### PR DESCRIPTION
Fix the next error in the `runner`:

```
[WARNING]: Skipping plugin (/tmp/trento/ansible/callback_plugins/trento.py) as
it seems to be invalid: The 'pyparsing<3,>=2.0.2' distribution was not found
and is required by packaging
[WARNING]: Skipping callback 'ara_default', unable to load due to: The
'pyparsing<3,>=2.0.2' distribution was not found and is required by packaging
```

This is caused due a new version in the `pyparsing` package. Pinning the version to `~2.0` fixes the issue.