### PR TITLE
Reduce discovery times to 10 seconds and do not store duplicated events

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -43,7 +43,7 @@ func NewAgentCmd() *cobra.Command {
 
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
-	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 30, "Discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 10, "Discovery mechanism loop period in seconds")
 
 	startCmd.Flags().StringVar(&collectorHost, "collector-host", "localhost", "Data Collector host")
 	startCmd.Flags().IntVar(&collectorPort, "collector-port", 8081, "Data Collector port")


### PR DESCRIPTION
This PR reduces the discovery time to 5 seconds and prevent the collector to store duplicated events.

If a duplicate is found, we keep sending it to the projectors in case a projection had failed before and we need to retry.
NOTE: the projectors skip old events by looking to their subscriptions.