### PR TITLE
Remove skipping for an older event

### DIFF
--- a/web/datapipeline/projector.go
+++ b/web/datapipeline/projector.go
@@ -53,15 +53,6 @@ func (p *projector) Project(dataCollectedEvent *DataCollectedEvent) error {
 		var subscription Subscription
 		tx.Clauses(clause.Locking{Strength: "UPDATE"}).Where(&Subscription{ProjectorID: p.ID, AgentID: dataCollectedEvent.AgentID}).First(&subscription)
 
-		if subscription.LastProjectedEventID >= dataCollectedEvent.ID {
-			log.Warnf("Projector: %s received an old event: %s %s %d. Skipping",
-				p.ID, dataCollectedEvent.DiscoveryType,
-				dataCollectedEvent.AgentID,
-				dataCollectedEvent.ID)
-
-			return nil
-		}
-
 		tx.Clauses(clause.OnConflict{
 			UpdateAll: true,
 		}).Create(&Subscription{

--- a/web/datapipeline/projector_test.go
+++ b/web/datapipeline/projector_test.go
@@ -114,29 +114,3 @@ func (suite *ProjectorTestSuite) TestProjector_Concurrency() {
 
 	suite.Equal(int64(2), subscription.LastProjectedEventID)
 }
-
-// TestProjector_SkipPastEvent tests that a projector does not project and update the subscription
-// if the event is older than the last projected one
-func (suite *ProjectorTestSuite) TestProjector_SkipPastEvent() {
-	projector := NewProjector("dummy_projector", suite.tx)
-	projected := false
-
-	projector.AddHandler("dummy_discovery_type", func(dataCollectedEvent *DataCollectedEvent, _ *gorm.DB) error {
-		projected = true
-		return nil
-	})
-
-	suite.tx.Create(&Subscription{
-		LastProjectedEventID: 123,
-		ProjectorID:          "dummy_projector",
-		AgentID:              "345",
-	})
-
-	projector.Project(&DataCollectedEvent{ID: 120, DiscoveryType: "dummy_discovery_type", AgentID: "345"})
-
-	var subscription Subscription
-	suite.tx.First(&subscription)
-
-	suite.False(projected)
-	suite.Equal(int64(123), subscription.LastProjectedEventID)
-}


### PR DESCRIPTION
To deal with the unlikely scenario of an agent sending multiple events of the same type at the same time, a skip event condition was introduced.
This wasn't working properly since it did not consider that an agent can send different types of events almost in parallel and it was just causing side effects when loading fixtures with `photofinish`.

Closes: #742