### PR TITLE
Add premium badge to the premium checks in catalog

### DIFF
--- a/runner/ansible/roles/post-metadata/tasks/store.yml
+++ b/runner/ansible/roles/post-metadata/tasks/store.yml
@@ -1,5 +1,15 @@
-- name: Load metadata
+- name: Load top level metadata
   include_vars: "{{ metadata_path }}"
+
+# This 2nd load is needed to get a fresh data set, without pre-loading already existing data.
+# Otherwise, we might have previous checks data here, as the first include_vars adds the variables
+# as top level (we still need that). As example, if the 1st check is premium and 2nd not, only
+# with the 1st include_vars, the premium value would be inherited, and we don't want that, otherwise,
+# we would need to define the premium entry in all the metadata files without having default options
+- name: Load specific metadata
+  include_vars:
+    file: "{{ metadata_path }}"
+    name: metadata_vars
 
 - name: Set metadata {{ id }}
   set_fact:
@@ -12,7 +22,8 @@
             'description': description,
             'remediation': remediation,
             'labels': labels,
-            'implementation': implementation
+            'implementation': implementation,
+            'premium': metadata_vars.premium|default(False)
           }]
         }, recursive=True, list_merge='append')
       }}

--- a/web/checks_api.go
+++ b/web/checks_api.go
@@ -31,6 +31,7 @@ type JSONCheck struct {
 	Remediation    string `json:"remediation,omitempty"`
 	Implementation string `json:"implementation,omitempty"`
 	Labels         string `json:"labels,omitempty"`
+	Premium        bool   `json:"premium,omitempty"`
 }
 
 type JSONChecksGroup struct {
@@ -115,6 +116,7 @@ func ApiCreateChecksCatalogHandler(s services.ChecksService) gin.HandlerFunc {
 				Remediation:    checkData.Remediation,
 				Implementation: checkData.Implementation,
 				Labels:         checkData.Labels,
+				Premium:        checkData.Premium,
 			}
 			catalog = append(catalog, newCheck)
 		}

--- a/web/checks_api_test.go
+++ b/web/checks_api_test.go
@@ -160,6 +160,7 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 			Remediation:    "remediation1",
 			Implementation: "implementation1",
 			Labels:         "labels1",
+			Premium:        true,
 		},
 		&models.Check{
 			ID:             "id2",
@@ -195,6 +196,7 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 			Remediation:    "remediation1",
 			Implementation: "implementation1",
 			Labels:         "labels1",
+			Premium:        true,
 		},
 		&JSONCheck{
 			ID:             "id2",

--- a/web/checks_catalog_test.go
+++ b/web/checks_catalog_test.go
@@ -39,6 +39,7 @@ func TestChecksCatalogHandler(t *testing.T) {
 					Remediation:    "remediation 2",
 					Implementation: "implementation 2",
 					Labels:         "labels 2",
+					Premium:        true,
 				},
 			},
 		},
@@ -80,7 +81,7 @@ func TestChecksCatalogHandler(t *testing.T) {
 	assert.Contains(t, responseBody, "Checks catalog")
 
 	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>ABCDEF</td><td.*>description 1<div.*id=info-ABCDEF.*><p>remediation 1</p></div><div.*implementation 1.*</div>.*</td>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>123456</td><td.*>description 2<div.*id=info-123456.*><p>remediation 2</p></div><div.*implementation 2.*</div>.*</td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>123456</td><td.*>description 2<span class=\"badge badge-trento-premium\">Premium</span><div.*id=info-123456.*><p>remediation 2</p></div><div.*implementation 2.*</div>.*</td>"), responseBody)
 	assert.Regexp(t, regexp.MustCompile("<h4.*>group 2</h4>.*<td.*>123ABC</td><td.*>description 3<div.*id=info-123ABC.*><p>remediation 3</p></div><div.*implementation 3.*</div>.*</td>"), responseBody)
 	assert.Equal(t, 2, strings.Count(responseBody, "<h4"))
 	assert.Equal(t, 5, strings.Count(responseBody, "<tr>"))

--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -205,3 +205,8 @@ td i.critical {
 .trento-pointer {
   cursor: pointer;
 }
+
+.badge-trento-premium {
+  color: #fff;
+  background-color: $eos-bc-green-500;
+}

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -31,6 +31,7 @@ type Check struct {
 	Remediation    string `json:"remediation,omitempty" mapstructure:"remediation,omitempty"`
 	Implementation string `json:"implementation,omitempty" mapstructure:"implementation,omitempty"`
 	Labels         string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
+	Premium        bool   `json:"premium,omitempty" mapstructure:"premium,omitempty"`
 	Selected       bool   `json:"selected,omitempty" mapstructure:"selected,omitempty"`
 	Result         string `json:"result,omitempty" mapstructure:"result,omitempty"`
 }

--- a/web/templates/checks_catalog.html.tmpl
+++ b/web/templates/checks_catalog.html.tmpl
@@ -38,7 +38,7 @@
                                 <tr>
                                     <td class="align-top">{{ .ID }}</td>
                                     <td class="align-top">
-                                        {{ .Description }}
+                                        {{ .Description }}{{ if .Premium }}<span class="badge badge-trento-premium">Premium</span>{{ end }}
                                         <div class="ha-check-remediation collapse" id="info-{{ .ID }}">
                                             {{ markdown (.Remediation) }}
                                         </div>


### PR DESCRIPTION
Add premium badge to the premium checks in the checks catalog.
**How to use**.
In order to make a check `Premium` we need to add the data in the its metadata. To do that we need to change the file `runner/ansible/roles/checks/my-check/defaults/main.tf` for the check, and include a `premium: True` in the file.
By default, the checks are not premium.

![image](https://user-images.githubusercontent.com/36370954/143565343-1035c278-918d-4c48-afac-69e82bab978d.png)

**Question**:
It only goes in the catalog by now. I can include it in the `Check selection` and `Checks results`. In the 1st one it gets pretty ugly, I would need to widen the whole modal (something I would do in any case). Should we add it in those places too?