### PR TITLE
Allow using `~` in the SSH key path used in the server installer.

### DIFF
--- a/install-server.sh
+++ b/install-server.sh
@@ -24,6 +24,7 @@ EOF
 
 cmdline() {
     local arg=
+    local private_key_absolute_path=
     for arg
     do
         local delim=""
@@ -63,6 +64,14 @@ cmdline() {
     if [[ -z "$PRIVATE_KEY" ]]; then
         read -rp "Please provide the path of the runner private key: " PRIVATE_KEY </dev/tty
     fi
+
+    # Replace tilde with the current home:
+    PRIVATE_KEY="${PRIVATE_KEY/#\~/$HOME}"
+    private_key_absolute_path=$(realpath -q -e "$PRIVATE_KEY" || {
+         echo "Path '${PRIVATE_KEY}' to private SSH key does not exist, please try again."
+         exit 1
+    })
+    PRIVATE_KEY="$private_key_absolute_path"
 
     if [[ "$ROLLING" == "true" ]]; then
         TRENTO_VERSION="rolling"


### PR DESCRIPTION
This PR fixes #492.

The script fails if the user adds something like `~/.ssh/id_rsa` instead of a absolute path starting with `/home/...`. The fix replaces tilde by `$HOME`.

Maybe there are other places to replace this, but I haven't looked into that.