### PR TITLE
Further consul cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,6 @@ Please refer to the [Helm official documentation](https://helm.sh/docs/intro/ins
 Add third-party Helm repositories:
 
 ```
-helm repo add hashicorp https://helm.releases.hashicorp.com
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 ```

--- a/docs/trento-architecture.md
+++ b/docs/trento-architecture.md
@@ -4,17 +4,15 @@
 
 ## Trento Agent
 
-The Trento Agent is to be set up on every node that should be handled by Trento,
-and it needs to be combined with a Consul Agent. 
+The Trento Agent is to be set up on every node that should be handled by Trento.
 
 The Trento Agent will run several periodic job loops. 
 
 ### Discovery Loop
 
 The Discovery loop is happening at a very low frequency and priority and is capturing record-worthy
-Data in the Consul Key-Value Store. At the current implementation, only selected datapoints are
-regularly updated into the Consul Key-Value Store. There is no conflict-resolution being implemented,
-the data is unconditionally overwritten.
+Data. At the current implementation, only selected datapoints are regularly updated. 
+There is no conflict-resolution being implemented, the data is unconditionally overwritten.
 
 ## Checker Loop
 

--- a/install-server.sh
+++ b/install-server.sh
@@ -110,7 +110,6 @@ install_helm() {
 
 update_helm_dependencies() {
     echo "Updating Helm dependencies..."
-    helm repo add hashicorp https://helm.releases.hashicorp.com >/dev/null
     helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null
     helm repo update >/dev/null
 }


### PR DESCRIPTION
As title says, some extra cleanup.

Heads up: there are still some consul references in our `go.sum`. That's because of viper dependencies.