### PR TITLE
Remove hardcoded constant for the flavor to a Makefile variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 VERSION ?= $(shell ./hack/get_version_from_git.sh)
+FLAVOR ?= "Community"
 LDFLAGS = -X github.com/trento-project/trento/version.Version="$(VERSION)"
+LDFLAGS := $(LDFLAGS) -X github.com/trento-project/trento/version.Flavor="$(FLAVOR)"
 ARCHS ?= amd64 arm64 ppc64le s390x
 DEBUG ?= 0
 

--- a/version/flavor.go
+++ b/version/flavor.go
@@ -1,3 +1,0 @@
-package version
-
-const Flavor string = "Community"

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,4 @@
 package version
 
 var Version string
+var Flavor string


### PR DESCRIPTION
Due to the recent changes that allow the trento-premium spec file to differ from the community one, it now makes more sense to set the flavor from the Makefile.

This PR does that.