### PR TITLE
Update gin gonic to the latest version due to major breaking bug in the router mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/StackExchange/wmi v1.2.1 // indirect
 	github.com/gin-contrib/sessions v0.0.3
-	github.com/gin-gonic/gin v1.7.0
+	github.com/gin-gonic/gin v1.7.7
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/gin-gonic/gin v1.3.0/go.mod h1:7cKuhb5qV2ggCFctp2fJQ+ErvciLZrIeoOSOm6
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
 github.com/gin-gonic/gin v1.7.0 h1:jGB9xAJQ12AIGNB4HguylppmDK1Am9ppF7XnGXXJuoU=
 github.com/gin-gonic/gin v1.7.0/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gin-gonic/gin v1.7.7 h1:3DoBmSbJbZAWqXJC3SLjAPfutPJJRN1U5pALB7EeTTs=
+github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/web/checks_api_test.go
+++ b/web/checks_api_test.go
@@ -235,7 +235,7 @@ func TestApiCreateChecksCatalogHandler(t *testing.T) {
 
 func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	mockClustersService := new(services.MockClustersService)
-	mockClustersService.On("GetClusterSettingsByID", "a615a35f65627be5a757319a0741127f").Return(&models.ClusterSettings{
+	mockClustersService.On("GetClusterSettingsByID", "cluster_id").Return(&models.ClusterSettings{
 		SelectedChecks: []string{"ABCDEF", "123456"},
 		Hosts: []*models.HostConnection{
 			{
@@ -257,7 +257,7 @@ func TestApiCheckGetSettingsByIdHandler(t *testing.T) {
 	assert.NoError(t, err)
 
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/api/checks/a615a35f65627be5a757319a0741127f/settings", nil)
+	req, err := http.NewRequest("GET", "/api/checks/cluster_id/settings", nil)
 	assert.NoError(t, err)
 
 	app.webEngine.ServeHTTP(resp, req)


### PR DESCRIPTION
The route `/checks/catalog` was overriding the route of `/checks/:id/catalog` when `:id` was staring with the letter `c`.

Updating to the latest gin gonic version solves the problem.

More info: https://github.com/gin-gonic/gin/issues/2696

Solves: #608 and partially #606 