### PR TITLE
"About premium" improvements

### DIFF
--- a/web/about_test.go
+++ b/web/about_test.go
@@ -52,8 +52,7 @@ func TestAboutHandlerPremium(t *testing.T) {
 
 	assert.Equal(t, 200, resp.Code)
 	assert.Contains(t, minified, "About")
-	assert.Regexp(t, regexp.MustCompile("<dt.*>Subscription</dt><dd.*>Premium.*</dd>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<dt.*>SLES_SAP machines</dt><dd.*>2.*</dd>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<dt.*>SLES4SAP Subscriptions</dt><dd.*badge-success.*>2 Found.*</dd>"), minified)
 }
 
 func TestAboutHandlerCommunity(t *testing.T) {
@@ -95,6 +94,6 @@ func TestAboutHandlerCommunity(t *testing.T) {
 
 	assert.Equal(t, 200, resp.Code)
 	assert.Contains(t, minified, "About")
-	assert.Regexp(t, regexp.MustCompile("<dt.*>Subscription</dt><dd.*>Community.*</dd>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<dt.*>SLES4SAP Subscriptions</dt><dd.*badge-secondary.*>0 Found.*</dd>"), minified)
 	assert.NotContains(t, minified, "SLES_SAP machine")
 }

--- a/web/templates/about.html.tmpl
+++ b/web/templates/about.html.tmpl
@@ -14,7 +14,7 @@
                     <dt class="col-sm-3">Github repository</dt>
                     <dd class="col-sm-9"><a href="https://github.com/trento-project/trento" target="_blank">https://github.com/trento-project/trento</a></dd>
                     <dt class="col-sm-3">SLES4SAP Subscriptions</dt>
-                    <dd class="col-sm-9"><span data-toggle='tooltip' data-original-title='You need at least one SLES4SAP subscription to activate Trento premium' class='badge badge-{{ if .PremiumData.IsPremium }}success{{ else }}secondary{{ end }}'>{{ .PremiumData.Sles4SapCount }} Found</span></dd>
+                    <dd class="col-sm-9"><span class='badge badge-{{ if .PremiumData.IsPremium }}success{{ else }}secondary{{ end }}'>{{ .PremiumData.Sles4SapCount }} Found</span><span class='eos-icons eos-18' data-toggle='tooltip' data-original-title='You need at least one SLES4SAP subscription to activate Trento premium'>info</span></dd>
                 </dl>
             </div>
             <div class="col-sm-6">

--- a/web/templates/about.html.tmpl
+++ b/web/templates/about.html.tmpl
@@ -7,18 +7,14 @@
                   life of SAP Applications administrators</p>
                 <hr/>
                 <dl class="row">
-                    <dt class="col-sm-3">Web version</dt>
-                    <dd class="col-sm-9">v{{ .Version }}</dd>
                     <dt class="col-sm-3">Trento flavor</dt>
                     <dd class="col-sm-9">{{ .Flavor }}</dd>
+                    <dt class="col-sm-3">Server version</dt>
+                    <dd class="col-sm-9">v{{ .Version }}</dd>
                     <dt class="col-sm-3">Github repository</dt>
                     <dd class="col-sm-9"><a href="https://github.com/trento-project/trento" target="_blank">https://github.com/trento-project/trento</a></dd>
-                    <dt class="col-sm-3">Subscription</dt>
-                    <dd class="col-sm-9"><span class='badge badge-{{ if .PremiumData.IsPremium }}success{{ else }}secondary{{ end }}'>{{ if .PremiumData.IsPremium }}Premium{{ else }}Community{{ end }}</span></dd>
-                    {{- if .PremiumData.IsPremium }}
-                    <dt class="col-sm-3">SLES_SAP machines</dt>
-                    <dd class="col-sm-9">{{ .PremiumData.Sles4SapCount }}</dd>
-                    {{- end }}
+                    <dt class="col-sm-3">SLES4SAP Subscriptions</dt>
+                    <dd class="col-sm-9"><span data-toggle='tooltip' data-original-title='You need at least one SLES4SAP subscription to activate Trento premium' class='badge badge-{{ if .PremiumData.IsPremium }}success{{ else }}secondary{{ end }}'>{{ .PremiumData.Sles4SapCount }} Found</span></dd>
                 </dl>
             </div>
             <div class="col-sm-6">


### PR DESCRIPTION
This PR addresses the new template changes requested in issue #582. The other changes should have been addressed in PR #586

This is how it looks now for both cases when no subscriptions are found and when there are e.g. 2 subscriptions found.
![2-found](https://user-images.githubusercontent.com/2668401/146387822-0382e037-7239-40d4-b9e2-ba7d0eb274a3.png)
![none-found](https://user-images.githubusercontent.com/2668401/146387826-0723edd3-f994-4705-89b1-bce52c21ed3a.png)

In both cases there is now a tooltip 
![tooltip](https://user-images.githubusercontent.com/2668401/146388213-26cca956-2570-4b38-8300-baa19d92a54d.png)

stating the number of subscriptions found. This is not exactly what the issue wanted but what I understood was the intention from the conversation we had yesterday.
 