### PR TITLE
Fix parse azure cloud data

### DIFF
--- a/web/datapipeline/hosts_projector_test.go
+++ b/web/datapipeline/hosts_projector_test.go
@@ -106,6 +106,11 @@ func (s *HostsProjectorTestSuite) Test_CloudDiscoveryHandler() {
 	}, projectedAzureCloudData)
 }
 
+func (s *HostsProjectorTestSuite) Test_parseAzureCloudData_Empty() {
+	azureCloudData := parseAzureCloudData(struct{}{})
+	s.EqualValues(entities.AzureCloudData{}, azureCloudData)
+}
+
 // Test_ClusterDiscoveryHandler tests the ClusterDiscoveryHandler function execution on a ClusterDiscovery published by an agent
 func (s *HostsProjectorTestSuite) Test_ClusterDiscoveryHandler() {
 	discoveredClusterMock := mocks.NewDiscoveredClusterMock()

--- a/web/datapipeline/hosts_projector_test.go
+++ b/web/datapipeline/hosts_projector_test.go
@@ -89,6 +89,21 @@ func (s *HostsProjectorTestSuite) Test_CloudDiscoveryHandler() {
 	s.Equal("", projectedHost.ClusterID)
 	s.Equal("", projectedHost.ClusterName)
 	s.Equal("", projectedHost.ClusterType)
+
+	var projectedAzureCloudData entities.AzureCloudData
+	err := json.Unmarshal(projectedHost.CloudData, &projectedAzureCloudData)
+
+	s.NoError(err)
+	s.EqualValues(entities.AzureCloudData{
+		VMName:          "vmhana01",
+		ResourceGroup:   "RG-HA-SAP-THERESOURCEGROUP",
+		Location:        "westeurope",
+		VMSize:          "Standard_E4s_v3",
+		DataDisksNumber: 7,
+		Offer:           "sles-sap-15-sp2-byos",
+		SKU:             "gen2",
+		AdminUsername:   "cloudadmin",
+	}, projectedAzureCloudData)
 }
 
 // Test_ClusterDiscoveryHandler tests the ClusterDiscoveryHandler function execution on a ClusterDiscovery published by an agent


### PR DESCRIPTION
This PR refactors the azure cloud data parsers function in the hosts projector to use `mapstructure` instead of manually casting the nested interface/map fields.
It also adds asserts to the host projector cloud discovery handler  test.

Related to: #755 