### PR TITLE
Paginate correctly sap systems

### DIFF
--- a/web/entities/sap_system.go
+++ b/web/entities/sap_system.go
@@ -2,6 +2,7 @@ package entities
 
 import (
 	"time"
+	"sort"
 
 	"github.com/lib/pq"
 	"github.com/trento-project/trento/web/models"
@@ -84,5 +85,13 @@ func (s SAPSystemInstances) ToModel() []*models.SAPSystem {
 	for _, sapSystem := range set {
 		sapSystems = append(sapSystems, sapSystem)
 	}
+	sortBySid(sapSystems)
+
 	return sapSystems
+}
+
+func sortBySid(sapSystems []*models.SAPSystem) {
+	sort.Slice(sapSystems, func(i, j int) bool {
+		return sapSystems[i].SID < sapSystems[j].SID
+	})
 }

--- a/web/entities/sap_system.go
+++ b/web/entities/sap_system.go
@@ -1,8 +1,8 @@
 package entities
 
 import (
-	"time"
 	"sort"
+	"time"
 
 	"github.com/lib/pq"
 	"github.com/trento-project/trento/web/models"

--- a/web/entities/sap_system.go
+++ b/web/entities/sap_system.go
@@ -85,12 +85,12 @@ func (s SAPSystemInstances) ToModel() []*models.SAPSystem {
 	for _, sapSystem := range set {
 		sapSystems = append(sapSystems, sapSystem)
 	}
-	sortBySid(sapSystems)
+	sortBySID(sapSystems)
 
 	return sapSystems
 }
 
-func sortBySid(sapSystems []*models.SAPSystem) {
+func sortBySID(sapSystems []*models.SAPSystem) {
 	sort.Slice(sapSystems, func(i, j int) bool {
 		return sapSystems[i].SID < sapSystems[j].SID
 	})

--- a/web/services/sap_systems.go
+++ b/web/services/sap_systems.go
@@ -172,11 +172,17 @@ func (s *sapSystemsService) GetAllDatabasesTags() ([]string, error) {
 func (s *sapSystemsService) getAllByType(sapSystemType string, tagResourceType string, filter *SAPSystemFilter, page *Page) (models.SAPSystemList, error) {
 	var instances entities.SAPSystemInstances
 
+	paginationSubQuery := s.db.
+		Distinct("sid").
+		Where("type = ?", sapSystemType).
+		Scopes(Paginate(page)).
+		Order("sid").
+		Table("sap_system_instances")
+
 	db := s.db.
 		Preload("Host").
-		Scopes(Paginate(page)).
 		Preload("Tags", "resource_type = (?)", tagResourceType).
-		Where("type = ?", sapSystemType).
+		Where("sid IN (?)", paginationSubQuery).
 		Order("sid, instance_number")
 
 	if filter != nil {

--- a/web/services/sap_systems.go
+++ b/web/services/sap_systems.go
@@ -176,7 +176,8 @@ func (s *sapSystemsService) getAllByType(sapSystemType string, tagResourceType s
 		Preload("Host").
 		Scopes(Paginate(page)).
 		Preload("Tags", "resource_type = (?)", tagResourceType).
-		Where("type = ?", sapSystemType)
+		Where("type = ?", sapSystemType).
+		Order("sid, instance_number")
 
 	if filter != nil {
 		if len(filter.SIDs) > 0 {

--- a/web/services/sap_systems.go
+++ b/web/services/sap_systems.go
@@ -173,7 +173,7 @@ func (s *sapSystemsService) getAllByType(sapSystemType string, tagResourceType s
 	var instances entities.SAPSystemInstances
 
 	paginationSubQuery := s.db.
-		Distinct("sid").
+		Distinct("id,sid").
 		Where("type = ?", sapSystemType).
 		Scopes(Paginate(page)).
 		Order("sid").
@@ -182,7 +182,7 @@ func (s *sapSystemsService) getAllByType(sapSystemType string, tagResourceType s
 	db := s.db.
 		Preload("Host").
 		Preload("Tags", "resource_type = (?)", tagResourceType).
-		Where("sid IN (?)", paginationSubQuery).
+		Where("(id,sid) IN (?)", paginationSubQuery).
 		Order("sid, instance_number")
 
 	if filter != nil {

--- a/web/services/sap_systems_test.go
+++ b/web/services/sap_systems_test.go
@@ -175,6 +175,17 @@ func (suite *SAPSystemsServiceTestSuite) TestSAPSystemsService_GetAllApplication
 	}, applications)
 }
 
+func (suite *SAPSystemsServiceTestSuite) TestSAPSystemsService_getAllByType_Pagination() {
+	applications, err := suite.sapSystemsService.getAllByType(
+		models.SAPSystemTypeDatabase, models.TagSAPSystemResourceType,
+		&SAPSystemFilter{
+			SIDs: []string{"PRD"}, Tags: []string{},
+		}, &Page{Number: 1, Size: 1})
+	suite.NoError(err)
+	suite.Equal(1, len(applications))
+	suite.Equal(2, len(applications[0].Instances))
+}
+
 func (suite *SAPSystemsServiceTestSuite) TestSAPSystemsService_GetAllApplications_Filter() {
 	applications, err := suite.sapSystemsService.GetAllApplications(&SAPSystemFilter{
 		SIDs: []string{"HA1"}, Tags: []string{"tag1"},

--- a/web/templates/sap_systems.html.tmpl
+++ b/web/templates/sap_systems.html.tmpl
@@ -43,4 +43,5 @@
         </select>
     </div>
     {{ template "sap_systems_table" . }}
+    {{ template "pagination" .Pagination }}
 {{ end }}


### PR DESCRIPTION
The sap systems list page was not paginating properly, as it was paginating based on the instances number rather than the systems number, which was hiding some instances within visualized systems.

This implementation limits the pagination to the systems instead of instances.

Besides this:
- It includes the pagination controls in the sap systems page.
- Sorts the SAP systems before showing them in the UI to have always the same order based in sid and instance number

![image](https://user-images.githubusercontent.com/36370954/146755045-8f23da0d-b1e2-4f4b-be09-8e73bc2213b6.png)
