### PR TITLE
Replace premium check position to description column

### DIFF
--- a/web/checks_catalog_test.go
+++ b/web/checks_catalog_test.go
@@ -84,7 +84,7 @@ func TestChecksCatalogHandler(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile("<td.*?>ABCDEF</td>"), responseBody)
 	assert.Regexp(t, regexp.MustCompile("<div class=check-description>.*description 1.*</div>"), responseBody)
 	assert.Regexp(t, regexp.MustCompile("<div class=\"check-remediation collapse\" id=collapse-ABCDEF.*?>.*remediation 1.*<pre>implementation 1</pre>"), responseBody)
-	assert.Regexp(t, regexp.MustCompile("<tr class=check-row id=123456><td.*?>123456 <span class=\"badge badge-trento-premium\">Premium</span></td>"), responseBody)
+	assert.Regexp(t, regexp.MustCompile("<div class=check-description>.*<p>description 2 <span class=\"badge badge-trento-premium\">Premium</span></p>.*</div>"), responseBody)
 	assert.Equal(t, 2, strings.Count(responseBody, "<div class=check-group"))
 	assert.Equal(t, 3, strings.Count(responseBody, "<tr class=check-row"))
 

--- a/web/frontend/stylesheets/stylesheets.scss
+++ b/web/frontend/stylesheets/stylesheets.scss
@@ -214,6 +214,7 @@ td i.critical {
 .badge-trento-premium {
   color: #fff;
   background-color: $eos-bc-green-500;
+  display: inline;
 }
 
 .align-right {

--- a/web/templates/checks_catalog.html.tmpl
+++ b/web/templates/checks_catalog.html.tmpl
@@ -27,9 +27,11 @@
                     <tbody>
                     {{- range .Checks }}
                         <tr class="check-row" id="{{ .ID }}">
-                            <td class="align-top">{{ .ID }} {{ if .Premium }}<span class="badge badge-trento-premium">Premium</span>{{ end }}</td>
+                            <td class="align-top">{{ .ID }}</td>
                             <td class="align-top">
-                                <div class="check-description">{{ markdown (.Description) }}</div>
+                                {{ $premiumBadge := "" }}
+                                {{- if .Premium }}{{ $premiumBadge = " <span class=\"badge badge-trento-premium\">Premium</span>" }}{{- end }}
+                                <div class="check-description">{{ markdown (print .Description $premiumBadge) }}</div>
                                 <div class="check-remediation collapse" id="collapse-{{ .ID }}">
                                     {{ markdown (.Remediation) }}
                                     <h2>Implementation</h2>


### PR DESCRIPTION
Fix for: https://github.com/trento-project/trento/issues/655

In order to show the premium badge properly, this PR moves the badge to the description column:

![image](https://user-images.githubusercontent.com/36370954/149513846-a60fda20-3240-4c8f-af46-5e3e21627667.png)
