### PR TITLE
Revert collector deduplication

### DIFF
--- a/web/services/collector.go
+++ b/web/services/collector.go
@@ -1,9 +1,6 @@
 package services
 
 import (
-	"errors"
-
-	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/web/datapipeline"
 	"gorm.io/gorm"
 )
@@ -22,36 +19,11 @@ func NewCollectorService(db *gorm.DB, projectorsChannel chan *datapipeline.DataC
 	return &collectorService{db: db, projectorsChannel: projectorsChannel}
 }
 
-// StoreEvent stores the event in the database and sends it to the projectors.
-// If the last event is equal to the current one, it is not stored nor sent.
 func (c *collectorService) StoreEvent(collectedData *datapipeline.DataCollectedEvent) error {
-	return c.db.Transaction(func(tx *gorm.DB) error {
-		var event datapipeline.DataCollectedEvent
-		err := tx.
-			Where(&datapipeline.DataCollectedEvent{
-				AgentID:       collectedData.AgentID,
-				DiscoveryType: collectedData.DiscoveryType,
-				Payload:       collectedData.Payload,
-			}).
-			Last(&event).
-			Error
+	if err := c.db.Create(collectedData).Error; err != nil {
+		return err
+	}
+	c.projectorsChannel <- collectedData
 
-		if errors.Is(gorm.ErrRecordNotFound, err) {
-			err := tx.Create(collectedData).Error
-			if err != nil {
-				return err
-			}
-			c.projectorsChannel <- collectedData
-			return nil
-		}
-
-		if err != nil {
-			return err
-		}
-
-		log.Debugf("Event already exists. Agent ID: %s, DiscoveryType: %s ", collectedData.AgentID, collectedData.DiscoveryType)
-		c.projectorsChannel <- &event
-
-		return nil
-	})
+	return nil
 }

--- a/web/services/collector_test.go
+++ b/web/services/collector_test.go
@@ -60,38 +60,3 @@ func (suite *CollectorServiceTestSuite) TestCollectorService_StoreEvent() {
 	suite.EqualValues(eventFromChannel.DiscoveryType, eventFromDB.DiscoveryType)
 	suite.EqualValues(eventFromChannel.Payload, eventFromDB.Payload)
 }
-
-func (suite *CollectorServiceTestSuite) TestCollectorService_StoreEvent_Skipping() {
-	firstEvent := &datapipeline.DataCollectedEvent{
-		AgentID:       "agent_id",
-		DiscoveryType: "test_discovery_type",
-		Payload:       []byte("{}"),
-	}
-	err := suite.collectorService.StoreEvent(firstEvent)
-	suite.NoError(err)
-	<-suite.ch
-
-	var eventFromDBFirst datapipeline.DataCollectedEvent
-	suite.tx.Last(&eventFromDBFirst)
-
-	secondEvent := &datapipeline.DataCollectedEvent{
-		AgentID:       "agent_id",
-		DiscoveryType: "test_discovery_type",
-		Payload:       []byte("{}"),
-	}
-	err = suite.collectorService.StoreEvent(secondEvent)
-	suite.NoError(err)
-	<-suite.ch
-
-	var eventFromDBSecond datapipeline.DataCollectedEvent
-	err = suite.tx.Last(&eventFromDBSecond).Error
-	suite.NoError(err)
-
-	var allEvents []*datapipeline.DataCollectedEvent
-	err = suite.tx.Find(&allEvents).Error
-	suite.NoError(err)
-
-	suite.EqualValues(eventFromDBFirst.ID, eventFromDBSecond.ID)
-	suite.EqualValues(eventFromDBFirst.CreatedAt, eventFromDBSecond.CreatedAt)
-	suite.Equal(1, len(allEvents))
-}


### PR DESCRIPTION
This was causing performances problem due to the big jsonb field comparison in the QA env with 26 nodes.
We need to find a better solution (hashing/caching), reverting the premature optimization for now.