### PR TITLE
Reduce the agent discovery interval default value to 30 seconds

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -43,7 +43,7 @@ func NewAgentCmd() *cobra.Command {
 
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
-	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 2, "Discovery mechanism loop period on minutes")
+	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 30, "Discovery mechanism loop period in seconds")
 
 	startCmd.Flags().StringVar(&collectorHost, "collector-host", "localhost", "Data Collector host")
 	startCmd.Flags().IntVar(&collectorPort, "collector-port", 8081, "Data Collector port")

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -55,6 +55,6 @@ func LoadConfig() (*agent.Config, error) {
 		},
 		InstanceName:    hostname,
 		SSHAddress:      sshAddress,
-		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Minute,
+		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Second,
 	}, nil
 }


### PR DESCRIPTION
We can reduce the discovery interval to 30 seconds now that locking is gone