### PR TITLE
Helm: move `dependencies` variables to `global`

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,6 @@
 # https://github.com/helm/chart-testing
 chart-dirs:
+  - packaging/helm/trento-server/charts
   - packaging/helm
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,12 +1,12 @@
-#!BuildTag: trento/trento-server:0.3.3
-#!BuildTag: trento/trento-server:0.3.3-build%RELEASE%
+#!BuildTag: trento/trento-server:0.3.4
+#!BuildTag: trento/trento-server:0.3.4-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.3.3
+version: 0.3.4
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.5

--- a/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
             - name: TRENTO_LOG_LEVEL
               value: "{{ .Values.global.logLevel }}"
             - name: TRENTO_API_HOST
-              value: "{{ .Release.Name }}-{{ .Values.dependencies.trentoWeb.name }}"
+              value: "{{ .Release.Name }}-{{ .Values.global.trentoWeb.name }}"
             - name: TRENTO_API_PORT
-              value: "{{ .Values.dependencies.trentoWeb.port }}"
+              value: "{{ .Values.global.trentoWeb.servicePort }}"
             - name: TRENTO_INTERVAL
               value: "{{ .Values.checkIntervalMins }}"
           args:

--- a/packaging/helm/trento-server/charts/trento-runner/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-runner/values.yaml
@@ -4,6 +4,9 @@
 
 global:
   logLevel: info
+  trentoWeb:
+    name: web
+    servicePort: 8080
 
 privateKey: ""
 checkIntervalMins: 5
@@ -81,12 +84,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-# service dependencies to be consumed by the runner deployment
-dependencies:
-  trentoWeb:
-    name: trento-web
-    port: 8080
-  trentoCollector:
-    name: trento-web-collector
-    port: 8081

--- a/packaging/helm/trento-server/charts/trento-web/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.6
+version: 0.3.7

--- a/packaging/helm/trento-server/charts/trento-web/templates/_helpers.tpl
+++ b/packaging/helm/trento-server/charts/trento-web/templates/_helpers.tpl
@@ -60,3 +60,14 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return Trento Web service port
+*/}}
+{{- define "trentoWeb.port" -}}
+{{- if .Values.global.trentoWeb.servicePort }}
+    {{- .Values.global.trentoWeb.servicePort -}}
+{{- else -}}
+    {{- .Values.webService.port -}}
+{{- end -}}
+{{- end -}}

--- a/packaging/helm/trento-server/charts/trento-web/templates/certs.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/certs.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "trento-runner.fullname" . }}-certs
+  name: {{ include "trento-web.fullname" . }}-certs
 data:
   cert: |-
     {{ .Values.mTLS.cert | b64enc }}

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -34,9 +34,9 @@ spec:
             - name: TRENTO_LOG_LEVEL
               value: "{{ .Values.global.logLevel }}"
             - name: TRENTO_DB_HOST
-              value: "{{ .Release.Name }}-{{ .Values.dependencies.postgresql.name }}"
+              value: "{{ .Release.Name }}-{{ .Values.global.postgresql.name }}"
             - name: TRENTO_DB_PORT
-              value: "{{ .Values.dependencies.postgresql.port }}"
+              value: "{{ .Values.global.postgresql.servicePort }}"
             - name: TRENTO_PORT
               value: "{{ .Values.webService.port }}"
             - name: TRENTO_COLLECTOR_PORT

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -94,7 +94,7 @@ spec:
       volumes:
       - name: certs
         secret:
-          secretName: {{ include "trento-runner.fullname" . }}-certs
+          secretName: {{ include "trento-web.fullname" . }}-certs
           items:
           - key: cert
             path: cert.pem

--- a/packaging/helm/trento-server/charts/trento-web/templates/ingress.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "trento-web.fullname" . -}}
-{{- $svcPort := .Values.webService.port -}}
+{{- $svcPort := include "trentoWeb.port" . -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
   {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}

--- a/packaging/helm/trento-server/charts/trento-web/templates/webservice.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/webservice.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.webService.type }}
   ports:
-    - port: {{ .Values.webService.port }}
+    - port: {{ template "trentoWeb.port" . }}
       targetPort: http
       protocol: TCP
       name: http

--- a/packaging/helm/trento-server/charts/trento-web/values.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/values.yaml
@@ -4,6 +4,11 @@
 
 global:
   logLevel: info
+  trentoWeb:
+    servicePort: ""
+  postgresql:
+    name: postgresql
+    servicePort: 5432
 
 mTLS:
   enabled: false
@@ -98,9 +103,3 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-
-# service dependencies to be consumed by the web deployment
-dependencies:
-  postgresql:
-    name: postgresql
-    port: 5432

--- a/packaging/helm/trento-server/values.yaml
+++ b/packaging/helm/trento-server/values.yaml
@@ -1,6 +1,12 @@
 ### Global Values ###
 global:
   logLevel: info
+  trentoWeb:
+    name: web
+    servicePort: 8080
+  postgresql:
+    name: postgresql
+    servicePort: 5432
 
 ### Sub Charts Specific Values ###
 trento-web:
@@ -10,9 +16,6 @@ trento-web:
 trento-runner:
   nameOverride: runner
   enabled: true
-  dependencies:
-    trentoWeb:
-      name: web
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Declaring variables as global enables cross-referencing those variables
from lower level charts through the parent helm chart.

This PR also includes the following changes:
- Fix trento-web secret name
- Enable linting on subcharts

Fixes: https://github.com/trento-project/trento/issues/382