### PR TITLE
Disable test parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ mod-tidy:
 
 .PHONY: test
 test: web-assets
-	GIN_MODE=test go test -v -count=1 ./...
+	GIN_MODE=test go test -v -p 1 ./...
 
 .PHONY: full-check
 full-check: generate vet-check test web-check


### PR DESCRIPTION
After disabling the cache of tests in the make target, tests were failing in go `1.17`.
This due the added support of per-package parallelism,  which was breaking the database tests isolation.

This PR restores the caching mechanism to speed up test execution but disable parallelism to avoid concurrency in tests.
