### PR TITLE
Set a timeout in ansible tasks

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -4,7 +4,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.2.0
+version: 0.2.1
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.1

--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: CONSUL_HTTP_ADDR
               value: {{ .Release.Name }}-{{ .Values.dependencies.consul.name }}:{{ .Values.dependencies.consul.port }}
+          # tty is required to allow a correct ansible execution
+          tty: true
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/runner/ansible/callback_plugins/trento.py
+++ b/runner/ansible/callback_plugins/trento.py
@@ -48,7 +48,8 @@ class Results(object):
                 "ABCDEF": {
                     "hosts": {
                         "host1": {
-                            "result": "passing"
+                            "result": "passing",
+                            "msg": "",
                         }
                     }
                 }
@@ -68,7 +69,7 @@ class Results(object):
             self.results["results"][group]["hosts"] = {}
             self.results["results"][group]["checks"] = {}
 
-    def add_result(self, group, test, host, result):
+    def add_result(self, group, test, host, result, msg=""):
         """
         Add new result
         """
@@ -87,6 +88,7 @@ class Results(object):
             hosts[host] = {}
 
         hosts[host]["result"] = result
+        hosts[host]["msg"] = msg
 
     def result_exist(self, group, test, host):
         """
@@ -175,9 +177,11 @@ class CallbackModule(CallbackBase):
         if CHECK_ID not in task_vars:
             return
 
+        msg = result._check_key("msg")
+
         for group in task_vars["group_names"]:
             self.results.set_host_state(group, host, True)
-            self.results.add_result(group, task_vars[CHECK_ID], host, "warning")
+            self.results.add_result(group, task_vars[CHECK_ID], host, "warning", msg)
 
     def v2_runner_on_skipped(self, result):
         """

--- a/runner/ansible/callback_plugins/trento.py
+++ b/runner/ansible/callback_plugins/trento.py
@@ -88,6 +88,15 @@ class Results(object):
 
         hosts[host]["result"] = result
 
+    def result_exist(self, group, test, host):
+        """
+        Check if the result already exists
+        """
+        try:
+            return bool(self.results["results"][group]["checks"][test]["hosts"][host]["result"])
+        except KeyError:
+            return False
+
     def set_host_state(self, group, host, state, msg=""):
         """
         Set the host state. Reachable or Unreachable
@@ -152,21 +161,23 @@ class CallbackModule(CallbackBase):
         test_result = result._task_fields["args"]["test_result"]
         for group in task_vars["group_names"]:
             self.results.set_host_state(group, host, True)
+            if self.results.result_exist(group, task_vars[CHECK_ID], host):
+                continue
             self.results.add_result(group, task_vars[CHECK_ID], host, test_result)
 
-    def v2_runner_on_failed(self, result):
+    def v2_runner_on_failed(self, result, ignore_errors):
         """
         On task Failed
         """
-        if not self._is_test_result(result):
-            return
-
         host = result._host.get_name()
         task_vars = self._all_vars(host=result._host, task=result._task)
 
+        if CHECK_ID not in task_vars:
+            return
+
         for group in task_vars["group_names"]:
             self.results.set_host_state(group, host, True)
-            self.results.add_result(group, task_vars[CHECK_ID], host, False)
+            self.results.add_result(group, task_vars[CHECK_ID], host, "warning")
 
     def v2_runner_on_skipped(self, result):
         """

--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -2,6 +2,7 @@
   gather_facts: false
   ignore_errors: true
   become: true
+  timeout: 30  # Task timeout set to 30 seconds. If some task needs a bigger timeout, set a new timeout in the task itself
 
   vars:
     ara_playbook_labels:

--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -125,7 +125,6 @@ func NewClusterInventoryContent(client consul.Client, trentoApi api.TrentoApiSer
 		for _, node := range clusterData.Crmmon.Nodes {
 			node := &Node{
 				Name:        node.Name,
-				AnsibleUser: DefaultUser,
 				Variables:   make(map[string]interface{}),
 			}
 
@@ -147,6 +146,11 @@ func NewClusterInventoryContent(client consul.Client, trentoApi api.TrentoApiSer
 				if err == nil {
 					node.AnsibleUser = cloudUser
 				}
+			}
+
+			// Fallback to default
+			if len(node.AnsibleUser) == 0 {
+				node.AnsibleUser = DefaultUser
 			}
 
 			nodes = append(nodes, node)

--- a/runner/inventory.go
+++ b/runner/inventory.go
@@ -124,8 +124,8 @@ func NewClusterInventoryContent(client consul.Client, trentoApi api.TrentoApiSer
 
 		for _, node := range clusterData.Crmmon.Nodes {
 			node := &Node{
-				Name:        node.Name,
-				Variables:   make(map[string]interface{}),
+				Name:      node.Name,
+				Variables: make(map[string]interface{}),
 			}
 
 			node.Variables[clusterSelectedChecks] = string(jsonSelectedChecks)

--- a/web/checks_api_test.go
+++ b/web/checks_api_test.go
@@ -39,6 +39,7 @@ func TestApiClusterCheckResultsHandler(t *testing.T) {
 				Hosts: map[string]*models.Check{
 					"host1": &models.Check{
 						Result: models.CheckPassing,
+						Msg:    "some random message",
 					},
 					"host2": &models.Check{
 						Result: models.CheckPassing,
@@ -100,6 +101,7 @@ func TestApiClusterCheckResultsHandler(t *testing.T) {
 				"hosts": gin.H{
 					"host1": gin.H{
 						"result": "passing",
+						"msg":    "some random message",
 					},
 					"host2": gin.H{
 						"result": "passing",

--- a/web/frontend/components/ChecksTable/RowGroup.js
+++ b/web/frontend/components/ChecksTable/RowGroup.js
@@ -5,6 +5,10 @@ const getResult = function (hosts, hostname) {
   return hostname in hosts ? hosts[hostname].result : 'unknown';
 };
 
+const getMsg = function (hosts, hostname) {
+  return hostname in hosts ? hosts[hostname].msg : '';
+};
+
 const RowGroup = ({ name, checks, clusterHosts }) => {
   const [open, setOpen] = useState(true);
   const emptyCells = Object.keys(clusterHosts)
@@ -25,7 +29,10 @@ const RowGroup = ({ name, checks, clusterHosts }) => {
               <td>{id}</td>
               {Object.keys(clusterHosts).map((hostname) => (
                 <td key={hostname} className="align-center">
-                  <CheckResultIcon result={getResult(hosts, hostname)} />
+                  <CheckResultIcon
+                    result={getResult(hosts, hostname)}
+                    tooltip={getMsg(hosts, hostname)}
+                  />
                 </td>
               ))}
             </tr>

--- a/web/models/check.go
+++ b/web/models/check.go
@@ -31,6 +31,7 @@ type Check struct {
 	Premium        bool   `json:"premium,omitempty" mapstructure:"premium,omitempty"`
 	Selected       bool   `json:"selected,omitempty" mapstructure:"selected,omitempty"`
 	Result         string `json:"result,omitempty" mapstructure:"result,omitempty"`
+	Msg            string `json:"msg,omitempty" mapstructure:"msg,omitempty"`
 }
 
 type GroupedChecks struct {

--- a/web/services/checks_test.go
+++ b/web/services/checks_test.go
@@ -67,6 +67,7 @@ func araResultRecord() *ara.Record {
 								},
 								"host2": map[string]interface{}{
 									"result": "passing",
+									"msg":    "some random message",
 								},
 							},
 						},
@@ -159,6 +160,7 @@ func TestGetChecksResult(t *testing.T) {
 						},
 						"host2": &models.Check{
 							Result: models.CheckPassing,
+							Msg:    "some random message",
 						},
 					},
 				},
@@ -333,6 +335,7 @@ func TestGetChecksResultByCluster(t *testing.T) {
 					},
 					"host2": &models.Check{
 						Result: models.CheckPassing,
+						Msg:    "some random message",
 					},
 				},
 			},


### PR DESCRIPTION
Enhancement of the runner to not block the whole ansible execution if some task gets blocked.
It workarounds the issue happening in: https://github.com/trento-project/trento/issues/507

With this hardening, even though the check is not properly implemented or it has some limitation that blocks the execution, the task will be set as failed and the ansible execution will continue.

As UX/UI, I have set the check as warning, and the error message provided by ansible as tooltip.

Here a short gif (in this case the check was blocked for some reason that I unknown yet). The used message is the one provide by ansible:
![Peek 2021-12-02 15-24](https://user-images.githubusercontent.com/36370954/144440488-0d2eea18-b1b3-4769-83cc-09d7fc7975b9.gif)

After this I will continue with the work to fix the check `2C2D43` which is the root cause of the ansible execution blocking

**Edit**: Finally I have fixed the ansible execution blocking issue. It has been fixed adding `tty: true` to the container declaration