### PR TITLE
Fix health container numbers and pagination numbers

### DIFF
--- a/web/clusters.go
+++ b/web/clusters.go
@@ -51,7 +51,13 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 			Size:   pageSize,
 		}
 
-		clusterList, err := clustersService.GetAll(clustersFilter, page)
+		clusterListPaginated, err := clustersService.GetAll(clustersFilter, page)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		clusterListAll, err := clustersService.GetAll(clustersFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -81,18 +87,13 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 			return
 		}
 
-		healthContainer := NewClustersHealthContainer(clusterList)
+		healthContainer := NewClustersHealthContainer(clusterListAll)
 		healthContainer.Layout = "horizontal"
 
-		count, err := clustersService.GetCount()
-		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		pagination := NewPagination(count, pageNumber, pageSize)
+		pagination := NewPagination(len(clusterListAll), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "clusters.html.tmpl", gin.H{
-			"ClustersTable":      clusterList,
+			"ClustersTable":      clusterListPaginated,
 			"AppliedFilters":     query,
 			"filterClusterNames": filterClusterNames,
 			"FilterClusterTypes": filterClusterTypes,

--- a/web/clusters.go
+++ b/web/clusters.go
@@ -51,13 +51,13 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 			Size:   pageSize,
 		}
 
-		clusterListPaginated, err := clustersService.GetAll(clustersFilter, page)
+		paginatedClusterList, err := clustersService.GetAll(clustersFilter, page)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
 
-		clusterListAll, err := clustersService.GetAll(clustersFilter, nil)
+		clusterList, err := clustersService.GetAll(clustersFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -87,13 +87,13 @@ func NewClusterListHandler(clustersService services.ClustersService) gin.Handler
 			return
 		}
 
-		healthContainer := NewClustersHealthContainer(clusterListAll)
+		healthContainer := NewClustersHealthContainer(clusterList)
 		healthContainer.Layout = "horizontal"
 
-		pagination := NewPagination(len(clusterListAll), pageNumber, pageSize)
+		pagination := NewPagination(len(clusterList), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "clusters.html.tmpl", gin.H{
-			"ClustersTable":      clusterListPaginated,
+			"ClustersTable":      paginatedClusterList,
 			"AppliedFilters":     query,
 			"filterClusterNames": filterClusterNames,
 			"FilterClusterTypes": filterClusterTypes,

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -49,13 +49,13 @@ func NewHostListHandler(hostsService services.HostsService) gin.HandlerFunc {
 			Size:   pageSize,
 		}
 
-		hostListPaginated, err := hostsService.GetAll(hostsFilter, page)
+		paginatedHostList, err := hostsService.GetAll(hostsFilter, page)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
 
-		hostListAll, err := hostsService.GetAll(hostsFilter, nil)
+		hostList, err := hostsService.GetAll(hostsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -73,13 +73,13 @@ func NewHostListHandler(hostsService services.HostsService) gin.HandlerFunc {
 			return
 		}
 
-		pagination := NewPagination(len(hostListAll), pageNumber, pageSize)
+		pagination := NewPagination(len(hostList), pageNumber, pageSize)
 
-		hContainer := NewHostsHealthContainer(hostListAll)
+		hContainer := NewHostsHealthContainer(hostList)
 		hContainer.Layout = "horizontal"
 
 		c.HTML(http.StatusOK, "hosts.html.tmpl", gin.H{
-			"Hosts":           hostListPaginated,
+			"Hosts":           paginatedHostList,
 			"AppliedFilters":  query,
 			"FilterSIDs":      filterSIDs,
 			"FilterTags":      filterTags,

--- a/web/hosts.go
+++ b/web/hosts.go
@@ -49,7 +49,13 @@ func NewHostListHandler(hostsService services.HostsService) gin.HandlerFunc {
 			Size:   pageSize,
 		}
 
-		hostList, err := hostsService.GetAll(hostsFilter, page)
+		hostListPaginated, err := hostsService.GetAll(hostsFilter, page)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		hostListAll, err := hostsService.GetAll(hostsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -67,18 +73,13 @@ func NewHostListHandler(hostsService services.HostsService) gin.HandlerFunc {
 			return
 		}
 
-		count, err := hostsService.GetCount()
-		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		pagination := NewPagination(count, pageNumber, pageSize)
+		pagination := NewPagination(len(hostListAll), pageNumber, pageSize)
 
-		hContainer := NewHostsHealthContainer(hostList)
+		hContainer := NewHostsHealthContainer(hostListAll)
 		hContainer.Layout = "horizontal"
 
 		c.HTML(http.StatusOK, "hosts.html.tmpl", gin.H{
-			"Hosts":           hostList,
+			"Hosts":           hostListPaginated,
 			"AppliedFilters":  query,
 			"FilterSIDs":      filterSIDs,
 			"FilterTags":      filterTags,

--- a/web/pagination.go
+++ b/web/pagination.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"math"
-	"strconv"
 )
 
 const (
@@ -24,20 +23,6 @@ type Page struct {
 
 func getPageCount(items, perPage int) int {
 	return int((float64(items) + float64(perPage) - 1) / float64(perPage))
-}
-
-func NewPaginationWithStrings(items int, page, perPage string) *Pagination {
-	pageInt, err := strconv.Atoi(page)
-	if err != nil {
-		pageInt = defaultPageIndex
-	}
-
-	perPageInt, err := strconv.Atoi(perPage)
-	if err != nil {
-		perPageInt = defaultPerPage
-	}
-
-	return NewPagination(items, pageInt, perPageInt)
 }
 
 func NewPagination(items, page, perPage int) *Pagination {

--- a/web/pagination_test.go
+++ b/web/pagination_test.go
@@ -35,20 +35,6 @@ func TestNewPagination(t *testing.T) {
 	assert.Equal(t, p.PageIndex, 5)
 }
 
-func TestNewPaginationWithStrings(t *testing.T) {
-	p := NewPaginationWithStrings(10, "1", "10")
-	assert.Equal(t, p.ItemCount, 10)
-	assert.Equal(t, p.PageIndex, 1)
-	assert.Equal(t, p.PerPage, 10)
-	assert.Equal(t, p.PageCount, 1)
-
-	p = NewPaginationWithStrings(10, "a", "b")
-	assert.Equal(t, p.ItemCount, 10)
-	assert.Equal(t, p.PageIndex, 1)
-	assert.Equal(t, p.PerPage, 10)
-	assert.Equal(t, p.PageCount, 1)
-}
-
 func TestGetCurrentPages(t *testing.T) {
 	p := NewPagination(111, 1, 10)
 	pages := p.GetCurrentPages()

--- a/web/sap_systems.go
+++ b/web/sap_systems.go
@@ -32,13 +32,13 @@ func NewSAPSystemListHandler(sapSystemsService services.SAPSystemsService) gin.H
 			Size:   pageSize,
 		}
 
-		sapSystemsPaginated, err := sapSystemsService.GetAllApplications(tagsFilter, page)
+		paginatedSapSystems, err := sapSystemsService.GetAllApplications(tagsFilter, page)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
 
-		sapSystemsAll, err := sapSystemsService.GetAllApplications(tagsFilter, nil)
+		sapSystems, err := sapSystemsService.GetAllApplications(tagsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -56,11 +56,11 @@ func NewSAPSystemListHandler(sapSystemsService services.SAPSystemsService) gin.H
 			return
 		}
 
-		pagination := NewPagination(len(sapSystemsAll), pageNumber, pageSize)
+		pagination := NewPagination(len(sapSystems), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "sap_systems.html.tmpl", gin.H{
 			"Type":           models.SAPSystemTypeApplication,
-			"SAPSystems":     sapSystemsPaginated,
+			"SAPSystems":     paginatedSapSystems,
 			"AppliedFilters": query,
 			"FilterSIDs":     filterSIDs,
 			"FilterTags":     filterTags,
@@ -92,13 +92,13 @@ func NewHANADatabaseListHandler(sapSystemsService services.SAPSystemsService) gi
 			Size:   pageSize,
 		}
 
-		databasesPaginated, err := sapSystemsService.GetAllDatabases(tagsFilter, page)
+		paginatedDatabases, err := sapSystemsService.GetAllDatabases(tagsFilter, page)
 		if err != nil {
 			_ = c.Error(err)
 			return
 		}
 
-		databasesAll, err := sapSystemsService.GetAllDatabases(tagsFilter, nil)
+		databases, err := sapSystemsService.GetAllDatabases(tagsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -116,11 +116,11 @@ func NewHANADatabaseListHandler(sapSystemsService services.SAPSystemsService) gi
 			return
 		}
 
-		pagination := NewPagination(len(databasesAll), pageNumber, pageSize)
+		pagination := NewPagination(len(databases), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "sap_systems.html.tmpl", gin.H{
 			"Type":           models.SAPSystemTypeDatabase,
-			"SAPSystems":     databasesPaginated,
+			"SAPSystems":     paginatedDatabases,
 			"AppliedFilters": query,
 			"FilterSIDs":     filterSIDs,
 			"FilterTags":     filterTags,

--- a/web/sap_systems.go
+++ b/web/sap_systems.go
@@ -32,7 +32,13 @@ func NewSAPSystemListHandler(sapSystemsService services.SAPSystemsService) gin.H
 			Size:   pageSize,
 		}
 
-		sapSystems, err := sapSystemsService.GetAllApplications(tagsFilter, page)
+		sapSystemsPaginated, err := sapSystemsService.GetAllApplications(tagsFilter, page)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		sapSystemsAll, err := sapSystemsService.GetAllApplications(tagsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -50,16 +56,11 @@ func NewSAPSystemListHandler(sapSystemsService services.SAPSystemsService) gin.H
 			return
 		}
 
-		count, err := sapSystemsService.GetApplicationsCount()
-		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		pagination := NewPagination(count, pageNumber, pageSize)
+		pagination := NewPagination(len(sapSystemsAll), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "sap_systems.html.tmpl", gin.H{
 			"Type":           models.SAPSystemTypeApplication,
-			"SAPSystems":     sapSystems,
+			"SAPSystems":     sapSystemsPaginated,
 			"AppliedFilters": query,
 			"FilterSIDs":     filterSIDs,
 			"FilterTags":     filterTags,
@@ -91,7 +92,13 @@ func NewHANADatabaseListHandler(sapSystemsService services.SAPSystemsService) gi
 			Size:   pageSize,
 		}
 
-		databases, err := sapSystemsService.GetAllDatabases(tagsFilter, page)
+		databasesPaginated, err := sapSystemsService.GetAllDatabases(tagsFilter, page)
+		if err != nil {
+			_ = c.Error(err)
+			return
+		}
+
+		databasesAll, err := sapSystemsService.GetAllDatabases(tagsFilter, nil)
 		if err != nil {
 			_ = c.Error(err)
 			return
@@ -109,16 +116,11 @@ func NewHANADatabaseListHandler(sapSystemsService services.SAPSystemsService) gi
 			return
 		}
 
-		count, err := sapSystemsService.GetDatabasesCount()
-		if err != nil {
-			_ = c.Error(err)
-			return
-		}
-		pagination := NewPagination(count, pageNumber, pageSize)
+		pagination := NewPagination(len(databasesAll), pageNumber, pageSize)
 
 		c.HTML(http.StatusOK, "sap_systems.html.tmpl", gin.H{
 			"Type":           models.SAPSystemTypeDatabase,
-			"SAPSystems":     databases,
+			"SAPSystems":     databasesPaginated,
 			"AppliedFilters": query,
 			"FilterSIDs":     filterSIDs,
 			"FilterTags":     filterTags,

--- a/web/sap_systems_test.go
+++ b/web/sap_systems_test.go
@@ -83,7 +83,6 @@ func TestSAPSystemsListHandler(t *testing.T) {
 			AttachedDatabase: &models.SAPSystem{},
 		},
 	}, nil)
-	sapSystemsService.On("GetApplicationsCount").Return(1, nil)
 	sapSystemsService.On("GetAllApplicationsSIDs").Return([]string{"HA1"}, nil)
 	sapSystemsService.On("GetAllApplicationsTags").Return([]string{"tag1"}, nil)
 
@@ -139,7 +138,6 @@ func TestSAPDatabaseListHandler(t *testing.T) {
 			},
 		},
 	}, nil)
-	sapSystemsService.On("GetDatabasesCount").Return(1, nil)
 	sapSystemsService.On("GetAllDatabasesSIDs").Return([]string{"PRD"}, nil)
 	sapSystemsService.On("GetAllDatabasesTags").Return([]string{"tag1"}, nil)
 

--- a/web/services/checks_mock.go
+++ b/web/services/checks_mock.go
@@ -83,15 +83,15 @@ func (_m *MockChecksService) CreateSelectedChecks(id string, selectedChecksList 
 }
 
 // GetAggregatedChecksResultByCluster provides a mock function with given fields: clusterId
-func (_m *MockChecksService) GetAggregatedChecksResultByCluster(clusterId string) (*AggregatedCheckData, error) {
+func (_m *MockChecksService) GetAggregatedChecksResultByCluster(clusterId string) (*models.AggregatedCheckData, error) {
 	ret := _m.Called(clusterId)
 
-	var r0 *AggregatedCheckData
-	if rf, ok := ret.Get(0).(func(string) *AggregatedCheckData); ok {
+	var r0 *models.AggregatedCheckData
+	if rf, ok := ret.Get(0).(func(string) *models.AggregatedCheckData); ok {
 		r0 = rf(clusterId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*AggregatedCheckData)
+			r0 = ret.Get(0).(*models.AggregatedCheckData)
 		}
 	}
 
@@ -106,15 +106,15 @@ func (_m *MockChecksService) GetAggregatedChecksResultByCluster(clusterId string
 }
 
 // GetAggregatedChecksResultByHost provides a mock function with given fields: clusterId
-func (_m *MockChecksService) GetAggregatedChecksResultByHost(clusterId string) (map[string]*AggregatedCheckData, error) {
+func (_m *MockChecksService) GetAggregatedChecksResultByHost(clusterId string) (map[string]*models.AggregatedCheckData, error) {
 	ret := _m.Called(clusterId)
 
-	var r0 map[string]*AggregatedCheckData
-	if rf, ok := ret.Get(0).(func(string) map[string]*AggregatedCheckData); ok {
+	var r0 map[string]*models.AggregatedCheckData
+	if rf, ok := ret.Get(0).(func(string) map[string]*models.AggregatedCheckData); ok {
 		r0 = rf(clusterId)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[string]*AggregatedCheckData)
+			r0 = ret.Get(0).(map[string]*models.AggregatedCheckData)
 		}
 	}
 

--- a/web/services/checks_mock.go
+++ b/web/services/checks_mock.go
@@ -264,6 +264,29 @@ func (_m *MockChecksService) GetConnectionSettingsByNode(node string) (models.Co
 	return r0, r1
 }
 
+// GetLastExecutionByGroup provides a mock function with given fields:
+func (_m *MockChecksService) GetLastExecutionByGroup() ([]*models.ChecksResult, error) {
+	ret := _m.Called()
+
+	var r0 []*models.ChecksResult
+	if rf, ok := ret.Get(0).(func() []*models.ChecksResult); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*models.ChecksResult)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetSelectedChecksById provides a mock function with given fields: id
 func (_m *MockChecksService) GetSelectedChecksById(id string) (models.SelectedChecks, error) {
 	ret := _m.Called(id)

--- a/web/services/checks_test.go
+++ b/web/services/checks_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestAggregatedCheckDataString(t *testing.T) {
-	aCritical := &AggregatedCheckData{
+	aCritical := &models.AggregatedCheckData{
 		PassingCount:  2,
 		WarningCount:  1,
 		CriticalCount: 1,
@@ -24,7 +24,7 @@ func TestAggregatedCheckDataString(t *testing.T) {
 
 	assert.Equal(t, aCritical.String(), "critical")
 
-	aWarning := &AggregatedCheckData{
+	aWarning := &models.AggregatedCheckData{
 		PassingCount:  2,
 		WarningCount:  1,
 		CriticalCount: 0,
@@ -32,7 +32,7 @@ func TestAggregatedCheckDataString(t *testing.T) {
 
 	assert.Equal(t, aWarning.String(), "warning")
 
-	aPassing := &AggregatedCheckData{
+	aPassing := &models.AggregatedCheckData{
 		PassingCount:  2,
 		WarningCount:  0,
 		CriticalCount: 0,
@@ -40,7 +40,7 @@ func TestAggregatedCheckDataString(t *testing.T) {
 
 	assert.Equal(t, aPassing.String(), "passing")
 
-	aUndefined := &AggregatedCheckData{
+	aUndefined := &models.AggregatedCheckData{
 		PassingCount:  0,
 		WarningCount:  0,
 		CriticalCount: 0,
@@ -392,13 +392,13 @@ func (suite *ChecksServiceTestSuite) TestChecksService_CreateChecksResult() {
 func (suite *ChecksServiceTestSuite) TestChecksService_GetAggregatedChecksResultByHost() {
 	results, err := suite.checksService.GetAggregatedChecksResultByHost("group1")
 
-	expectedResults := map[string]*AggregatedCheckData{
-		"host1": &AggregatedCheckData{
+	expectedResults := map[string]*models.AggregatedCheckData{
+		"host1": &models.AggregatedCheckData{
 			PassingCount:  1,
 			WarningCount:  1,
 			CriticalCount: 0,
 		},
-		"host2": &AggregatedCheckData{
+		"host2": &models.AggregatedCheckData{
 			PassingCount:  1,
 			WarningCount:  0,
 			CriticalCount: 1,
@@ -412,7 +412,7 @@ func (suite *ChecksServiceTestSuite) TestChecksService_GetAggregatedChecksResult
 func (suite *ChecksServiceTestSuite) TestChecksService_GetAggregatedChecksResultByCluster() {
 	results, err := suite.checksService.GetAggregatedChecksResultByCluster("group1")
 
-	expectedResults := &AggregatedCheckData{
+	expectedResults := &models.AggregatedCheckData{
 		PassingCount:  2,
 		WarningCount:  1,
 		CriticalCount: 1,

--- a/web/services/checks_test.go
+++ b/web/services/checks_test.go
@@ -134,7 +134,7 @@ func loadChecksResultFixtures(db *gorm.DB) {
 		GroupID: "group1",
 		Payload: datatypes.JSON([]byte(group1payloadLast)),
 	})
-	group2payload := `{"hosts":{"host3":{"reachable":true "msg":""},"host4":{"reachable":true,"msg":""}},
+	group2payload := `{"hosts":{"host3":{"reachable":true, "msg":""},"host4":{"reachable":true,"msg":""}},
 	"checks":{"check1":{"hosts":{"host3":{"result":"critical"},"host4":{"result":"critical"}}},
 	"check2":{"hosts":{"host3":{"result":"passing"},"host4":{"result":"warning"}}}}}`
 	db.Create(&entities.ChecksResult{
@@ -317,6 +317,15 @@ func (suite *ChecksServiceTestSuite) TestChecksService_CreateChecksCatalog() {
 	var count int64
 	suite.tx.Table("checks").Count(&count)
 	suite.Equal(int64(2), count)
+}
+
+func (suite *ChecksServiceTestSuite) TestChecksService_GetLastExecutionByGroup() {
+	results, err := suite.checksService.GetLastExecutionByGroup()
+
+	suite.NoError(err)
+	suite.Equal(len(results), 2)
+	suite.Equal(results[0].ID, "group1")
+	suite.Equal(results[1].ID, "group2")
 }
 
 func (suite *ChecksServiceTestSuite) TestChecksService_GetChecksResultByCluster() {

--- a/web/services/clusters.go
+++ b/web/services/clusters.go
@@ -53,20 +53,15 @@ func (s *clustersService) GetAll(filter *ClustersFilter, page *Page) (models.Clu
 
 	// Filter the clusters by Health
 	if filter != nil && len(filter.Health) > 0 {
-		var checksResults []entities.ChecksResult
-
-		err := s.db.Where("(group_id, created_at) IN (?)", s.db.Model(&entities.ChecksResult{}).
-			Select("group_id, max(created_at)").
-			Group("group_id")).Find(&checksResults).Error
+		checksResults, err := s.checksService.GetLastExecutionByGroup()
 		if err != nil {
 			return nil, err
 		}
 
 		for _, checksResult := range checksResults {
-			checksResultModel, _ := checksResult.ToModel()
-			clusterHealth := checksResultModel.GetAggregatedChecksResultByCluster().String()
+			clusterHealth := checksResult.GetAggregatedChecksResultByCluster().String()
 			if internal.Contains(filter.Health, clusterHealth) {
-				healthFilteredClusters = append(healthFilteredClusters, checksResultModel.ID)
+				healthFilteredClusters = append(healthFilteredClusters, checksResult.ID)
 			}
 		}
 	}


### PR DESCRIPTION
- Fix how the health container numbers are shown, to show all the numbers except the current page numbers.
- Filter properly the health with pagination. Now, the health filter is done together with the others using SQL, so it is included in the pagination. Before this, as the health filter was applied after the pagination, we could get the elements in pages that don't really exist (like only having 2 hosts, but being them in page 4).
- Fix the pagination total numbers and page count

In order to improve the code structure, I have moved some structs to models
![test](https://user-images.githubusercontent.com/36370954/150315922-2dca60d2-b280-4a1b-93f1-9ab3b4f7accd.gif)

