### PR TITLE
Added scrollbars to the codeblocks

### DIFF
--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -63,6 +63,12 @@ dt {
   pre code {
     color: $eos-bc-red-900;
   }
+  pre {
+    overflow-x: scroll;
+    overflow-y: scroll;
+    max-width: 80rem;
+    max-height: 30rem;
+  }
 }
 
 .nav-title {


### PR DESCRIPTION
By adding scrollbars to the codeblocks, both verticaly and
horizontialy, the checks catalog should be more comfortable to use.

fix #365