### PR TITLE
Bump ansible-lint to 5.3.2

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,5 @@
 ansible==4.6.0
 ansible-core==2.11.5
-ansible-lint==5.1.3
+ansible-lint==5.3.2
 PyYAML
 requests==2.26.0


### PR DESCRIPTION
Right now we are suffering https://github.com/ansible-community/ansible-lint/issues/1795 in our pipelines. Bumping ansible-lint to the latest release should solve that.