### PR TITLE
Add cluster settings api

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -334,7 +334,7 @@ jobs:
           set -ex
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
           do
-            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--agent-bind-ip" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
+            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ifeq (, $(shell command -v mockery 2> /dev/null))
 	$(error "'mockery' command not found. You can install it locally with 'go install github.com/vektra/mockery/v2'.")
 endif
 ifeq (, $(shell command -v swag 2> /dev/null))
-	$(error "'swag' command not found. You can install it locally with 'go install github.com/swaggo/swag/cmd/swag@latest'.")
+	$(error "'swag' command not found. You can install it locally with 'go install github.com/swaggo/swag/cmd/swag'.")
 endif
 	go generate ./...
 

--- a/README.md
+++ b/README.md
@@ -150,20 +150,18 @@ sudo ./install-agent.sh
 
 The script will ask you for two IP addresses.
 
-- `agent bind IP`: the private address to which the trento-agent should be bound for internal communications.
-  This is an IP address that should be reachable by the other hosts, including the trento server.
-  Note for the Pacemaker users: this IP address _should not be_ a floating IP.
+- `ssh address`: the address to which the trento-agent should be reachable for ssh connection by the runner for check execution.
 
 - `trento server IP`: the address where Trento server can be reached.
 
 You can pass these arguments as flags or env variables too:
 
 ```
-curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh | sudo bash -s - --agent-bind-ip=192.168.33.10 --server-ip=192.168.33.1
+curl -sfL https://raw.githubusercontent.com/trento-project/trento/main/install-agent.sh | sudo bash -s - --ssh-address=192.168.33.10 --server-ip=192.168.33.1
 ```
 
 ```
-AGENT_BIND_IP=192.168.33.10 SERVER_IP=192.168.33.1 sudo ./install-agent.sh
+SSH_ADDRESS=192.168.33.10 SERVER_IP=192.168.33.1 sudo ./install-agent.sh
 ```
 
 #### Starting Trento Agent service

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,7 +34,7 @@ type Agent struct {
 
 type Config struct {
 	InstanceName    string
-	BindIP          string
+	SSHAddress      string
 	ConsulConfigDir string
 	DiscoveryPeriod time.Duration
 	CollectorConfig *collector.Config
@@ -69,7 +69,7 @@ func NewAgent(config *Config) (*Agent, error) {
 			discovery.NewSAPSystemsDiscovery(consulClient, collectorClient),
 			discovery.NewCloudDiscovery(consulClient, collectorClient),
 			discovery.NewSubscriptionDiscovery(collectorClient),
-			discovery.NewHostDiscovery(config.BindIP, consulClient, collectorClient),
+			discovery.NewHostDiscovery(config.SSHAddress, consulClient, collectorClient),
 		},
 		templateRunner: templateRunner,
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -34,6 +34,7 @@ type Agent struct {
 
 type Config struct {
 	InstanceName    string
+	BindIP          string
 	ConsulConfigDir string
 	DiscoveryPeriod time.Duration
 	CollectorConfig *collector.Config
@@ -68,7 +69,7 @@ func NewAgent(config *Config) (*Agent, error) {
 			discovery.NewSAPSystemsDiscovery(consulClient, collectorClient),
 			discovery.NewCloudDiscovery(consulClient, collectorClient),
 			discovery.NewSubscriptionDiscovery(collectorClient),
-			discovery.NewHostDiscovery(consulClient, collectorClient),
+			discovery.NewHostDiscovery(config.BindIP, consulClient, collectorClient),
 		},
 		templateRunner: templateRunner,
 	}

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -19,15 +19,15 @@ import (
 const HostDiscoveryId string = "host_discovery"
 
 type HostDiscovery struct {
-	id          string
-	agentBindIP string
-	discovery   BaseDiscovery
+	id         string
+	sshAddress string
+	discovery  BaseDiscovery
 }
 
-func NewHostDiscovery(agentBindIP string, consulClient consul.Client, collectorClient collector.Client) HostDiscovery {
+func NewHostDiscovery(sshAddress string, consulClient consul.Client, collectorClient collector.Client) HostDiscovery {
 	d := HostDiscovery{}
 	d.id = HostDiscoveryId
-	d.agentBindIP = agentBindIP
+	d.sshAddress = sshAddress
 	d.discovery = NewDiscovery(consulClient, collectorClient)
 	return d
 }
@@ -52,7 +52,7 @@ func (h HostDiscovery) Discover() (string, error) {
 	}
 
 	host := hosts.DiscoveredHost{
-		AgentBindIP:     h.agentBindIP,
+		SSHAddress:      h.sshAddress,
 		OSVersion:       getOSVersion(),
 		HostIpAddresses: ipAddresses,
 		HostName:        h.discovery.host,

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -19,13 +19,15 @@ import (
 const HostDiscoveryId string = "host_discovery"
 
 type HostDiscovery struct {
-	id        string
-	discovery BaseDiscovery
+	id          string
+	agentBindIP string
+	discovery   BaseDiscovery
 }
 
-func NewHostDiscovery(consulClient consul.Client, collectorClient collector.Client) HostDiscovery {
+func NewHostDiscovery(agentBindIP string, consulClient consul.Client, collectorClient collector.Client) HostDiscovery {
 	d := HostDiscovery{}
 	d.id = HostDiscoveryId
+	d.agentBindIP = agentBindIP
 	d.discovery = NewDiscovery(consulClient, collectorClient)
 	return d
 }
@@ -50,6 +52,7 @@ func (h HostDiscovery) Discover() (string, error) {
 	}
 
 	host := hosts.DiscoveredHost{
+		AgentBindIP:     h.agentBindIP,
 		OSVersion:       getOSVersion(),
 		HostIpAddresses: ipAddresses,
 		HostName:        h.discovery.host,

--- a/agent/discovery/mocks/discovered_host_mock.go
+++ b/agent/discovery/mocks/discovered_host_mock.go
@@ -4,7 +4,7 @@ import "github.com/trento-project/trento/internal/hosts"
 
 func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	return hosts.DiscoveredHost{
-		AgentBindIP:     "10.2.2.22",
+		SSHAddress:      "10.2.2.22",
 		OSVersion:       "15-SP2",
 		HostIpAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
 		HostName:        "thehostnamewherethediscoveryhappened",

--- a/agent/discovery/mocks/discovered_host_mock.go
+++ b/agent/discovery/mocks/discovered_host_mock.go
@@ -4,6 +4,7 @@ import "github.com/trento-project/trento/internal/hosts"
 
 func NewDiscoveredHostMock() hosts.DiscoveredHost {
 	return hosts.DiscoveredHost{
+		AgentBindIP:     "10.2.2.22",
 		OSVersion:       "15-SP2",
 		HostIpAddresses: []string{"10.1.1.4", "10.1.1.5", "10.1.1.6"},
 		HostName:        "thehostnamewherethediscoveryhappened",

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -16,6 +16,7 @@ import (
 )
 
 func NewAgentCmd() *cobra.Command {
+	var bindIP string
 	var consulConfigDir string
 	var discoveryPeriod int
 
@@ -40,6 +41,10 @@ func NewAgentCmd() *cobra.Command {
 			return internal.InitConfig("agent")
 		},
 	}
+
+	startCmd.Flags().StringVar(&bindIP, "bind-ip", "", "Private address to which the trento-agent should be bound for internal communications. Reachable by the other hosts, including the trento server.")
+	startCmd.MarkFlagRequired("bind-ip")
+
 	startCmd.Flags().StringVarP(&consulConfigDir, "consul-config-dir", "", "consul.d", "Consul configuration directory used to store node meta-data")
 	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 2, "Discovery mechanism loop period on minutes")
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -16,7 +16,7 @@ import (
 )
 
 func NewAgentCmd() *cobra.Command {
-	var bindIP string
+	var sshAddress string
 	var consulConfigDir string
 	var discoveryPeriod int
 
@@ -42,8 +42,8 @@ func NewAgentCmd() *cobra.Command {
 		},
 	}
 
-	startCmd.Flags().StringVar(&bindIP, "bind-ip", "", "Private address to which the trento-agent should be bound for internal communications. Reachable by the other hosts, including the trento server.")
-	startCmd.MarkFlagRequired("bind-ip")
+	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
+	startCmd.MarkFlagRequired("ssh-address")
 
 	startCmd.Flags().StringVarP(&consulConfigDir, "consul-config-dir", "", "consul.d", "Consul configuration directory used to store node meta-data")
 	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 2, "Discovery mechanism loop period on minutes")

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -50,6 +50,7 @@ func LoadConfig() (*agent.Config, error) {
 		},
 		ConsulConfigDir: viper.GetString("consul-config-dir"),
 		InstanceName:    hostname,
+		BindIP:          viper.GetString("bind-ip"),
 		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Minute,
 	}, nil
 }

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -50,7 +50,7 @@ func LoadConfig() (*agent.Config, error) {
 		},
 		ConsulConfigDir: viper.GetString("consul-config-dir"),
 		InstanceName:    hostname,
-		BindIP:          viper.GetString("bind-ip"),
+		SSHAddress:      viper.GetString("ssh-address"),
 		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Minute,
 	}, nil
 }

--- a/docs/api/docs.go
+++ b/docs/api/docs.go
@@ -171,6 +171,37 @@ var doc = `{
                 }
             }
         },
+        "/clusters/settings": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Retrieve Settings for all the clusters. Cluster's Selected checks and Hosts connection settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClusterSettings"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/clusters/{cluster_id}/results": {
             "get": {
                 "produces": [
@@ -682,6 +713,40 @@ var doc = `{
                 },
                 "selected": {
                     "type": "boolean"
+                }
+            }
+        },
+        "models.ClusterSettings": {
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.HostConnection"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "selected_checks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "models.HostConnection": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -159,6 +159,37 @@
                 }
             }
         },
+        "/clusters/settings": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Retrieve Settings for all the clusters. Cluster's Selected checks and Hosts connection settings",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.ClusterSettings"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/clusters/{cluster_id}/results": {
             "get": {
                 "produces": [
@@ -670,6 +701,40 @@
                 },
                 "selected": {
                     "type": "boolean"
+                }
+            }
+        },
+        "models.ClusterSettings": {
+            "type": "object",
+            "properties": {
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.HostConnection"
+                    }
+                },
+                "id": {
+                    "type": "string"
+                },
+                "selected_checks": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "models.HostConnection": {
+            "type": "object",
+            "properties": {
+                "address": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "user": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -25,6 +25,28 @@ definitions:
       selected:
         type: boolean
     type: object
+  models.ClusterSettings:
+    properties:
+      hosts:
+        items:
+          $ref: '#/definitions/models.HostConnection'
+        type: array
+      id:
+        type: string
+      selected_checks:
+        items:
+          type: string
+        type: array
+    type: object
+  models.HostConnection:
+    properties:
+      address:
+        type: string
+      name:
+        type: string
+      user:
+        type: string
+    type: object
   web.JSONCheck:
     properties:
       description:
@@ -310,6 +332,27 @@ paths:
             additionalProperties: true
             type: object
       summary: Delete a specific tag that belongs to a cluster
+  /clusters/settings:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.ClusterSettings'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Retrieve Settings for all the clusters. Cluster's Selected checks and
+        Hosts connection settings
   /databases/{id}/tags:
     post:
       consumes:

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -117,6 +117,7 @@ AGENT_CONFIG_PATH="/etc/trento"
 AGENT_CONFIG_FILE="$AGENT_CONFIG_PATH/agent.yaml"
 AGENT_CONFIG_TEMPLATE='
 consul-config-dir: @CONFIG_PATH@
+bind-ip: @BIND_IP@
 collector-host: @COLLECTOR_HOST@
 '
 
@@ -240,7 +241,8 @@ function setup_trento() {
 
     echo "$AGENT_CONFIG_TEMPLATE" |
         sed "s|@CONFIG_PATH@|${CONFIG_PATH}|g" |
-        sed "s|@COLLECTOR_HOST@|${SERVER_IP}|g" \
+        sed "s|@COLLECTOR_HOST@|${SERVER_IP}|g" |
+        sed "s|@BIND_IP@|${AGENT_BIND_IP}|g" \
             > ${AGENT_CONFIG_FILE}
 }
 

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -15,11 +15,10 @@ that can help you deploy, provision and operate infrastructure for SAP Applicati
 
 Usage:
 
-  sudo ./install-agent.sh --agent-bind-ip <192.168.122.10> --server-ip <192.168.122.5>
+  sudo ./install-agent.sh --ssh-address <192.168.122.10> --server-ip <192.168.122.5>
 
 Arguments:
-  --agent-bind-ip   The private address to which the trento-agent should be bound for internal communications.
-                    This is an IP address that should be reachable by the other hosts, including the trento server.
+  --ssh-address     The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.
   --server-ip       The trento server ip.
   --rolling         Use the factory/rolling-release version instead of the stable one.
   --use-tgz         Use the trento tar.gz file from GH releases rather than the RPM
@@ -35,7 +34,7 @@ case "$1" in
 esac
 
 ARGUMENT_LIST=(
-    "agent-bind-ip:"
+    "ssh-address:"
     "server-ip:"
     "rolling"
     "use-tgz"
@@ -55,8 +54,8 @@ eval set "--$opts"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-    --agent-bind-ip)
-        AGENT_BIND_IP=$2
+    --ssh-address)
+        SSH_ADDRESS=$2
         shift 2
         ;;
 
@@ -117,7 +116,7 @@ AGENT_CONFIG_PATH="/etc/trento"
 AGENT_CONFIG_FILE="$AGENT_CONFIG_PATH/agent.yaml"
 AGENT_CONFIG_TEMPLATE='
 consul-config-dir: @CONFIG_PATH@
-bind-ip: @BIND_IP@
+ssh-address: @SSH_ADDRESS@
 collector-host: @COLLECTOR_HOST@
 '
 
@@ -141,8 +140,8 @@ function check_installer_deps() {
 }
 
 function configure_installation() {
-    if [[ -z "$AGENT_BIND_IP" ]]; then
-        read -rp "Please provide a bind IP for the agent: " AGENT_BIND_IP </dev/tty
+    if [[ -z "$SSH_ADDRESS" ]]; then
+        read -rp "Please provide an ssh address for the agent: " SSH_ADDRESS </dev/tty
     fi
     if [[ -z "$SERVER_IP" ]]; then
         read -rp "Please provide the server IP: " SERVER_IP </dev/tty
@@ -161,7 +160,7 @@ function install_consul() {
 function setup_consul() {
     echo "$CONSUL_HCL_TEMPLATE" |
         sed "s|@JOIN_ADDR@|${SERVER_IP}|g" |
-        sed "s|@BIND_ADDR@|${AGENT_BIND_IP}|g" \
+        sed "s|@BIND_ADDR@|${SSH_ADDRESS}|g" \
             >${CONFIG_PATH}/consul.hcl
 
     if [[ -f "/usr/lib/systemd/system/$CONSUL_SERVICE_NAME" ]]; then
@@ -242,7 +241,7 @@ function setup_trento() {
     echo "$AGENT_CONFIG_TEMPLATE" |
         sed "s|@CONFIG_PATH@|${CONFIG_PATH}|g" |
         sed "s|@COLLECTOR_HOST@|${SERVER_IP}|g" |
-        sed "s|@BIND_IP@|${AGENT_BIND_IP}|g" \
+        sed "s|@SSH_ADDRESS@|${SSH_ADDRESS}|g" \
             > ${AGENT_CONFIG_FILE}
 }
 

--- a/internal/hosts/discovered_host.go
+++ b/internal/hosts/discovered_host.go
@@ -1,6 +1,7 @@
 package hosts
 
 type DiscoveredHost struct {
+	AgentBindIP     string   `json:"agent_bind_ip"`
 	OSVersion       string   `json:"os_version"`
 	HostIpAddresses []string `json:"ip_addresses"`
 	HostName        string   `json:"hostname"`

--- a/internal/hosts/discovered_host.go
+++ b/internal/hosts/discovered_host.go
@@ -1,7 +1,7 @@
 package hosts
 
 type DiscoveredHost struct {
-	AgentBindIP     string   `json:"agent_bind_ip"`
+	SSHAddress      string   `json:"ssh_address"`
 	OSVersion       string   `json:"os_version"`
 	HostIpAddresses []string `json:"ip_addresses"`
 	HostName        string   `json:"hostname"`

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -34,6 +34,13 @@
 
 ###############################################################################
 
+## The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.
+## Required.
+
+# ssh-address: 0.0.0.0
+
+###############################################################################
+
 ## Discovery period configures the tick interval for the discovery loops.
 ## Time unit is minutes
 ## Defaults to 2.

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -2,7 +2,7 @@
     "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type": "host_discovery",
     "payload": {
-        "agent_bind_ip": "10.2.2.22",
+        "ssh_address": "10.2.2.22",
         "os_version": "15-SP2",
         "ip_addresses": [
             "10.1.1.4",

--- a/test/fixtures/discovery/host/expected_published_host_discovery.json
+++ b/test/fixtures/discovery/host/expected_published_host_discovery.json
@@ -2,6 +2,7 @@
     "agent_id": "779cdd70-e9e2-58ca-b18a-bf3eb3f71244",
     "discovery_type": "host_discovery",
     "payload": {
+        "agent_bind_ip": "10.2.2.22",
         "os_version": "15-SP2",
         "ip_addresses": [
             "10.1.1.4",

--- a/web/app.go
+++ b/web/app.go
@@ -186,6 +186,7 @@ func NewAppWithDeps(config *Config, deps Dependencies) (*App, error) {
 		apiGroup.POST("/clusters/:id/tags", ApiClusterCreateTagHandler(deps.clustersService, deps.tagsService))
 		apiGroup.DELETE("/clusters/:id/tags/:tag", ApiClusterDeleteTagHandler(deps.clustersService, deps.tagsService))
 		apiGroup.GET("/clusters/:cluster_id/results", ApiClusterCheckResultsHandler(deps.consul, deps.checksService))
+		apiGroup.GET("/clusters/settings", ApiGetClustersSettingsHandler(deps.clustersService))
 		apiGroup.POST("/sapsystems/:id/tags", ApiSAPSystemCreateTagHandler(deps.sapSystemsService, deps.tagsService))
 		apiGroup.DELETE("/sapsystems/:id/tags/:tag", ApiSAPSystemDeleteTagHandler(deps.sapSystemsService, deps.tagsService))
 		apiGroup.POST("/databases/:id/tags", ApiDatabaseCreateTagHandler(deps.sapSystemsService, deps.tagsService))

--- a/web/clusters_api.go
+++ b/web/clusters_api.go
@@ -1,0 +1,31 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/trento-project/trento/web/models"
+	"github.com/trento-project/trento/web/services"
+)
+
+type ClustersSettingsResponse models.ClustersSettings
+
+// ApiGetClustersSettingsHandler godoc
+// @Summary Retrieve Settings for all the clusters. Cluster's Selected checks and Hosts connection settings
+// @Accept json
+// @Produce json
+// @Success 200 {object} ClustersSettingsResponse
+// @Failure 500 {object} map[string]string
+// @Router /clusters/settings [get]
+func ApiGetClustersSettingsHandler(clusters services.ClustersService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clustersSettings, err := clusters.GetAllClustersSettings()
+
+		if err != nil {
+			c.Error(err)
+			return
+		}
+
+		c.JSON(http.StatusOK, clustersSettings)
+	}
+}

--- a/web/clusters_api_test.go
+++ b/web/clusters_api_test.go
@@ -1,0 +1,111 @@
+package web
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/trento/web/models"
+	"github.com/trento-project/trento/web/services"
+)
+
+type ClustersApiTestCase struct {
+	suite.Suite
+	mockClusterService *services.MockClustersService
+	config             *Config
+	deps               Dependencies
+}
+
+func TestClustersApiTestCase(t *testing.T) {
+	suite.Run(t, new(ClustersApiTestCase))
+}
+
+func (suite *ClustersApiTestCase) SetupTest() {
+	suite.mockClusterService = new(services.MockClustersService)
+	suite.config = setupTestConfig()
+	suite.deps = setupTestDependencies()
+}
+
+func (suite *ClustersApiTestCase) Test_EmptyClustersSettings() {
+	suite.mockClusterService.On("GetAllClustersSettings").Return(models.ClustersSettings{}, nil)
+	suite.deps.clustersService = suite.mockClusterService
+
+	app, err := NewAppWithDeps(suite.config, suite.deps)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/clusters/settings", nil)
+	app.webEngine.ServeHTTP(resp, req)
+
+	suite.Equal(200, resp.Code)
+	suite.JSONEq(`[]`, resp.Body.String())
+}
+
+func (suite *ClustersApiTestCase) Test_ClustersSettingsWereFound() {
+	mockedClustersSettings := mockedClustersSettings()
+	suite.mockClusterService.On("GetAllClustersSettings").Return(mockedClustersSettings, nil)
+
+	suite.deps.clustersService = suite.mockClusterService
+
+	app, err := NewAppWithDeps(suite.config, suite.deps)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/clusters/settings", nil)
+	app.webEngine.ServeHTTP(resp, req)
+
+	expectedJson, _ := json.Marshal(mockedClustersSettings)
+	suite.Equal(200, resp.Code)
+	suite.JSONEq(string(expectedJson), resp.Body.String())
+}
+
+func (suite *ClustersApiTestCase) Test_AnErrorOccurs() {
+	suite.mockClusterService.On("GetAllClustersSettings").Return(nil, errors.New("KABOOM"))
+
+	suite.deps.clustersService = suite.mockClusterService
+
+	app, err := NewAppWithDeps(suite.config, suite.deps)
+	if err != nil {
+		suite.T().Fatal(err)
+	}
+
+	resp := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/clusters/settings", nil)
+	app.webEngine.ServeHTTP(resp, req)
+
+	suite.Equal(500, resp.Code)
+	suite.JSONEq(`{"error":"KABOOM"}`, resp.Body.String())
+}
+
+func mockedClustersSettings() models.ClustersSettings {
+	return models.ClustersSettings{
+		{
+			ID:             "cluster1",
+			SelectedChecks: []string{"A", "B", "C"},
+			Hosts: []*models.HostConnection{
+				{
+					Name:    "host1",
+					Address: "10.0.0.1",
+					User:    "root",
+				},
+			},
+		},
+		{
+			ID:             "cluster2",
+			SelectedChecks: []string{},
+			Hosts: []*models.HostConnection{
+				{
+					Name:    "host2",
+					Address: "10.0.0.2",
+					User:    "theuser",
+				},
+			},
+		},
+	}
+}

--- a/web/datapipeline/hosts_projector.go
+++ b/web/datapipeline/hosts_projector.go
@@ -36,6 +36,7 @@ func hostsProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent,
 
 	host := entities.Host{
 		AgentID:      dataCollectedEvent.AgentID,
+		AgentBindIP:  discoveredHost.AgentBindIP,
 		Name:         discoveredHost.HostName,
 		IPAddresses:  filterIPAddresses(discoveredHost.HostIpAddresses),
 		AgentVersion: discoveredHost.AgentVersion,
@@ -45,6 +46,7 @@ func hostsProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent,
 		"name",
 		"ip_addresses",
 		"agent_version",
+		"agent_bind_ip",
 	)
 }
 

--- a/web/datapipeline/hosts_projector.go
+++ b/web/datapipeline/hosts_projector.go
@@ -36,7 +36,7 @@ func hostsProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent,
 
 	host := entities.Host{
 		AgentID:      dataCollectedEvent.AgentID,
-		AgentBindIP:  discoveredHost.AgentBindIP,
+		SSHAddress:   discoveredHost.SSHAddress,
 		Name:         discoveredHost.HostName,
 		IPAddresses:  filterIPAddresses(discoveredHost.HostIpAddresses),
 		AgentVersion: discoveredHost.AgentVersion,
@@ -46,7 +46,7 @@ func hostsProjector_HostDiscoveryHandler(dataCollectedEvent *DataCollectedEvent,
 		"name",
 		"ip_addresses",
 		"agent_version",
-		"agent_bind_ip",
+		"ssh_address",
 	)
 }
 

--- a/web/entities/host.go
+++ b/web/entities/host.go
@@ -10,7 +10,7 @@ import (
 
 type Host struct {
 	AgentID            string `gorm:"primaryKey"`
-	AgentBindIP        string
+	SSHAddress         string
 	Name               string
 	IPAddresses        pq.StringArray `gorm:"type:text[]"`
 	CloudProvider      string

--- a/web/entities/host.go
+++ b/web/entities/host.go
@@ -10,6 +10,7 @@ import (
 
 type Host struct {
 	AgentID            string `gorm:"primaryKey"`
+	AgentBindIP        string
 	Name               string
 	IPAddresses        pq.StringArray `gorm:"type:text[]"`
 	CloudProvider      string

--- a/web/models/clusters_settings.go
+++ b/web/models/clusters_settings.go
@@ -1,0 +1,15 @@
+package models
+
+type ClusterSettings struct {
+	ID             string            `json:"id"`
+	SelectedChecks []string          `json:"selected_checks"`
+	Hosts          []*HostConnection `json:"hosts"`
+}
+
+type HostConnection struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+	User    string `json:"user"`
+}
+
+type ClustersSettings []*ClusterSettings

--- a/web/services/checks.go
+++ b/web/services/checks.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/mitchellh/mapstructure"
@@ -260,9 +261,15 @@ Selected checks services
 */
 
 func (c *checksService) GetSelectedChecksById(id string) (models.SelectedChecks, error) {
-	var selectedChecks models.SelectedChecks
+	selectedChecks := models.SelectedChecks{
+		ID:             "",
+		SelectedChecks: []string{},
+	}
 
 	result := c.db.Where("id", id).First(&selectedChecks)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return selectedChecks, nil
+	}
 
 	return selectedChecks, result.Error
 }

--- a/web/services/checks_test.go
+++ b/web/services/checks_test.go
@@ -843,9 +843,10 @@ func (suite *ChecksServiceTestSuite) TestChecksService_GetSelectedChecksById() {
 }
 
 func (suite *ChecksServiceTestSuite) TestChecksService_GetSelectedChecksByIdError() {
-	_, err := suite.checksService.GetSelectedChecksById("other")
+	selectedChecks, err := suite.checksService.GetSelectedChecksById("other")
 
-	suite.EqualError(err, "record not found")
+	suite.NoError(err)
+	suite.EqualValues([]string{}, selectedChecks.SelectedChecks)
 }
 
 func (suite *ChecksServiceTestSuite) TestChecksService_CreateSelectedChecks() {

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -226,7 +226,7 @@ func (s *clustersService) GetAllClustersSettings() (models.ClustersSettings, err
 
 			hosts = append(hosts, &models.HostConnection{
 				Name:    host.Name,
-				Address: host.AgentBindIP,
+				Address: host.SSHAddress,
 				User:    username,
 			})
 		}

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -197,14 +197,13 @@ func (s *clustersService) GetAllClustersSettings() (models.ClustersSettings, err
 	for _, cluster := range clusters {
 		var hosts []*models.HostConnection
 
-		selectedChecks, err := s.checksService.GetSelectedChecksById(cluster.ID) // ??
-
+		selectedChecks, err := s.checksService.GetSelectedChecksById(cluster.ID)
 		if err != nil {
 			log.Error(err)
 			return clustersSettings, err
 		}
 
-		connectionSettings, err := s.checksService.GetConnectionSettingsById(cluster.ID) // ??
+		connectionSettings, err := s.checksService.GetConnectionSettingsById(cluster.ID)
 		if err != nil {
 			log.Error(err)
 			return clustersSettings, err
@@ -227,7 +226,7 @@ func (s *clustersService) GetAllClustersSettings() (models.ClustersSettings, err
 
 			hosts = append(hosts, &models.HostConnection{
 				Name:    host.Name,
-				Address: host.IPAddresses[0], // a host has many IPs, which one shall we get?
+				Address: host.AgentBindIP,
 				User:    username,
 			})
 		}

--- a/web/services/clusters_mock.go
+++ b/web/services/clusters_mock.go
@@ -58,6 +58,29 @@ func (_m *MockClustersService) GetAllClusterTypes() ([]string, error) {
 	return r0, r1
 }
 
+// GetAllClustersSettings provides a mock function with given fields:
+func (_m *MockClustersService) GetAllClustersSettings() (models.ClustersSettings, error) {
+	ret := _m.Called()
+
+	var r0 models.ClustersSettings
+	if rf, ok := ret.Get(0).(func() models.ClustersSettings); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(models.ClustersSettings)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllSIDs provides a mock function with given fields:
 func (_m *MockClustersService) GetAllSIDs() ([]string, error) {
 	ret := _m.Called()

--- a/web/services/clusters_test.go
+++ b/web/services/clusters_test.go
@@ -74,7 +74,7 @@ func loadClustersFixtures(db *gorm.DB) {
 		Hosts: []*entities.Host{
 			{
 				AgentID:     "1",
-				AgentBindIP: "10.74.2.10",
+				SSHAddress:  "10.74.2.10",
 				ClusterID:   "1",
 				Name:        "host1",
 				IPAddresses: []string{"10.74.1.10"},
@@ -102,7 +102,7 @@ func loadClustersFixtures(db *gorm.DB) {
 		Hosts: []*entities.Host{
 			{
 				AgentID:     "2",
-				AgentBindIP: "10.74.2.11",
+				SSHAddress:  "10.74.2.11",
 				ClusterID:   "2",
 				Name:        "host2",
 				IPAddresses: pq.StringArray{"10.74.1.11"},

--- a/web/services/clusters_test.go
+++ b/web/services/clusters_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/trento-project/trento/test/helpers"
 	"github.com/trento-project/trento/web/entities"
 	"github.com/trento-project/trento/web/models"
+	araMocks "github.com/trento-project/trento/web/services/ara/mocks"
 	"gorm.io/gorm"
 )
 
@@ -27,12 +28,12 @@ func TestClustersServiceTestSuite(t *testing.T) {
 func (suite *ClustersServiceTestSuite) SetupSuite() {
 	suite.db = helpers.SetupTestDatabase(suite.T())
 
-	suite.db.AutoMigrate(entities.Cluster{}, entities.Host{}, models.Tag{})
+	suite.db.AutoMigrate(entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{})
 	loadClustersFixtures(suite.db)
 }
 
 func (suite *ClustersServiceTestSuite) TearDownSuite() {
-	suite.db.Migrator().DropTable(entities.Cluster{}, entities.Host{}, models.Tag{})
+	suite.db.Migrator().DropTable(entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{})
 }
 
 func (suite *ClustersServiceTestSuite) SetupTest() {
@@ -73,6 +74,7 @@ func loadClustersFixtures(db *gorm.DB) {
 		Hosts: []*entities.Host{
 			{
 				AgentID:     "1",
+				AgentBindIP: "10.74.2.10",
 				ClusterID:   "1",
 				Name:        "host1",
 				IPAddresses: []string{"10.74.1.10"},
@@ -99,12 +101,19 @@ func loadClustersFixtures(db *gorm.DB) {
 		},
 		Hosts: []*entities.Host{
 			{
+				AgentID:     "2",
+				AgentBindIP: "10.74.2.11",
 				ClusterID:   "2",
 				Name:        "host2",
 				IPAddresses: pq.StringArray{"10.74.1.11"},
 			},
 		},
 	})
+
+	azureCloudData := &entities.AzureCloudData{}
+	azureCloudData.AdminUsername = "cloudadmin"
+	cloudData, _ := json.Marshal(&azureCloudData)
+
 	db.Create(&entities.Cluster{
 		ID:              "3",
 		Name:            "cluster3",
@@ -121,9 +130,13 @@ func loadClustersFixtures(db *gorm.DB) {
 		},
 		Hosts: []*entities.Host{
 			{
-				ClusterID:   "3",
-				Name:        "host3",
-				IPAddresses: pq.StringArray{"10.74.1.12"},
+				AgentID:       "3",
+				SSHAddress:    "10.74.2.12",
+				ClusterID:     "3",
+				Name:          "host3",
+				IPAddresses:   pq.StringArray{"10.74.1.12"},
+				CloudProvider: "azure",
+				CloudData:     cloudData,
 			},
 		},
 	})
@@ -243,4 +256,97 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetAllTags() {
 func (suite *ClustersServiceTestSuite) TestClustersService_GetAllSIDs() {
 	sids, _ := suite.clustersService.GetAllSIDs()
 	suite.ElementsMatch([]string{"DEV", "QAS", "PRD"}, sids)
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllClustersSettingsReturnsNoSettings() {
+	mockAra := new(araMocks.AraService)
+
+	tx := suite.tx.Raw("TRUNCATE TABLE clusters")
+	checksService := NewChecksService(mockAra, tx)
+	suite.clustersService = NewClustersService(tx, checksService)
+
+	clustersSettings, err := suite.clustersService.GetAllClustersSettings()
+	suite.NoError(err)
+	suite.Empty(clustersSettings)
+
+	tx.Rollback()
+}
+
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllClustersSettingsReturnsExpectedSettings() {
+	mockAra := new(araMocks.AraService)
+	checksService := NewChecksService(mockAra, suite.db)
+	suite.clustersService = NewClustersService(suite.db, checksService)
+
+	loadClustersSettingsFixtures(suite.db)
+
+	clustersSettings, err := suite.clustersService.GetAllClustersSettings()
+	suite.NoError(err)
+	suite.NotEmpty(clustersSettings)
+	suite.Len(clustersSettings, 3)
+
+	suite.EqualValues(expectedClustersSettingsFixtures(), clustersSettings)
+}
+
+func loadClustersSettingsFixtures(db *gorm.DB) {
+	db.Create(&models.SelectedChecks{
+		ID:             "1",
+		SelectedChecks: []string{"A", "B", "C"},
+	})
+	db.Create(&models.SelectedChecks{
+		ID:             "2",
+		SelectedChecks: []string{},
+	})
+	db.Create(&models.ConnectionSettings{
+		ID:   "1",
+		Node: "host1",
+		User: "theuser",
+	})
+	db.Create(&models.ConnectionSettings{
+		ID:   "2",
+		Node: "host2",
+		User: "root",
+	})
+	db.Create(&models.ConnectionSettings{
+		ID:   "3",
+		Node: "host3",
+		User: "",
+	})
+}
+
+func expectedClustersSettingsFixtures() models.ClustersSettings {
+	return models.ClustersSettings{
+		{
+			ID:             "1",
+			SelectedChecks: []string{"A", "B", "C"},
+			Hosts: []*models.HostConnection{
+				{
+					Name:    "host1",
+					Address: "10.74.2.10",
+					User:    "theuser",
+				},
+			},
+		},
+		{
+			ID:             "2",
+			SelectedChecks: []string{},
+			Hosts: []*models.HostConnection{
+				{
+					Name:    "host2",
+					Address: "10.74.2.11",
+					User:    "root",
+				},
+			},
+		},
+		{
+			ID:             "3",
+			SelectedChecks: []string{},
+			Hosts: []*models.HostConnection{
+				{
+					Name:    "host3",
+					Address: "10.74.2.12",
+					User:    "cloudadmin",
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
This PR exposes an api at `GET /api/clusters/settings` to retrieve the clusters settings for the runner to provide to Ansible.

Involved settings are:
- selected checks for a cluster
- hosts for a given cluster with `address` and `user` to enable ansible connection

Example API response.
```
[
    {
        "id": "c115e7ecf5901d9a768d06a28ab0ba26",
        "selected_checks": [],
        "hosts": [
            {
                "name": "vmnetweaver01",
                "address": "x.x.x.x",
                "user": "root"
            },
            {
                "name": "vmnetweaver02",
                "address": "x.x.x.x",
                "user": "root"
            }
        ]
    },
    {
        "id": "5dfbd28f35cbfb38969f9b99243ae8d4",
        "selected_checks": [
            "A",
            "B",
            "C",
        ],
        "hosts": [
            {
                "name": "vmhana01",
                "address": "x.x.x.x",
                "user": "cloudadmin"
            },
            {
                "name": "vmhana02",
                "address": "x.x.x.x",
                "user": "cloudadmin"
            }
        ]
    }
]
```

This allows the runner to only call one API and provided useful information to Ansible and remove consul dependency from the runner itself (next PR).