### PR TITLE
Move checks structs to entities and remove old checks in catalog

### DIFF
--- a/web/app.go
+++ b/web/app.go
@@ -127,7 +127,7 @@ func NewNamedEngine(instance string) *gin.Engine {
 func MigrateDB(db *gorm.DB) error {
 	err := db.AutoMigrate(
 		entities.Settings{}, models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{},
-		models.CheckRaw{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{},
+		entities.Check{}, datapipeline.DataCollectedEvent{}, datapipeline.Subscription{},
 		entities.HostTelemetry{}, entities.Cluster{}, entities.Host{}, entities.HostHeartbeat{},
 		entities.SlesSubscription{}, entities.SAPSystemInstance{},
 	)

--- a/web/entities/check.go
+++ b/web/entities/check.go
@@ -1,0 +1,41 @@
+package entities
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/trento-project/trento/web/models"
+	"gorm.io/datatypes"
+)
+
+type Check struct {
+	ID        string `gorm:"primaryKey"`
+	CreatedAt time.Time
+	Payload   datatypes.JSON
+}
+
+type CheckList []*Check
+
+func (c *Check) ToModel() (*models.Check, error) {
+	var check models.Check
+	err := json.Unmarshal(c.Payload, &check)
+	if err != nil {
+		return nil, err
+	}
+
+	return &check, nil
+}
+
+func (c CheckList) ToModel() (models.ChecksCatalog, error) {
+	var checksCatalog models.ChecksCatalog
+
+	for _, checkRaw := range c {
+		check, err := checkRaw.ToModel()
+		if err != nil {
+			return nil, err
+		}
+		checksCatalog = append(checksCatalog, check)
+	}
+
+	return checksCatalog, nil
+}

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -2,9 +2,6 @@ package models
 
 import (
 	"sort"
-	"time"
-
-	"gorm.io/datatypes"
 )
 
 const (
@@ -33,18 +30,6 @@ type Check struct {
 	Labels         string `json:"labels,omitempty" mapstructure:"labels,omitempty"`
 	Selected       bool   `json:"selected,omitempty" mapstructure:"selected,omitempty"`
 	Result         string `json:"result,omitempty" mapstructure:"result,omitempty"`
-}
-
-// Store the data as payload. Changes in this struct are expected
-type CheckRaw struct {
-	ID        string `gorm:"primaryKey"`
-	CreatedAt time.Time
-	Payload   datatypes.JSON
-}
-
-// TableName overrides the table name used by CheckRaw to `checks`
-func (CheckRaw) TableName() string {
-	return "checks"
 }
 
 type GroupedChecks struct {


### PR DESCRIPTION
While testing the Trento premium usage, I have noticed that if a check catalog entry is created, it is not never removed. This happened because I used the trento premium first, and the community version next with the same DB. The premium checks were still there.

During the fix, I have realized that I should move some of the data structs to entities. This is what this PR implements.

So, basically the next line is what fixes the bug, everything else is just model2entity work:
```
// Remove old not updated checks
return c.db.Not(&checkEntityList).Delete(entities.CheckList{}).Error
```

PD: Unfortunately, we cannot have `ToEntity` kind of functions, to convert models to entities, as this would require to have the enitity package imported in the models, which would create an infinite import loop. How much I love you golang... XD