### PR TITLE
Add support to scroll to anchors in the catalog

### DIFF
--- a/web/checks_catalog_test.go
+++ b/web/checks_catalog_test.go
@@ -80,9 +80,9 @@ func TestChecksCatalogHandler(t *testing.T) {
 	assert.Equal(t, 200, resp.Code)
 	assert.Contains(t, responseBody, "Checks catalog")
 
-	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>ABCDEF</td><td.*>description 1<div.*id=info-ABCDEF.*><p>remediation 1</p></div><div.*implementation 1.*</div>.*</td>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>123456</td><td.*>description 2<span class=\"badge badge-trento-premium\">Premium</span><div.*id=info-123456.*><p>remediation 2</p></div><div.*implementation 2.*</div>.*</td>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<h4.*>group 2</h4>.*<td.*>123ABC</td><td.*>description 3<div.*id=info-123ABC.*><p>remediation 3</p></div><div.*implementation 3.*</div>.*</td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>ABCDEF</td><td.*>description 1<div.*id=info-ABCDEF.*><p>remediation 1</p><.*implementation 1.*</div>.*</td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<h4.*>group 1</h4>.*<td.*>123456</td><td.*>description 2<span class=\"badge badge-trento-premium\">Premium</span><div.*id=info-123456.*><p>remediation 2</p><.*implementation 2.*</div>.*</td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<h4.*>group 2</h4>.*<td.*>123ABC</td><td.*>description 3<div.*id=info-123ABC.*><p>remediation 3</p><.*implementation 3.*</div>.*</td>"), responseBody)
 	assert.Equal(t, 2, strings.Count(responseBody, "<h4"))
 	assert.Equal(t, 5, strings.Count(responseBody, "<tr>"))
 

--- a/web/frontend/components/ChecksTable/RowGroup.js
+++ b/web/frontend/components/ChecksTable/RowGroup.js
@@ -21,7 +21,9 @@ const RowGroup = ({ name, checks, clusterHosts }) => {
         checks.map(({ id, description, hosts }) => {
           return (
             <tr key={id}>
-              <td>{description}</td>
+              <td>
+                <a href={`/catalog#info-${id}`}>{description}</a>
+              </td>
               <td>{id}</td>
               {Object.keys(clusterHosts).map((hostname) => (
                 <td key={hostname} className="align-center">

--- a/web/frontend/javascripts/catalog_scroll.js
+++ b/web/frontend/javascripts/catalog_scroll.js
@@ -1,0 +1,10 @@
+const anchor = window.location.hash.slice(1);
+if (anchor) {
+  const anchorEl = '#' + anchor;
+  $(anchorEl).closest('.card').find('.collapse-toggle').click();
+  const checkElem = $(anchorEl).closest('tr').find('a');
+  checkElem.click();
+  setTimeout(() => {
+    checkElem[0].scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, 500);
+}

--- a/web/templates/checks_catalog.html.tmpl
+++ b/web/templates/checks_catalog.html.tmpl
@@ -41,8 +41,6 @@
                                         {{ .Description }}{{ if .Premium }}<span class="badge badge-trento-premium">Premium</span>{{ end }}
                                         <div class="ha-check-remediation collapse" id="info-{{ .ID }}">
                                             {{ markdown (.Remediation) }}
-                                        </div>
-                                        <div class="ha-check-remediation collapse" id="info-{{ .ID }}">
                                             <h2>Implementation</h2>
                                             <pre>{{ .Implementation }}</pre>
                                         </div>
@@ -70,4 +68,5 @@
         </div>
         {{- end }}
     </div>
+    {{ script "catalog_scroll.js" }}
 {{ end }}


### PR DESCRIPTION
This PR addresses https://github.com/trento-project/trento/issues/532 by allowing navigation from the check results modal to the checks catalog by clicking on the check description.