### PR TITLE
Add suse registry tag labels in the helm chart

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,10 +1,12 @@
+# !BuildTag: trento/trento-server:0.2.4
+# !BuildTag: trento/trento-server:0.2.4-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.2.3
+version: 0.2.4
 
 dependencies:
   - name: trento-web


### PR DESCRIPTION
This tags are required during the helm chart creation in IBS/OBS. They simply set the version.

As this is the unique difference with the premium helm chart, I think having them is the easiest by now instead of just creating other `Chart.yaml` in the premium project only with these 3 lines of difference.

The version in `revx.y.z` must match the version of the helm chart itself 

PD: The version replacement doesn't work.. And in fact, apparently we don't need to put the trento package version there, so only the helm chart version and build version are needed