### PR TITLE
Make runner use clusters settings API instead of Consul

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 type TrentoApiService interface {
 	IsWebServerUp() bool
 	GetChecksSettingsById(id string) (*webApi.JSONChecksSettings, error)
+	GetClustersSettings() (webApi.ClustersSettingsResponse, error)
 }
 
 type trentoApiService struct {
@@ -37,7 +38,7 @@ func (t *trentoApiService) getJson(query string) ([]byte, int, error) {
 
 	resp, err := t.httpClient.Get(t.composeQuery(query))
 	if err != nil {
-		return nil, resp.StatusCode, err
+		return nil, 0, err
 	}
 
 	defer resp.Body.Close()

--- a/api/clusters_settings.go
+++ b/api/clusters_settings.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	webApi "github.com/trento-project/trento/web"
+)
+
+func (t *trentoApiService) GetClustersSettings() (webApi.ClustersSettingsResponse, error) {
+	body, statusCode, err := t.getJson("internal/clusters/settings")
+	if err != nil {
+		return nil, err
+	}
+
+	if statusCode != http.StatusOK {
+		return nil, fmt.Errorf("error during the request with status code %d", statusCode)
+	}
+
+	var clustersSettings webApi.ClustersSettingsResponse
+
+	err = json.Unmarshal(body, &clustersSettings)
+	if err != nil {
+		return nil, err
+	}
+
+	return clustersSettings, nil
+}

--- a/api/clusters_settings_test.go
+++ b/api/clusters_settings_test.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/trento/test/helpers"
+	"github.com/trento-project/trento/web/models"
+)
+
+const clustersSettingsResponseMock = `
+[
+	{
+		"id": "c115e7ecf5901d9a768d06a28ab0ba26",
+		"selected_checks": [],
+		"hosts": [
+			{
+				"name": "vmnetweaver01",
+				"address": "10.1.2.10",
+				"user": "root"
+			},
+			{
+				"name": "vmnetweaver02",
+				"address": "10.1.2.11",
+				"user": "root"
+			}
+		]
+	},
+	{
+		"id": "5dfbd28f35cbfb38969f9b99243ae8d4",
+		"selected_checks": [
+			"check1",
+			"check2"
+		],
+		"hosts": [
+			{
+				"name": "vmhana01",
+				"address": "10.1.2.12",
+				"user": "cloudadmin"
+			},
+			{
+				"name": "vmhana02",
+				"address": "10.1.2.13",
+				"user": "cloudadmin"
+			}
+		]
+	}
+]`
+
+type ClusterSettingsApiTestCase struct {
+	suite.Suite
+	trentoApi *trentoApiService
+}
+
+func TestClusterSettingsApiTestCase(t *testing.T) {
+	suite.Run(t, new(ClusterSettingsApiTestCase))
+}
+
+func (suite *ClusterSettingsApiTestCase) SetupSuite() {
+	suite.trentoApi = NewTrentoApiService("192.168.1.10", 8000)
+}
+
+func (suite *ClusterSettingsApiTestCase) Test_AnErrorOccursInCommunication() {
+	suite.trentoApi.httpClient.Transport = helpers.ErroringRoundTripFunc(func() error {
+		return fmt.Errorf("some error")
+	})
+
+	_, err := suite.trentoApi.GetClustersSettings()
+
+	suite.Error(err, "some error")
+}
+
+func (suite *ClusterSettingsApiTestCase) Test_ResponseIsNotSuccessful() {
+	suite.trentoApi.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 401,
+		}
+	})
+
+	_, err := suite.trentoApi.GetClustersSettings()
+
+	suite.Error(err, "error during the request with status code 401")
+}
+
+func (suite *ClusterSettingsApiTestCase) Test_ResponseUnmarshalingFailure() {
+	suite.trentoApi.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader("unmatching")),
+		}
+	})
+
+	_, err := suite.trentoApi.GetClustersSettings()
+
+	suite.Contains(err.Error(), "invalid character")
+}
+
+func (suite *ClusterSettingsApiTestCase) Test_ClustersSettingsAreSuccessfullyRetrieved() {
+	suite.trentoApi.httpClient.Transport = helpers.RoundTripFunc(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(clustersSettingsResponseMock)),
+		}
+	})
+
+	clustersSettings, _ := suite.trentoApi.GetClustersSettings()
+	suite.Len(clustersSettings, 2)
+
+	cluster0 := clustersSettings[0]
+	suite.Equal("c115e7ecf5901d9a768d06a28ab0ba26", cluster0.ID)
+	suite.Empty(cluster0.SelectedChecks)
+	assertMatchingHostsOnCluster0(suite, cluster0.Hosts)
+
+	cluster1 := clustersSettings[1]
+	suite.Equal("5dfbd28f35cbfb38969f9b99243ae8d4", cluster1.ID)
+	suite.NotEmpty(cluster1.SelectedChecks)
+	suite.Equal([]string{"check1", "check2"}, cluster1.SelectedChecks)
+	assertMatchingHostsOnCluster1(suite, cluster1.Hosts)
+
+}
+
+func assertMatchingHostsOnCluster0(suite *ClusterSettingsApiTestCase, hosts []*models.HostConnection) {
+	suite.Len(hosts, 2)
+
+	suite.Equal("vmnetweaver01", hosts[0].Name)
+	suite.Equal("10.1.2.10", hosts[0].Address)
+	suite.Equal("root", hosts[0].User)
+
+	suite.Equal("vmnetweaver02", hosts[1].Name)
+	suite.Equal("10.1.2.11", hosts[1].Address)
+	suite.Equal("root", hosts[1].User)
+}
+
+func assertMatchingHostsOnCluster1(suite *ClusterSettingsApiTestCase, hosts []*models.HostConnection) {
+	suite.Len(hosts, 2)
+
+	suite.Equal("vmhana01", hosts[0].Name)
+	suite.Equal("10.1.2.12", hosts[0].Address)
+	suite.Equal("cloudadmin", hosts[0].User)
+
+	suite.Equal("vmhana02", hosts[1].Name)
+	suite.Equal("10.1.2.13", hosts[1].Address)
+	suite.Equal("cloudadmin", hosts[1].User)
+}

--- a/api/mocks/TrentoApiService.go
+++ b/api/mocks/TrentoApiService.go
@@ -35,6 +35,29 @@ func (_m *TrentoApiService) GetChecksSettingsById(id string) (*web.JSONChecksSet
 	return r0, r1
 }
 
+// GetClustersSettings provides a mock function with given fields:
+func (_m *TrentoApiService) GetClustersSettings() (web.ClustersSettingsResponse, error) {
+	ret := _m.Called()
+
+	var r0 web.ClustersSettingsResponse
+	if rf, ok := ret.Get(0).(func() web.ClustersSettingsResponse); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(web.ClustersSettingsResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsWebServerUp provides a mock function with given fields:
 func (_m *TrentoApiService) IsWebServerUp() bool {
 	ret := _m.Called()

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -10,10 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/internal"
-	"github.com/trento-project/trento/internal/consul"
 
 	"github.com/trento-project/trento/api"
 )
@@ -32,7 +30,6 @@ type Runner struct {
 	config    *Config
 	ctx       context.Context
 	ctxCancel context.CancelFunc
-	consul    consul.Client
 	trentoApi api.TrentoApiService
 }
 
@@ -45,18 +42,12 @@ type Config struct {
 }
 
 func NewRunner(config *Config) (*Runner, error) {
-	client, err := consul.DefaultClient()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not create the consul client connection")
-	}
-
 	ctx, ctxCancel := context.WithCancel(context.Background())
 
 	runner := &Runner{
 		config:    config,
 		ctx:       ctx,
 		ctxCancel: ctxCancel,
-		consul:    client,
 	}
 
 	return runner, nil
@@ -202,7 +193,7 @@ func (c *Runner) startCheckRunnerTicker() {
 	}
 
 	tick := func() {
-		content, err := NewClusterInventoryContent(c.consul, c.trentoApi)
+		content, err := NewClusterInventoryContent(c.trentoApi)
 		if err != nil {
 			log.Errorf("Error creating the ansible inventory content")
 			return


### PR DESCRIPTION
this PR cleans up the runner Inventory generation from Consul