### PR TITLE
Fix error in prune checks chart declaration

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,12 +1,12 @@
-#!BuildTag: trento/trento-server:0.2.8
-#!BuildTag: trento/trento-server:0.2.8-build%RELEASE%
+#!BuildTag: trento/trento-server:0.2.9
+#!BuildTag: trento/trento-server:0.2.9-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.2.8
+version: 0.2.9
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-web/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3

--- a/packaging/helm/trento-server/charts/trento-web/templates/prune_checks_cronjob.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/prune_checks_cronjob.yaml
@@ -18,7 +18,7 @@ spec:
             - web
             - prune-checks
             - --olther-than
-            - 30
+            - "30"
             - --db-host
             - {{ .Release.Name }}-postgresql
           restartPolicy: OnFailure


### PR DESCRIPTION
I made a mistake in https://github.com/trento-project/trento/pull/661

```
Error: UPGRADE FAILED: failed to create resource: CronJob in version "v1" cannot be handled as a CronJob: v1.CronJob.Spec: v1.CronJobSpec.JobTemplate: v1.JobTemplateSpec.Spec: v1.JobSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Args: []string: ReadString: expects " or n, but found 3, error found in #10 byte of ...|er-than",30,"--db-ho|..., bigger context ...|":[{"args":["web","prune-checks","--olther-than",30,"--db-host","trento-server-postgresql"],"image":|...
```

This change fixes it