### PR TITLE
Revert count=1 flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ mod-tidy:
 
 .PHONY: test
 test: web-assets
-	GIN_MODE=test go test -v -count=1 ./...
+	GIN_MODE=test go test -v ./...
 
 .PHONY: full-check
 full-check: generate vet-check test web-check


### PR DESCRIPTION
For some reason, disabling test caching doesn't play well with our testify suite test, needs further investigation.
Reverting for now.