### PR TITLE
Use info icon in duplicated cluster names and sids

### DIFF
--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -363,7 +363,7 @@ func TestClustersListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<td .*>.*check_circle.*</td><td>.*hana_cluster.*</td><td>.*47d1190ffb4f781974c8356d7f863b03.*</td><td>HANA scale-up</td><td>PRD</td><td>3</td><td>5</td><td><input.*value=tag1.*></td>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<td .*>.*error.*</td><td>.*other_cluster.*</td><td>.*a615a35f65627be5a757319a0741127f.*</td><td>Unknown</td><td></td>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<td .*>.*error.*</td><td>.*duplicated.*netweaver_cluster.*</td><td>.*e2f2eb50aef748e586a7baa85e0162cf.*</td><td>Unknown</td><td></td><td>2</td><td>10</td><td><input.*value=tag1.*></td>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td .*>.*fiber_manual_record.*</td><td>.*duplicated.*netweaver_cluster.*</td><td>.*e27d313a674375b2066777a89ee346b9.*</td><td>Unknown</td><td></td>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td .*>.*fiber_manual_record.*</td><td>.*duplicated.*info.*netweaver_cluster.*</td><td>.*e27d313a674375b2066777a89ee346b9.*</td><td>Unknown</td><td></td>"), minified)
 }
 
 func TestClusterHandlerHANA(t *testing.T) {

--- a/web/sapsystems_test.go
+++ b/web/sapsystems_test.go
@@ -225,8 +225,8 @@ func TestSAPSystemsListHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<td>HA1</td><td>MESSAGESERVER\\|ENQUE</td><td>00</td><td></td><td><a href=/clusters/e2f2eb50aef748e586a7baa85e0162cf>netweaver_cluster</a></td><td><a href=/hosts/netweaver01>netweaver01</a></td>"), responseBody)
 	assert.Regexp(t, regexp.MustCompile("<td>HA1</td><td>ENQREP</td><td>10</td><td></td><td><a href=/clusters/e2f2eb50aef748e586a7baa85e0162cf>netweaver_cluster</a></td><td><a href=/hosts/netweaver02>netweaver02</a></td>"), responseBody)
 	assert.Regexp(t, regexp.MustCompile("(?s)<td>PRD</td><td>HDB_WORKER</td><td>00</td><td>.*HANA Primary.*SOK.*</td><td><a href=/clusters/5dfbd28f35cbfb38969f9b99243ae8d4>hana_cluster</a></td><td><a href=/hosts/hana01>hana01</a></td>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<td><i .*This SAP system SID exists multiple times.*warning.*<a href=/sapsystems/systemId2>DEV</a></td>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<td><i .*This SAP system SID exists multiple times.*warning.*<a href=/sapsystems/systemId3>DEV</a></td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<td><i .*This SAP system SID exists multiple times.*info.*<a href=/sapsystems/systemId2>DEV</a></td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<td><i .*This SAP system SID exists multiple times.*info.*<a href=/sapsystems/systemId3>DEV</a></td>"), responseBody)
 }
 
 func TestSAPDatabaseListHandler(t *testing.T) {

--- a/web/templates/blocks/clusters_table.html.tmpl
+++ b/web/templates/blocks/clusters_table.html.tmpl
@@ -18,7 +18,7 @@
                 <tr>
                     <td class="row-status">{{ template "health_icon" .Health }}</td>
                     <td>
-                        {{- if .HasDuplicatedName }}<i class="eos-icons eos-18 text-warning" data-toggle="tooltip" data-original-title="This cluster has a duplicated name">warning</i>{{- end }}<a href="/clusters/{{ .ID }}">{{ .Name }}</a>
+                        {{- if .HasDuplicatedName }}<i class="eos-icons eos-18 text-info" data-toggle="tooltip" data-original-title="This cluster has a duplicated name">info</i>{{- end }}<a href="/clusters/{{ .ID }}">{{ .Name }}</a>
                     </td>
                     <td><a href="/clusters/{{ .ID }}">{{ .ID }}</a></td>
                     <td>{{ .ClusterType }}</td>
@@ -26,9 +26,9 @@
                     <td>{{ .HostsNumber }}</td>
                     <td>{{ .ResourcesNumber }}</td>
                     <td>
-                        <input class="tags-input" 
-                            value="{{- range .Tags }}{{ . }},{{- end }}" 
-                            data-resource-type="clusters" 
+                        <input class="tags-input"
+                            value="{{- range .Tags }}{{ . }},{{- end }}"
+                            data-resource-type="clusters"
                             data-resource-id="{{ .ID }}"
                             autocomplete="off">
                         </input>

--- a/web/templates/blocks/sapsystems_table.html.tmpl
+++ b/web/templates/blocks/sapsystems_table.html.tmpl
@@ -22,7 +22,7 @@
                 <td class="row-status">{{ template "health_icon" "unknown" }}</td>
                 <td class="row-status"><a class="eos-icons eos-18  collapse-toggle clickable collapsed text-dark"
                                           data-toggle="collapse" data-target="#inner_{{ $index }}"></a></td>
-                <td>{{- if .HasDuplicatedSid }}<i class="eos-icons eos-18 text-warning" data-toggle="tooltip" data-original-title="This SAP system SID exists multiple times">warning</i>{{- end }}<a href="/{{ $resource }}/{{ .Id }}">{{ .SID }}</a></td>
+                <td>{{- if .HasDuplicatedSid }}<i class="eos-icons eos-18 text-info" data-toggle="tooltip" data-original-title="This SAP system SID exists multiple times">info</i>{{- end }}<a href="/{{ $resource }}/{{ .Id }}">{{ .SID }}</a></td>
                 <td></td>
                 {{- if eq $resource "sapsystems" }}
                 <td><a href="/databases/{{ $value.AttachedDatabaseId }}">{{ $value.AttachedDatabaseSID }}</a></td>


### PR DESCRIPTION
**Edit**: Please, validate if the solution is the desired one. I have implemented this based on the issue [479](https://github.com/trento-project/trento/issues/479)

It basically changes the duplicated name warning icon by a info icon to be less invasive and have less option to confuse the user with the checks or cluster result.

Fix for: https://github.com/trento-project/trento/issues/479

![image](https://user-images.githubusercontent.com/36370954/144633631-1a0d15fb-129e-40d1-ac07-afcb76b7e3a4.png)
