### PR TITLE
Dump scenario from a running k3s installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,33 +21,34 @@ of existing clusters, rather than deploying new one.
 - [Features](#features)
 - [Introduction](#introduction)
 - [Installation](#installation)
-  * [Requirements](#requirements)
-  * [Quick-Start installation](#quick-start-installation)
-    + [Trento Server installation](#trento-server-installation)
-    + [Trento Agent installation](#trento-agent-installation)
+  - [Requirements](#requirements)
+  - [Quick-Start installation](#quick-start-installation)
+    - [Trento Server installation](#trento-server-installation)
+    - [Trento Agent installation](#trento-agent-installation)
       - [Starting Trento Agent service](#starting-trento-agent-service)
-  * [Manual installation](#manual-installation)
-    + [Pre-built binaries](#pre-built-binaries)
-    + [Compile from source](#compile-from-source)
-  * [Docker images](#docker-images)
-  * [RPM Packages](#rpm-packages)
-  * [Helm chart](#helm-chart)
-    + [Install K3S](#install-k3s)
-    + [Install Helm and chart dependencies](#install-helm-and-chart-dependencies)
-    + [Install the Trento Server Helm chart](#install-the-trento-server-helm-chart)
-    + [Other Helm chart usage examples:](#other-helm-chart-usage-examples-)
-  * [Manually running Trento](#manually-running-trento)
-    + [Trento Agents](#trento-agents)
-    + [Trento Runner](#trento-runner)
+  - [Manual installation](#manual-installation)
+    - [Pre-built binaries](#pre-built-binaries)
+    - [Compile from source](#compile-from-source)
+  - [Docker images](#docker-images)
+  - [RPM Packages](#rpm-packages)
+  - [Helm chart](#helm-chart)
+    - [Install K3S](#install-k3s)
+    - [Install Helm and chart dependencies](#install-helm-and-chart-dependencies)
+    - [Install the Trento Server Helm chart](#install-the-trento-server-helm-chart)
+    - [Other Helm chart usage examples:](#other-helm-chart-usage-examples-)
+  - [Manually running Trento](#manually-running-trento)
+    - [Trento Agents](#trento-agents)
+    - [Trento Runner](#trento-runner)
       - [Starting the Trento Runner](#starting-the-trento-runner)
-    + [Trento Web UI](#trento-web-ui)
+    - [Trento Web UI](#trento-web-ui)
 - [Configuration](#configuration)
 - [Development](#development)
-  * [Helm development chart](#helm-development-chart)
-  * [Build system](#build-system)
-  * [Development dependencies](#development-dependencies)
-  * [Docker](#docker)
-  * [SAPControl web service](#sapcontrol-web-service)
+  - [Helm development chart](#helm-development-chart)
+  - [Build system](#build-system)
+  - [Development dependencies](#development-dependencies)
+  - [Docker](#docker)
+  - [Dump a scenario from a running cluster](#dump-a-scenario-from-a-running-cluster)
+  - [SAPControl web service](#sapcontrol-web-service)
 - [Support](#support)
 - [Contributing](#contributing)
 - [License](#license)
@@ -308,16 +309,18 @@ To start the trento agent:
 
 Trento Agents publish discovery data to a Collector on Trento Server.
 
-The communication can be made secure by enabling `mTLS`  with `--enable-mtls`
+The communication can be made secure by enabling `mTLS` with `--enable-mtls`
 
 See [this tutorial](https://www.digitalocean.com/community/tutorials/openssl-essentials-working-with-ssl-certificates-private-keys-and-csrs) for extra information about SSL Certificates.
 
 #### Server
+
 ```
 $> ./trento web serve [...] --enable-mtls --cert /path/to/certs/server-cert.pem --key /path/to/certs/server-key.pem --ca /path/to/certs/ca-cert.pem
 ```
 
 #### Agent
+
 ```
 $> ./trento agent start [...] --enable-mtls --cert /path/to/certs/client-cert.pem --key /path/to/certs/client-key.pem --ca /path/to/certs/ca-cert.pem
 ```
@@ -352,7 +355,7 @@ Once dependencies are in place, you can start the Runner itself:
 ./trento runner start --api-host $WEB_IP --api-port $WEB_PORT -i 5
 ```
 
-> *Note:* The Trento Runner component must have SSH access to all the agents via a password-less SSH key pair.
+> _Note:_ The Trento Runner component must have SSH access to all the agents via a password-less SSH key pair.
 
 ### Trento Web UI
 
@@ -364,12 +367,12 @@ At this point, we can start the web application as follows:
 
 Please consult the `help` CLI command for more insights on the various options.
 
-
 # Configuration
 
 Trento can be run with a config file in replacement of command-line arguments.
 
 ## Locations
+
 Configuration, if not otherwise specified by the `--config=/path/to/config.yaml` option, would be searched in following locations:
 
 Note that order represents priority
@@ -382,8 +385,8 @@ Note that order represents priority
 
 `yaml` is the only supported format at the moment.
 
-
 ## Naming conventions
+
 Each component of trento supports its own configuration, so the expected config files in the chosen location must be called after the component it is supporting.
 
 So supported names are `(agent|web|runner).yaml`
@@ -445,8 +448,6 @@ Examples:
 
 `cert` -> `TRENTO_CERT=/path/to/certs/server-cert.pem ./trento web serve`
 
-
-
 # Development
 
 ## Helm development chart
@@ -469,6 +470,7 @@ Since integration tests require a running PostgreSQL instance, please make sure 
 The PostgreSQL instance will be accessible at port `localhost:5432`.
 
 If you want to skip database integration tests, you can use a dedicated environment variable as follows:
+
 ```shell
 TRENTO_DB_INTEGRATION_TESTS=false make test
 ```
@@ -515,6 +517,18 @@ docker build -t trento-web . # same as specifying --target trento-web
 > commands in the container, it makes little sense because most of its internals
 > require direct access to the host of the HA Cluster components.
 
+## Dump a scenario from a running cluster
+
+A script to dump a scenario from a running cluster is available at [./hack/dump-scenario.sh](./hack/dump_scenario_from_k8s.sh).
+
+Running this script in the k3s node where trento-server was installed will dump the current state of Trento to a local folder.
+
+Please refer to the script usage help for more details:
+
+```bash
+./hack/dump-scenario.sh --help
+```
+
 ## SAPControl web service
 
 The SAPControl web service soap client was generated by [hooklift/gowsdl](https://github.com/hooklift/gowsdl),
@@ -545,4 +559,4 @@ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
-[K3S]: https://k3s.io
+[k3s]: https://k3s.io

--- a/cmd/ctl/ctl.go
+++ b/cmd/ctl/ctl.go
@@ -2,6 +2,7 @@ package ctl
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -208,7 +209,7 @@ func dumpScenario(db *gorm.DB, exportPath string, scenarioName string) {
 			log.Fatal("Error while marshaling event: ", err)
 		}
 
-		filePath := filepath.Join(path, event.AgentID, event.DiscoveryType)
+		filePath := filepath.Join(path, fmt.Sprintf("%s_%s.json", event.AgentID, event.DiscoveryType))
 		err = ioutil.WriteFile(filePath, data, 0644)
 		if err != nil {
 			log.Fatal("Error while writing event: ", err)

--- a/cmd/ctl/ctl.go
+++ b/cmd/ctl/ctl.go
@@ -197,6 +197,8 @@ func dumpScenario(db *gorm.DB, exportPath string, scenarioName string) {
 		if err != nil {
 			log.Fatal("Error while creating directory: ", err)
 		}
+	} else {
+		log.Fatalf("Directory %s already exists.", path)
 	}
 
 	for _, event := range events {

--- a/hack/dump_scenario_from_k8s.sh
+++ b/hack/dump_scenario_from_k8s.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+readonly ARGS=("$@")
+
+usage() {
+    cat <<-EOF
+    usage: dump_scenario_from_k8s.sh options
+
+    Dump the current scenario from a running trento-server installation on the k8s cluster
+
+    OPTIONS:
+        -n, --name            The name to use for the scenario. Defaults to "current".
+        -p, --path            The path where the scenario should be saved. Defaults to the current directory.
+        -h, --help            Print this help.
+
+    Example:
+        dump_scenario_from_k8s.sh --name failover --path /tmp
+EOF
+}
+
+cmdline() {
+    local arg=
+
+    for arg; do
+        local delim=""
+        case "$arg" in
+        --name) args="${args}-n " ;;
+        --path) args="${args}-p " ;;
+        --help) args="${args}-h " ;;
+
+        # pass through anything else
+        *)
+            [[ "${arg:0:1}" == "-" ]] || delim="\""
+            args="${args}${delim}${arg}${delim} "
+            ;;
+        esac
+    done
+
+    eval set -- "$args"
+
+    while getopts "n:p:h" OPTION; do
+        case $OPTION in
+        h)
+            usage
+            exit 0
+            ;;
+        n)
+            readonly NAME=$OPTARG
+            ;;
+        p)
+            readonly EXPORT_PATH=$OPTARG
+            ;;
+        *)
+            usage
+            exit 0
+            ;;
+        esac
+    done
+
+    return 0
+}
+
+dump-scenario() {
+    local name=${NAME:-current}
+    local path="${EXPORT_PATH:-$PWD}"
+
+    if [[ -d "$path/scenarios/$name" ]]; then
+        echo "The scenario $name already exists in $path/scenarios/$name"
+        echo "Please choose a different name."
+        exit 1
+    fi
+
+    kubectl exec -ti deploy/trento-server-web -- /app/trento ctl dump-scenario --name="$name" --path /scenarios
+    kubectl exec deploy/trento-server-web -- tar cf - scenarios | tar xf - -C "$path"
+    kubectl exec deploy/trento-server-web -- rm -rf /scenarios
+}
+
+main() {
+    cmdline "${ARGS[@]}"
+    dump-scenario
+}
+
+main

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -6,7 +6,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.3.1
+version: 0.3.2
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,5 +1,5 @@
-#!BuildTag: trento/trento-server:0.2.9
-#!BuildTag: trento/trento-server:0.2.9-build%RELEASE%
+#!BuildTag: trento/trento-server:0.3.2
+#!BuildTag: trento/trento-server:0.3.2-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.

--- a/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3

--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -30,17 +30,18 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          env:
+            - name: TRENTO_LOG_LEVEL
+              value: "{{ .Values.global.logLevel }}"
+            - name: TRENTO_API_HOST
+              value: "{{ .Release.Name }}-{{ .Values.dependencies.trentoWeb.name }}"
+            - name: TRENTO_API_PORT
+              value: "{{ .Values.dependencies.trentoWeb.port }}"
+            - name: TRENTO_INTERVAL
+              value: 
           args:
             - runner
             - start
-            - --log-level
-            - {{ .Values.global.logLevel }}
-            - --api-host
-            - {{ .Release.Name }}-{{ .Values.dependencies.trentoWeb.name }}
-            - --api-port
-            - "{{ .Values.dependencies.trentoWeb.port }}"
-            - -i
-            - "{{ .Values.checkIntervalMins }}"
           # tty is required to allow a correct ansible execution
           tty: true
           securityContext:

--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             - name: TRENTO_API_PORT
               value: "{{ .Values.dependencies.trentoWeb.port }}"
             - name: TRENTO_INTERVAL
-              value: 
+              value: "{{ .Values.checkIntervalMins }}"
           args:
             - runner
             - start

--- a/packaging/helm/trento-server/charts/trento-web/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -30,28 +30,30 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          env:
+            - name: TRENTO_LOG_LEVEL
+              value: "{{ .Values.global.logLevel }}"
+            - name: TRENTO_DB_HOST
+              value: "{{ .Release.Name }}-{{ .Values.dependencies.postgresql.name }}"
+            - name: TRENTO_DB_PORT
+              value: "{{ .Values.dependencies.postgresql.port }}"
+            - name: TRENTO_PORT
+              value: "{{ .Values.webService.port }}"
+            - name: TRENTO_COLLECTOR_PORT
+              value: "{{ .Values.collectorService.port }}"
+            {{ if .Values.mTLS.enabled }}
+            - name: TRENTO_ENABLE_MTLS
+              value: true
+            - name: TRENTO_CERT
+              value: /certs/cert.pem
+            - name: TRENTO_KEY
+              value: /certs/cert.pem
+            - name: TRENTO_CA
+              value: /certs/ca.pem
+            {{ end }}
           args:
             - web
             - serve
-            - --log-level
-            - {{ .Values.global.logLevel }}
-            - --db-host
-            - {{ .Release.Name }}-{{ .Values.dependencies.postgresql.name }}
-            - --db-port
-            - "{{ .Values.dependencies.postgresql.port }}"
-            - --port
-            - "{{ .Values.webService.port }}"
-            - --collector-port
-            - "{{ .Values.collectorService.port }}"
-            {{ if .Values.mTLS.enabled }}
-            - --enable-mtls
-            - --cert
-            - /certs/cert.pem
-            - --key
-            - /certs/key.pem
-            - --ca
-            - /certs/ca.pem
-            {{ end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
This PR adds a script to dump the current scenario from a running trento-server installation in k3s/k8s, so that we can use it with `photofinish` in our CI and locally for debugging purposes.

It also moves the trento web/runner command flags to env in the deployment definition, so that `kubectl exec` can launch commands using env based configuration.

