### PR TITLE
Fix SBD checks 0B6DB2 and 49591F remediation rendering

### DIFF
--- a/runner/ansible/roles/checks/1.3.1/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.1/defaults/main.yml
@@ -12,6 +12,7 @@ remediation: |
 
   ## Remediation
   Run the following commands in order:
+
   1. Put cluster into maintenance mode:
      ```crm configure property maintenance-mode=true```
   2. Stop the cluster:

--- a/runner/ansible/roles/checks/1.3.2/defaults/main.yml
+++ b/runner/ansible/roles/checks/1.3.2/defaults/main.yml
@@ -12,6 +12,7 @@ remediation: |
 
   ## Remediation
   Run the following commands in order:
+
   1. Put cluster into maintenance mode:
      ```crm configure property maintenance-mode=true```
   2. Stop the cluster:


### PR DESCRIPTION
Fix `0B6DB2` and `49591F` checks remediation rendering.

![image](https://user-images.githubusercontent.com/36370954/146344114-d8bb914f-f69c-476d-b6e7-00790737b16e.png)
