### PR TITLE
Recover and handle panics in projectors

### DIFF
--- a/web/datapipeline/projector.go
+++ b/web/datapipeline/projector.go
@@ -40,6 +40,12 @@ func (p *projector) AddHandler(discoveryType string, handler ProjectorHandler) {
 // By updating the subscription with the LastProjectedEventID, it leverages the PostgresSQL implicit lock
 // to enforce linearizability if a specific agent tries to use the same projector concurrently
 func (p *projector) Project(dataCollectedEvent *DataCollectedEvent) error {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Projector panicked. Recovered. ", r)
+		}
+	}()
+
 	handler, ok := p.handlers[dataCollectedEvent.DiscoveryType]
 
 	if !ok {


### PR DESCRIPTION
This PR recovers panics in projectors so we do not crash the whole application but we log the error instead (_à la_ gin gonic's recovery handler)

Related to: #755 