### PR TITLE
Improve changes file generation

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -358,7 +358,12 @@ jobs:
         mkdir -p $HOME/.config/osc
         cp /root/.config/osc/oscrc $HOME/.config/osc
     - name: Prepare trento.changes file
+    # The .changes file is updated only in release creation. This current task should be improved
+    # in order to add the current rolling release notes
+      if: github.event_name == 'release'
       run: |
+        osc checkout $OBS_PROJECT trento trento.changes
+        mv trento.changes $FOLDER
         VERSION=$(./hack/get_version_from_git.sh)
         TAG=$(echo $VERSION | cut -f1 -d+)
         hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento.changes

--- a/hack/gh_release_to_obs_changeset.py
+++ b/hack/gh_release_to_obs_changeset.py
@@ -50,7 +50,7 @@ releaseDate = datetime.strptime(release['published_at'], "%Y-%m-%dT%H:%M:%SZ").r
 with tempfile.TemporaryFile("r+") as temp:
     print("-------------------------------------------------------------------", file=temp)
 
-    print(f"{releaseDate.strftime('%c')} {releaseDate.strftime('%Z')}", end="", file=temp)
+    print(f"{releaseDate.strftime('%a %b %d %H:%M:%S %Z %Y')}", end="", file=temp)
     if args.author:
         print(f" - {args.author}", end="", file=temp)
     print("\n", file=temp)


### PR DESCRIPTION
Update the CI to achieve the next:
- Set the `changes` file format in the same format that `osc vc` creates. It is a small change, this highlights the date in green in obs: https://build.opensuse.org/package/view_file/devel:sap:trento/trento/trento.changes?expand=1
- Update the CI to only update the changes file in case of release. By now, we won't update it in the case of rolling as this requires much more work (we don't create the rolling tag in the same way than the stables one, and we would need some kind of additional logic to convert it to changes file mode)

**PD**: In order to start using the `changes` file correctly, I have updated the current changes file manually to have all of entries of all tags. This is the result: https://build.opensuse.org/package/view_file/devel:sap:trento/trento/trento.changes?expand=1
From now on, the release notes will be added on top of this content