### PR TITLE
Show HANA details in its details page

### DIFF
--- a/web/templates/sapsystem.html.tmpl
+++ b/web/templates/sapsystem.html.tmpl
@@ -1,6 +1,6 @@
 {{ define "content" }}
     <div class="col">
-        <h1>SAP System details</h1>
+        <h1>{{ if eq .SAPSystem.Type 1 }}HANA Database{{ else }}SAP System{{ end }} details</h1>
         <dl class="inline">
             <dt class="inline">Name</dt>
             <dd class="inline">{{ .SAPSystem.SID }}</dd>


### PR DESCRIPTION
Show `HANA Database details` as title if the SAP system is a database:
![image](https://user-images.githubusercontent.com/36370954/144200729-280704c6-06d9-42bd-8ee4-8fcf06ac4345.png)

PD: I didn't add any test to this, as i for see that this page must be completely refactored.