### PR TITLE
Add mTLS to the helm chart

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -30,15 +30,19 @@ func NewAgentCmd() *cobra.Command {
 	agentCmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Command tree related to the agent component",
+		PersistentPreRunE: func(agentCmd *cobra.Command, _ []string) error {
+			agentCmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+
+			return internal.InitConfig("agent")
+		},
 	}
 
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Start the agent",
 		Run:   start,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			return internal.InitConfig("agent")
-		},
 	}
 
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
@@ -52,11 +56,6 @@ func NewAgentCmd() *cobra.Command {
 	startCmd.Flags().StringVar(&cert, "cert", "", "mTLS client certificate")
 	startCmd.Flags().StringVar(&key, "key", "", "mTLS client key")
 	startCmd.Flags().StringVar(&ca, "ca", "", "mTLS Certificate Authority")
-
-	// Bind the flags to viper and make them available to the application
-	startCmd.Flags().VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(f.Name, f)
-	})
 
 	agentCmd.AddCommand(startCmd)
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -62,7 +62,7 @@ func NewAgentCmd() *cobra.Command {
 	return agentCmd
 }
 
-func start(cmd *cobra.Command, args []string) {
+func start(*cobra.Command, []string) {
 	var err error
 
 	signals := make(chan os.Signal, 1)

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -1,0 +1,94 @@
+package agent
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/trento/agent"
+	"github.com/trento-project/trento/agent/discovery/collector"
+)
+
+type AgentCmdTestSuite struct {
+	suite.Suite
+	cmd *cobra.Command
+}
+
+func TestAgentCmdTestSuite(t *testing.T) {
+	suite.Run(t, new(AgentCmdTestSuite))
+}
+
+func (suite *AgentCmdTestSuite) SetupTest() {
+	os.Clearenv()
+
+	cmd := NewAgentCmd()
+
+	cmd.Commands()[0].Run = func(cmd *cobra.Command, args []string) {
+		// do nothing
+	}
+
+	cmd.SetArgs([]string{
+		"start",
+	})
+
+	var b bytes.Buffer
+	cmd.SetOut(&b)
+
+	suite.cmd = cmd
+}
+
+func (suite *AgentCmdTestSuite) TearDownTest() {
+	suite.cmd.Execute()
+
+	expectedConfig := &agent.Config{
+		InstanceName:    "some-hostname",
+		SSHAddress:      "some-ssh-address",
+		DiscoveryPeriod: 10 * time.Second,
+		CollectorConfig: &collector.Config{
+			CollectorHost: "localhost",
+			CollectorPort: 1337,
+			EnablemTLS:    true,
+			Cert:          "some-cert",
+			Key:           "some-key",
+			CA:            "some-ca",
+		},
+	}
+
+	config, err := LoadConfig()
+	config.InstanceName = "some-hostname"
+	suite.NoError(err)
+
+	suite.EqualValues(expectedConfig, config)
+}
+
+func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
+	suite.cmd.SetArgs([]string{
+		"start",
+		"--ssh-address=some-ssh-address",
+		"--discovery-period=10",
+		"--collector-host=localhost",
+		"--collector-port=1337",
+		"--enable-mtls",
+		"--cert=some-cert",
+		"--key=some-key",
+		"--ca=some-ca",
+	})
+}
+
+func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
+	os.Setenv("TRENTO_SSH_ADDRESS", "some-ssh-address")
+	os.Setenv("TRENTO_DISCOVERY_PERIOD", "10")
+	os.Setenv("TRENTO_COLLECTOR_HOST", "localhost")
+	os.Setenv("TRENTO_COLLECTOR_PORT", "1337")
+	os.Setenv("TRENTO_ENABLE_MTLS", "true")
+	os.Setenv("TRENTO_CERT", "some-cert")
+	os.Setenv("TRENTO_KEY", "some-key")
+	os.Setenv("TRENTO_CA", "some-ca")
+}
+
+func (suite *AgentCmdTestSuite) TestConfigFromFile() {
+	os.Setenv("TRENTO_CONFIG", "../../test/fixtures/config/agent.yaml")
+}

--- a/cmd/runner/config.go
+++ b/cmd/runner/config.go
@@ -11,7 +11,7 @@ func LoadConfig() *runner.Config {
 	return &runner.Config{
 		ApiHost:       viper.GetString("api-host"),
 		ApiPort:       viper.GetInt("api-port"),
-		Interval:      time.Duration(interval) * time.Minute,
+		Interval:      time.Duration(viper.GetInt("interval")) * time.Minute,
 		AnsibleFolder: viper.GetString("ansible-folder"),
 	}
 }

--- a/cmd/runner/config_test.go
+++ b/cmd/runner/config_test.go
@@ -1,0 +1,78 @@
+package runner
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/trento/runner"
+)
+
+type RunnerCmdTestSuite struct {
+	suite.Suite
+	cmd *cobra.Command
+}
+
+func TestRunnerCmdTestSuite(t *testing.T) {
+	suite.Run(t, new(RunnerCmdTestSuite))
+}
+
+func (suite *RunnerCmdTestSuite) SetupTest() {
+	os.Clearenv()
+
+	cmd := NewRunnerCmd()
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		// do nothing
+	}
+
+	cmd.Commands()[0].Run = func(cmd *cobra.Command, args []string) {
+		// do nothing
+	}
+
+	cmd.SetArgs([]string{
+		"start",
+	})
+
+	var b bytes.Buffer
+	cmd.SetOut(&b)
+
+	suite.cmd = cmd
+}
+
+func (suite *RunnerCmdTestSuite) TearDownTest() {
+	suite.cmd.Execute()
+
+	expectedConfig := &runner.Config{
+		ApiHost:       "some-api-host",
+		ApiPort:       1337,
+		Interval:      1 * time.Minute,
+		AnsibleFolder: "path/to/ansible",
+	}
+	config := LoadConfig()
+
+	suite.EqualValues(expectedConfig, config)
+}
+
+func (suite *RunnerCmdTestSuite) TestConfigFromFlags() {
+	suite.cmd.SetArgs([]string{
+		"start",
+		"--api-host=some-api-host",
+		"--api-port=1337",
+		"--interval=1",
+		"--ansible-folder=path/to/ansible",
+	})
+}
+
+func (suite *RunnerCmdTestSuite) TestConfigFromEnv() {
+	os.Setenv("TRENTO_API_HOST", "some-api-host")
+	os.Setenv("TRENTO_API_PORT", "1337")
+	os.Setenv("TRENTO_INTERVAL", "1")
+	os.Setenv("TRENTO_ANSIBLE_FOLDER", "path/to/ansible")
+}
+
+func (suite *RunnerCmdTestSuite) TestConfigFromFile() {
+	os.Setenv("TRENTO_CONFIG", "../../test/fixtures/config/runner.yaml")
+}

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -15,12 +15,12 @@ import (
 	"github.com/trento-project/trento/runner"
 )
 
-var apiHost string
-var apiPort int
-var interval int
-var ansibleFolder string
-
 func NewRunnerCmd() *cobra.Command {
+	var apiHost string
+	var apiPort int
+	var interval int
+	var ansibleFolder string
+
 	runnerCmd := &cobra.Command{
 		Use:   "runner",
 		Short: "Command tree related to the runner component",
@@ -49,7 +49,7 @@ func NewRunnerCmd() *cobra.Command {
 	return runnerCmd
 }
 
-func start(cmd *cobra.Command, args []string) {
+func start(*cobra.Command, []string) {
 	var err error
 
 	signals := make(chan os.Signal, 1)

--- a/cmd/runner/runner.go
+++ b/cmd/runner/runner.go
@@ -24,26 +24,25 @@ func NewRunnerCmd() *cobra.Command {
 	runnerCmd := &cobra.Command{
 		Use:   "runner",
 		Short: "Command tree related to the runner component",
+		PersistentPreRunE: func(runnerCmd *cobra.Command, _ []string) error {
+			runnerCmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+
+			return internal.InitConfig("runner")
+		},
 	}
 
 	startCmd := &cobra.Command{
 		Use:   "start",
 		Short: "Starts the runner process. This process takes care of running the checks",
 		Run:   start,
-		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
-			return internal.InitConfig("runner")
-		},
 	}
 
 	startCmd.Flags().StringVar(&apiHost, "api-host", "0.0.0.0", "Trento web server API host")
 	startCmd.Flags().IntVar(&apiPort, "api-port", 8080, "Trento web server API port")
 	startCmd.Flags().IntVarP(&interval, "interval", "i", 5, "Interval in minutes to run the checks")
 	startCmd.Flags().StringVar(&ansibleFolder, "ansible-folder", "/tmp/trento", "Folder where the ansible file structure will be created")
-
-	// Bind the flags to viper and make them available to the application
-	startCmd.Flags().VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(f.Name, f)
-	})
 
 	runnerCmd.AddCommand(startCmd)
 

--- a/cmd/web/config_test.go
+++ b/cmd/web/config_test.go
@@ -1,0 +1,102 @@
+package web
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/suite"
+	"github.com/trento-project/trento/internal/db"
+	"github.com/trento-project/trento/web"
+)
+
+type WebCmdTestSuite struct {
+	suite.Suite
+	cmd *cobra.Command
+}
+
+func TestWebCmdTestSuite(t *testing.T) {
+	suite.Run(t, new(WebCmdTestSuite))
+}
+
+func (suite *WebCmdTestSuite) SetupTest() {
+	os.Clearenv()
+
+	cmd := NewWebCmd()
+
+	cmd.Commands()[1].Run = func(cmd *cobra.Command, args []string) {
+		// do nothing
+	}
+
+	cmd.SetArgs([]string{
+		"serve",
+	})
+
+	var b bytes.Buffer
+	cmd.SetOut(&b)
+
+	suite.cmd = cmd
+}
+
+func (suite *WebCmdTestSuite) TearDownTest() {
+	suite.cmd.Execute()
+
+	expectedConfig := &web.Config{
+		Host:          "some-host",
+		Port:          1337,
+		CollectorPort: 1338,
+		EnablemTLS:    true,
+		Cert:          "some-cert",
+		Key:           "some-key",
+		CA:            "some-ca",
+		DBConfig: &db.Config{
+			Host:     "some-db-host",
+			Port:     "6543",
+			User:     "postgres",
+			Password: "password",
+			DBName:   "trento",
+		},
+	}
+	config, err := LoadConfig()
+	suite.NoError(err)
+
+	suite.EqualValues(expectedConfig, config)
+}
+
+func (suite *WebCmdTestSuite) TestConfigFromFlags() {
+	suite.cmd.SetArgs([]string{
+		"serve",
+		"--host=some-host",
+		"--port=1337",
+		"--collector-port=1338",
+		"--enable-mtls",
+		"--cert=some-cert",
+		"--key=some-key",
+		"--ca=some-ca",
+		"--db-host=some-db-host",
+		"--db-port=6543",
+		"--db-user=postgres",
+		"--db-password=password",
+		"--db-name=trento",
+	})
+}
+
+func (suite *WebCmdTestSuite) TestConfigFromEnv() {
+	os.Setenv("TRENTO_HOST", "some-host")
+	os.Setenv("TRENTO_PORT", "1337")
+	os.Setenv("TRENTO_COLLECTOR_PORT", "1338")
+	os.Setenv("TRENTO_ENABLE_MTLS", "true")
+	os.Setenv("TRENTO_CERT", "some-cert")
+	os.Setenv("TRENTO_KEY", "some-key")
+	os.Setenv("TRENTO_CA", "some-ca")
+	os.Setenv("TRENTO_DB_HOST", "some-db-host")
+	os.Setenv("TRENTO_DB_PORT", "6543")
+	os.Setenv("TRENTO_DB_USER", "postgres")
+	os.Setenv("TRENTO_DB_PASSWORD", "password")
+	os.Setenv("TRENTO_DB_NAME", "trento")
+}
+
+func (suite *WebCmdTestSuite) TestConfigFromFile() {
+	os.Setenv("TRENTO_CONFIG", "../../test/fixtures/config/web.yaml")
+}

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -28,7 +28,13 @@ func NewWebCmd() *cobra.Command {
 	webCmd := &cobra.Command{
 		Use:   "web",
 		Short: "Command tree related to the web application component",
-		PersistentPreRunE: func(*cobra.Command, []string) error {
+		PersistentPreRunE: func(webCmd *cobra.Command, _ []string) error {
+			webCmd.Flags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
+			webCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+				viper.BindPFlag(f.Name, f)
+			})
 			return internal.InitConfig("web")
 		},
 	}
@@ -38,10 +44,6 @@ func NewWebCmd() *cobra.Command {
 	webCmd.PersistentFlags().StringVar(&dbUser, "db-user", "postgres", "The database user")
 	webCmd.PersistentFlags().StringVar(&dbPassword, "db-password", "postgres", "The database password")
 	webCmd.PersistentFlags().StringVar(&dbName, "db-name", "trento", "The database name that the application will use")
-
-	webCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(f.Name, f)
-	})
 
 	addServeCmd(webCmd)
 	addPruneCmd(webCmd)
@@ -74,11 +76,6 @@ func addServeCmd(webCmd *cobra.Command) {
 	serveCmd.Flags().StringVar(&key, "key", "", "mTLS server key")
 	serveCmd.Flags().StringVar(&ca, "ca", "", "mTLS Certificate Authority")
 
-	// Bind the flags to viper and make them available to the application
-	serveCmd.Flags().VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(f.Name, f)
-	})
-
 	webCmd.AddCommand(serveCmd)
 }
 
@@ -92,9 +89,6 @@ func addPruneCmd(webCmd *cobra.Command) {
 	}
 
 	pruneCmd.Flags().UintVar(&olderThan, "older-than", 10, "Prune data discovery events older than <value> days.")
-	pruneCmd.Flags().VisitAll(func(f *pflag.Flag) {
-		viper.BindPFlag(f.Name, f)
-	})
 
 	webCmd.AddCommand(pruneCmd)
 }

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -93,7 +93,7 @@ func addPruneCmd(webCmd *cobra.Command) {
 	webCmd.AddCommand(pruneCmd)
 }
 
-func serve(_ *cobra.Command, _ []string) {
+func serve(*cobra.Command, []string) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -6,7 +6,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.2.6
+version: 0.2.7
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-web/templates/certs.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/certs.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trento-runner.fullname" . }}-certs
+data:
+  cert: |-
+    {{ .Values.mTLS.cert | b64enc }}
+  key: |-
+    {{ .Values.mTLS.key | b64enc  }}
+  ca: |-
+    {{ .Values.mTLS.ca | b64enc  }}

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -43,6 +43,15 @@ spec:
             - "{{ .Values.webService.port }}"
             - --collector-port
             - "{{ .Values.collectorService.port }}"
+            {{ if .Values.mTLS.enabled }}
+            - --enable-mtls
+            - --cert
+            - /certs/cert.pem
+            - --key
+            - /certs/key.pem
+            - --ca
+            - /certs/ca.pem
+            {{ end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -64,6 +73,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: certs
+            mountPath: "/certs"
+            readOnly: true
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -76,3 +89,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ include "trento-runner.fullname" . }}-certs
+          items:
+          - key: cert
+            path: cert.pem
+          - key: ca
+            path: ca.pem
+          - key: key
+            path: key.pem
+            

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -5,6 +5,12 @@
 global:
   logLevel: info
 
+mTLS:
+  enabled: false
+  cert: ""
+  key: ""
+  ca: ""
+
 replicaCount: 1
 
 image:

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -1,0 +1,8 @@
+ssh-address: some-ssh-address
+discovery-period: 10
+collector-host: localhost
+collector-port: 1337
+enable-mtls: true
+cert: some-cert
+key: some-key
+ca: some-ca

--- a/test/fixtures/config/runner.yaml
+++ b/test/fixtures/config/runner.yaml
@@ -1,0 +1,4 @@
+api-host: some-api-host
+api-port: 1337
+interval: 1
+ansible-folder: path/to/ansible

--- a/test/fixtures/config/web.yaml
+++ b/test/fixtures/config/web.yaml
@@ -1,0 +1,12 @@
+host: some-host
+port: 1337
+collector-port: 1338
+enable-mtls: true
+cert: some-cert
+key: some-key
+ca: some-ca
+db-host: some-db-host
+db-port: 6543
+db-user: postgres
+db-password: password
+db-name: trento


### PR DESCRIPTION
This PR adds mTLS values to the helm chart and fixes several flag/configuration issues in our cli that emerged during the task.

It also adds configuration tests for agent/runner/web commands.

Closes: #410 and partially  #380