### PR TITLE
Fix Pacemaker Site Details displaying name-related host hrefs

### DIFF
--- a/web/templates/blocks/sites.html.tmpl
+++ b/web/templates/blocks/sites.html.tmpl
@@ -23,7 +23,7 @@
                                 {{ template "health_icon" .Health }}
                             </td>
                             <td>
-                                <a href='/hosts/{{ .Name }}'>
+                                <a href='/hosts/{{ .ID }}'>
                                     {{ .Name }}
                                 </a>
                             </td>


### PR DESCRIPTION
As above, a tiny fix.