### PR TITLE
Bump Trento version to 0.7.1 inside install scripts

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -40,7 +40,7 @@ ARGUMENT_LIST=(
     "use-tgz"
 )
 
-readonly TRENTO_VERSION=0.6.0
+readonly TRENTO_VERSION=0.7.1
 
 opts=$(
     getopt \

--- a/install-server.sh
+++ b/install-server.sh
@@ -4,7 +4,7 @@ set -e
 
 readonly ARGS=("$@")
 readonly PROGNAME="./install-server.sh"
-TRENTO_VERSION="0.6.0"
+TRENTO_VERSION="0.7.1"
 
 usage() {
     cat <<-EOF


### PR DESCRIPTION
As above, we forgot to bump Trento's version when we released the scripts :-)