### PR TITLE
Align properly the cluster sites tables columns

### DIFF
--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -470,8 +470,8 @@ func TestClusterHandlerHANA(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(".*error.*alert-body.*Critical.*1"), minified)
 
 	// Nodes
-	assert.Regexp(t, regexp.MustCompile("<td.*check_circle.*<td><a.*href=/hosts/host1.*>test_node_1</a></td><td>192.168.1.1</td><td>10.123.123.123</td><td><span .*>HANA Primary</span>"), minified)
-	assert.Regexp(t, regexp.MustCompile("<td.*error.*<td><a.*href=/hosts/host2.*>test_node_2</a></td><td>192.168.1.2</td>.*<span .*danger.*>HANA Failed</span>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*check_circle.*<td.*><a.*href=/hosts/host1.*>test_node_1</a></td><td.*>192\\.168\\.1\\.1</td><td.*>10\\.123\\.123\\.123</td><td.*><span .*>HANA Primary</span>"), minified)
+	assert.Regexp(t, regexp.MustCompile("<td.*error.*<td.*><a.*href=/hosts/host2.*>test_node_2</a></td><td.*>192\\.168\\.1\\.2</td>.*<span .*danger.*>HANA Failed</span>"), minified)
 	// Resources
 	assert.Regexp(t, regexp.MustCompile("<td>sbd</td><td>stonith:external/sbd</td><td>Started</td><td>active</td><td>0</td>"), minified)
 	assert.Regexp(t, regexp.MustCompile("<td>dummy_failed</td><td>dummy</td><td>Started</td><td>failed</td><td>0</td>"), minified)

--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -223,3 +223,15 @@ td i.critical {
 .margin-top-24 {
   margin-top: 24px;
 }
+
+.w-5 {
+  width: 5%;
+}
+
+.w-20 {
+  width: 20%;
+}
+
+.w-30 {
+  width: 30%;
+}

--- a/web/templates/blocks/sites.html.tmpl
+++ b/web/templates/blocks/sites.html.tmpl
@@ -8,29 +8,29 @@
                 <table class="table eos-table">
                     <thead>
                     <tr>
-                        <th scope="col"></th>
-                        <th scope="col">Hostname</th>
-                        <th scope="col">IP</th>
-                        <th scope="col">Virtual IP</th>
-                        <th scope="col">Role</th>
-                        <th scope="col"></th>
+                        <th scope="col" class="w-5"></th>
+                        <th scope="col" class="w-20">Hostname</th>
+                        <th scope="col" class="w-30">IP</th>
+                        <th scope="col" class="w-20">Virtual IP</th>
+                        <th scope="col" class="w-20">Role</th>
+                        <th scope="col" class="w-5"></th>
                     </tr>
                     </thead>
                     <tbody>
                     {{- range $nodes}}
                         <tr>
-                            <td>
+                            <td class="w-5">
                                 {{ template "health_icon" .Health }}
                             </td>
-                            <td>
+                            <td class="w-20">
                                 <a href='/hosts/{{ .HostID }}'>
                                     {{ .Name }}
                                 </a>
                             </td>
-                            <td>
+                            <td class="w-30">
                                 {{- range $i, $v := .IPAddresses }}{{- if $i }} ,{{- end }}{{ . }}{{- end }}
                             </td>
-                            <td>
+                            <td class="w-20">
                                 {{- range $i, $v := .VirtualIPs }}{{- if $i }} ,{{- end }}{{ . }}{{- end }}
                             </td>
                             <td>
@@ -42,8 +42,7 @@
                                 {{- end }}
                                 <span class="badge badge-pill {{ $badgeClass }}">HANA {{ .HANAStatus }}</span>
                             </td>
-
-                            <td class="float-right">
+                            <td class="w-5">
                                 <button class="btn btn-secondary btn-sm" data-toggle="modal"
                                         data-target="#{{ .Name }}Modal">
                                     Details


### PR DESCRIPTION
Align properly the sites tables in the cluster page. Now, all the columns have a fixed width.

![image](https://user-images.githubusercontent.com/36370954/146779535-1480c80c-1b44-487c-bbba-79c27427e36b.png)
