### PR TITLE
Change the Telemetry apiHost to a dummy service

### DIFF
--- a/web/telemetry/publisher.go
+++ b/web/telemetry/publisher.go
@@ -40,7 +40,7 @@ func (tp *TelemetryPublisher) Publish(telemetryName string, installationID uuid.
 	return nil
 }
 
-var apiHost = "https://httpbin.org/anything"
+var apiHost = "https://telemetry.trento-project.io" // this service still does not exist
 
 func NewTelemetryPublisher() Publisher {
 	return &TelemetryPublisher{


### PR DESCRIPTION
Til we get the correct service name we use a dummy servce endpoint for telemetry.