### PR TITLE
Pin container versions helm chart

### DIFF
--- a/hack/helm/trento-dev/Chart.lock
+++ b/hack/helm/trento-dev/Chart.lock
@@ -3,4 +3,8 @@ dependencies:
   repository: file://../../../packaging/helm/trento-server
   version: 0.3.2
 digest: sha256:0e45ffa919eacedd4264d3d2aef2f3974ad3d019c386ce802f869fd4681d4aba
+<<<<<<< HEAD
 generated: "2022-01-17T16:56:58.179958604+01:00"
+=======
+generated: "2022-01-13T13:59:50.542272826+01:00"
+>>>>>>> 33fb92d8 (Override image tag and pullPolicy in the trento-dev helm chart)

--- a/hack/helm/trento-dev/Chart.lock
+++ b/hack/helm/trento-dev/Chart.lock
@@ -1,10 +1,6 @@
 dependencies:
 - name: trento-server
   repository: file://../../../packaging/helm/trento-server
-  version: 0.3.2
-digest: sha256:0e45ffa919eacedd4264d3d2aef2f3974ad3d019c386ce802f869fd4681d4aba
-<<<<<<< HEAD
-generated: "2022-01-17T16:56:58.179958604+01:00"
-=======
-generated: "2022-01-13T13:59:50.542272826+01:00"
->>>>>>> 33fb92d8 (Override image tag and pullPolicy in the trento-dev helm chart)
+  version: 0.3.3
+digest: sha256:91993d7c27b2431b7977d17dd2252a063b340745d9e7d581fd3940c113fa50e0
+generated: "2022-01-20T16:32:44.285647265+01:00"

--- a/hack/helm/trento-dev/values.yaml
+++ b/hack/helm/trento-dev/values.yaml
@@ -5,3 +5,11 @@ trento-server:
     initdbScripts:
       init.sql: |
         CREATE DATABASE trento_test;
+  trento-web:
+    image:
+      tag: rolling
+      pullPolicy: Always
+  trento-runner:
+    image:
+      tag: rolling
+      pullPolicy: Always

--- a/install-server.sh
+++ b/install-server.sh
@@ -223,6 +223,12 @@ install_trento_server_chart() {
             --set-file trento-web.mTLS.ca="${CA}"
         )
     fi
+    if [[ "$ROLLING" == "true" ]]; then
+        args+=(
+            --set trento-web.image.pullPolicy=Always
+            --set trento-runner.image.pullPolicy=Always
+        )
+    fi
     helm upgrade --install trento-server . "${args[@]}"
 
     popd >/dev/null

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,12 +1,12 @@
-#!BuildTag: trento/trento-server:0.3.2
-#!BuildTag: trento/trento-server:0.3.2-build%RELEASE%
+#!BuildTag: trento/trento-server:0.3.3
+#!BuildTag: trento/trento-server:0.3.3-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.3.2
+version: 0.3.3
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.3.4

--- a/packaging/helm/trento-server/charts/trento-runner/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/trento-project/trento-runner
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   tag: "0.7.1"
 
 imagePullSecrets: []

--- a/packaging/helm/trento-server/charts/trento-runner/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/values.yaml
@@ -13,7 +13,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/trento-project/trento-runner
   pullPolicy: Always
-  tag: "rolling"
+  tag: "0.7.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/packaging/helm/trento-server/charts/trento-web/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -16,7 +16,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/trento-project/trento-web
   pullPolicy: Always
-  tag: "rolling"
+  tag: "0.7.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/trento-project/trento-web
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   tag: "0.7.1"
 
 imagePullSecrets: []


### PR DESCRIPTION
Due to the helm chart being distributed as an artifact to the end-user, we need to pin the version of the container image to the current release version to have a deterministic installation.