### PR TITLE
Add flavor to version package

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,6 +17,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Trento",
 	Long:  `All software has versions. This is Trento's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Trento version %s\nbuilt with %s %s/%s\n", version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Trento-%s version %s\nbuilt with %s %s/%s\n", version.Flavor, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,6 +17,6 @@ var versionCmd = &cobra.Command{
 	Short: "Print the version number of Trento",
 	Long:  `All software has versions. This is Trento's`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("Trento-%s version %s\nbuilt with %s %s/%s\n", version.Flavor, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Trento %s version %s\nbuilt with %s %s/%s\n", version.Flavor, version.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }

--- a/version/flavor.go
+++ b/version/flavor.go
@@ -1,0 +1,3 @@
+package version
+
+const Flavor string = "Community"

--- a/web/about.go
+++ b/web/about.go
@@ -20,6 +20,7 @@ func NewAboutHandler(s services.SubscriptionsService) gin.HandlerFunc {
 			"Title":       defaultLayoutData.Title,
 			"Version":     defaultLayoutData.Version,
 			"PremiumData": premiumData,
+			"Flavor":      defaultLayoutData.Flavor,
 		})
 	}
 }

--- a/web/layout.go
+++ b/web/layout.go
@@ -31,6 +31,7 @@ type LayoutData struct {
 	Title     string
 	Copyright string
 	Version   string
+	Flavor    string
 	Submenu   Submenu
 	Content   interface{}
 }
@@ -46,6 +47,7 @@ var defaultLayoutData = LayoutData{
 	Title:     "Trento Console",
 	Copyright: "© 2020-2021 SUSE LLC",
 	Version:   version.Version,
+	Flavor:    version.Flavor,
 }
 
 type LayoutHTML struct {

--- a/web/templates/about.html.tmpl
+++ b/web/templates/about.html.tmpl
@@ -9,6 +9,8 @@
                 <dl class="row">
                     <dt class="col-sm-3">Web version</dt>
                     <dd class="col-sm-9">v{{ .Version }}</dd>
+                    <dt class="col-sm-3">Trento flavor</dt>
+                    <dd class="col-sm-9">{{ .Flavor }}</dd>
                     <dt class="col-sm-3">Github repository</dt>
                     <dd class="col-sm-9"><a href="https://github.com/trento-project/trento" target="_blank">https://github.com/trento-project/trento</a></dd>
                     <dt class="col-sm-3">Subscription</dt>

--- a/web/templates/blocks/version.html.tmpl
+++ b/web/templates/blocks/version.html.tmpl
@@ -1,4 +1,4 @@
 {{ define "version" }}
     <a href="https://github.com/trento-project/trento/releases/tag/{{ .Version }}" target="_blank"
-       rel="noopener noreferrer">Trento v{{ .Version }}</a>
+       rel="noopener noreferrer">Trento-{{ .Flavor }} v{{ .Version }}</a>
 {{ end }}

--- a/web/templates/blocks/version.html.tmpl
+++ b/web/templates/blocks/version.html.tmpl
@@ -1,4 +1,4 @@
 {{ define "version" }}
     <a href="https://github.com/trento-project/trento/releases/tag/{{ .Version }}" target="_blank"
-       rel="noopener noreferrer">Trento-{{ .Flavor }} v{{ .Version }}</a>
+       rel="noopener noreferrer">Trento {{ .Flavor }} v{{ .Version }}</a>
 {{ end }}


### PR DESCRIPTION
This PR adds a "flavor" constant that gets printed both in the "About" page and the `version` CLI subcommand. By default this constant has the "community" value for the community and will be overwritten in other variants (e.g. premium).