### PR TITLE
Removes skipping certificate check from collector client

### DIFF
--- a/agent/discovery/collector/client.go
+++ b/agent/discovery/collector/client.go
@@ -138,8 +138,7 @@ func getTLSConfig(cert, key, ca string) (*tls.Config, error) {
 	}
 
 	return &tls.Config{
-		InsecureSkipVerify: true,
-		RootCAs:            caCertPool,
-		Certificates:       []tls.Certificate{certificate},
+		RootCAs:      caCertPool,
+		Certificates: []tls.Certificate{certificate},
 	}, nil
 }


### PR DESCRIPTION
Cleans up a leftover.
This enforces certificates to be valid.