### PR TITLE
Fix test 373DB8 to pass if timeout unit is set

### DIFF
--- a/runner/ansible/roles/checks/1.2.2/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.2.2/tasks/main.yml
@@ -4,9 +4,9 @@
   shell: |
    timeout=$(crm_attribute -t crm_config -G -n stonith-timeout --quiet)
    if [[cibadmin -Q --xpath "//primitive[@type='fence_azure_arm']/@type" > /dev/null 2>&1 ]]; then
-     exit $([[ "${timeout}" = "{{ expected[name + '.fence_azure_arm'] }}" ]])
+     exit $([[ "${timeout}" =~ {{ expected[name + '.fence_azure_arm'] }}s?$ ]])
    else
-     exit $([[ "${timeout}" = "{{ expected[name + '.sbd'] }}" ]])
+     exit $([[ "${timeout}" =~ {{ expected[name + '.sbd'] }}s?$ ]])
    fi
   check_mode: false
   register: config_updated


### PR DESCRIPTION
Fix for https://github.com/trento-project/trento/issues/447

Now the checks runs a regular expression to consider the `s` unit besides the value.

PD: 
@diegoakechi I guess this issue doesn't only happen in this check, as the usage of the unit is accepted in pacemaker. I guess that this situation is possible in any time based parameter.