### PR TITLE
Create properly the SAP system url in the host page

### DIFF
--- a/web/hosts_test.go
+++ b/web/hosts_test.go
@@ -163,8 +163,9 @@ func TestHostHandler(t *testing.T) {
 		Datacenter: "dc1",
 		Address:    "192.168.1.1",
 		Meta: map[string]string{
-			"trento-sap-systems":   "sys1",
-			"trento-agent-version": "1",
+			"trento-sap-systems":    "sys1",
+			"trento-sap-systems-id": "123456",
+			"trento-agent-version":  "1",
 		},
 	}
 
@@ -292,7 +293,7 @@ func TestHostHandler(t *testing.T) {
 	assert.Contains(t, minified, "Host details")
 
 	assert.Regexp(t, regexp.MustCompile("<dd.*>test_host</dd>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<a.*sapsystems.*>sys1</a>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<a.*sapsystems/123456.*>sys1</a>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<dd.*>v1</dd>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<span.*>passing</span>"), minified)
 	// Subscriptions

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -7,8 +7,9 @@
             <dd class="inline">{{ .Host.Name }}</dd>
             <dt class="inline">SAP System</dt>
             <dd class="inline">
-                {{- range $i, $v := split (index .Host.TrentoMeta "trento-sap-systems") "," }}{{- if $i }},{{- end }}
-                <a href="/sapsystems/{{ $v }}">{{ $v }}</a>{{- end }}
+                {{- $Host := .Host }}
+                {{- range $i, $v := split (index $Host.TrentoMeta "trento-sap-systems") "," }}{{- if $i }},{{- end }}
+                <a href="/sapsystems/{{ index (split (index $Host.TrentoMeta "trento-sap-systems-id") ",") $i }}">{{ $v }}</a>{{- end }}
             </dd>
 
             <dt class="inline">Cluster</dt>


### PR DESCRIPTION
Create properly the SAP system url in the host details page.
Right now, it was using the SID (`PRD`) instead of the internal system id to create the url.