### PR TITLE
Set table filters properly when the page is reloaded in a new tab

### DIFF
--- a/web/clusters.go
+++ b/web/clusters.go
@@ -57,6 +57,12 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 			return
 		}
 
+		filterClusterNames, err := clustersService.GetAllClusterNames()
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
 		filterClusterTypes, err := clustersService.GetAllClusterTypes()
 		if err != nil {
 			_ = c.Error(err)
@@ -88,6 +94,7 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 		c.HTML(http.StatusOK, "clusters.html.tmpl", gin.H{
 			"ClustersTable":      clusterList,
 			"AppliedFilters":     query,
+			"filterClusterNames": filterClusterNames,
 			"FilterClusterTypes": filterClusterTypes,
 			"FilterSIDs":         filterSIDs,
 			"FilterTags":         filterTags,

--- a/web/clusters_test.go
+++ b/web/clusters_test.go
@@ -322,6 +322,10 @@ func TestClustersListHandler(t *testing.T) {
 	mockClusterService := new(services.MockClustersService)
 	mockClusterService.On("GetAll", mock.Anything, mock.Anything).Return(clustersList, nil)
 	mockClusterService.On("GetCount").Return(4, nil)
+	mockClusterService.On("GetAllClusterNames", mock.Anything).Return(
+		[]string{"hana_cluster", "other_cluster", "netweaver_cluster"},
+		nil,
+	)
 	mockClusterService.On("GetAllClusterTypes", mock.Anything).Return(
 		[]string{models.ClusterTypeHANAScaleUp, models.ClusterTypeUnknown},
 		nil,

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -19,6 +19,7 @@ type ClustersService interface {
 	GetAll(*ClustersFilter, *Page) (models.ClusterList, error)
 	GetByID(string) (*models.Cluster, error)
 	GetCount() (int, error)
+	GetAllClusterNames() ([]string, error)
 	GetAllClusterTypes() ([]string, error)
 	GetAllSIDs() ([]string, error)
 	GetAllTags() ([]string, error)
@@ -132,6 +133,21 @@ func (s *clustersService) GetCount() (int, error) {
 	err := s.db.Model(&entities.Cluster{}).Count(&count).Error
 
 	return int(count), err
+}
+
+func (s *clustersService) GetAllClusterNames() ([]string, error) {
+	var clusterNames []string
+
+	err := s.db.Model(&entities.Cluster{}).
+		Distinct().
+		Pluck("name", &clusterNames).
+		Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return clusterNames, nil
 }
 
 func (s *clustersService) GetAllClusterTypes() ([]string, error) {

--- a/web/services/clusters_mock.go
+++ b/web/services/clusters_mock.go
@@ -35,6 +35,29 @@ func (_m *MockClustersService) GetAll(_a0 *ClustersFilter, _a1 *Page) (models.Cl
 	return r0, r1
 }
 
+// GetAllClusterNames provides a mock function with given fields:
+func (_m *MockClustersService) GetAllClusterNames() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAllClusterTypes provides a mock function with given fields:
 func (_m *MockClustersService) GetAllClusterTypes() ([]string, error) {
 	ret := _m.Called()

--- a/web/services/clusters_test.go
+++ b/web/services/clusters_test.go
@@ -238,6 +238,11 @@ func (suite *ClustersServiceTestSuite) TestClustersService_GetClustersCount() {
 	suite.Equal(3, count)
 }
 
+func (suite *ClustersServiceTestSuite) TestClustersService_GetAllClusterNames() {
+	clusterNames, _ := suite.clustersService.GetAllClusterNames()
+	suite.ElementsMatch([]string{"cluster1", "cluster2", "cluster3"}, clusterNames)
+}
+
 func (suite *ClustersServiceTestSuite) TestClustersService_GetAllClusterTypes() {
 	clusterTypes, _ := suite.clustersService.GetAllClusterTypes()
 	suite.ElementsMatch(

--- a/web/templates/blocks/health_filter.html.tmpl
+++ b/web/templates/blocks/health_filter.html.tmpl
@@ -1,5 +1,5 @@
 {{ define "health_filter" }}
-    <select name="health" id="health" class="selectpicker" multiple data-selected-text-format="count > 3"
+    <select name="health" class="selectpicker" multiple data-selected-text-format="count > 3"
             data-act/healions-box="true" title="Health status...">
     <option data-content="<span class='badge badge-success'>Passing</span>" value="passing">Passing</option>
     <option data-content="<span class='badge badge-warning'>Warning</span>" value="warning">Warning</option>

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -20,16 +20,13 @@
     <div class="horizontal-container">
         <script>
           $(document).ready(function () {
-              {{- range $Key, $Value := .AppliedFilters }}
-            $("#{{ $Key }}").selectpicker("val", {{ $Value }});
-              {{- end }}
-            $('#clean').click(function () {
-              $('.selectpicker').selectpicker("deselectAll")
-            });
+            {{- range $Key, $Value := .AppliedFilters }}
+            $("[name='{{ $Key }}']").selectpicker("val", {{ $Value }});
+            {{- end }}
           });
         </script>
         {{ template "health_filter" }}
-        <select name="name" id="name_filter" class="selectpicker" multiple
+        <select name="name" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                 title="Cluster name">
             {{- range .ClustersTable }}
@@ -38,13 +35,13 @@
                 {{- end }}
             {{- end}}
         </select>
-        <select name="sids" id="sid_filter" class="selectpicker" multiple
+        <select name="sids" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true" title="SID">
             {{- range .FilterSIDs }}
                 <option value="{{ . }}">{{ . }}</option>
             {{- end }}
         </select>
-        <select name="cluster_type" id="cluster_type_filter" class="selectpicker" multiple
+        <select name="cluster_type" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                 title="Cluster type">
             {{- range .FilterClusterTypes }}

--- a/web/templates/clusters.html.tmpl
+++ b/web/templates/clusters.html.tmpl
@@ -29,10 +29,8 @@
         <select name="name" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                 title="Cluster name">
-            {{- range .ClustersTable }}
-                {{- if .Name }}
-                    <option value="{{ .Name }}">{{ .Name }}</option>
-                {{- end }}
+            {{- range .filterClusterNames }}
+                <option value="{{ . }}">{{ . }}</option>
             {{- end}}
         </select>
         <select name="sids" class="selectpicker" multiple

--- a/web/templates/hosts.html.tmpl
+++ b/web/templates/hosts.html.tmpl
@@ -22,17 +22,14 @@
         <div class="horizontal-container">
             <script>
               $(document).ready(function () {
-                  {{- range $Key, $Value := .AppliedFilters }}
-                $("#{{ $Key }}").selectpicker("val", {{ $Value }});
-                  {{- end }}
-                $('#clean').click(function () {
-                  $('.selectpicker').selectpicker("deselectAll")
-                });
+                {{- range $Key, $Value := .AppliedFilters }}
+                $("[name='{{ $Key }}']").selectpicker("val", {{ $Value }});
+                {{- end }}
               });
             </script>
             {{ template "health_filter" }}
-            <select name="sids" id="trento-sap-systems" class="selectpicker" multiple
-                    data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true" 
+            <select name="sids" class="selectpicker" multiple
+                    data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true"
                     title="SAP system...">
                 {{- range .FilterSIDs }}
                     <option value="{{ . }}">{{ . }}</option>

--- a/web/templates/sap_systems.html.tmpl
+++ b/web/templates/sap_systems.html.tmpl
@@ -19,16 +19,13 @@
     <div class="horizontal-container">
         <script>
           $(document).ready(function () {
-              {{- range $Key, $Value := .AppliedFilters }}
-            $("#{{ $Key }}").selectpicker("val", {{ $Value }});
-              {{- end }}
-            $('#clean').click(function () {
-              $('.selectpicker').selectpicker("deselectAll")
-            });
+            {{- range $Key, $Value := .AppliedFilters }}
+            $("[name='{{ $Key }}']").selectpicker("val", {{ $Value }});
+            {{- end }}
           });
         </script>
         {{/* {{ template "health_filter" }} */}}
-        <select name="sids" id="sids" class="selectpicker" multiple
+        <select name="sids" class="selectpicker" multiple
                 data-selected-text-format="count > 3" data-actions-box="true" data-live-search="true" title="SID">
             {{- range .FilterSIDs }}
                 <option value="{{ . }}">{{ . }}</option>


### PR DESCRIPTION
Until now, when any of our views that has a table (host list, cluster list, sap system list, etc) was loaded with the filter queries in the url, the filters were not properly selected.

Now, the data is properly added to the filters:
![Peek 2022-01-18 15-17](https://user-images.githubusercontent.com/36370954/149954415-01105172-364e-4796-8070-586112fde3b6.gif)

