### PR TITLE
Add exporter deps

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -3,9 +3,9 @@ concurrency: ci-${{ github.ref }}
 on:
   push:
     tags-ignore:
-      - '*'
+      - "*"
     branches:
-      - 'main'
+      - "main"
   pull_request:
   release:
     types: [published]
@@ -134,7 +134,6 @@ jobs:
         with:
           name: e2e-videos
           path: test/e2e/cypress/videos/
-
 
   build-and-push-container-images:
     runs-on: ubuntu-20.04
@@ -296,10 +295,10 @@ jobs:
         with:
           name: trento-binaries
           path: |
-                  build/trento-amd64.tgz
-                  build/trento-arm64.tgz
-                  build/trento-ppc64le.tgz
-                  build/trento-s390x.tgz
+            build/trento-amd64.tgz
+            build/trento-arm64.tgz
+            build/trento-ppc64le.tgz
+            build/trento-s390x.tgz
 
   release-rolling:
     needs: [test-binary, test-checks, test-e2e]
@@ -337,8 +336,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   deploy-server:
-    runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ smoke-test-container-images, build-and-push-container-images, test-helm-charts, release-rolling ]
+    runs-on: [self-hosted, trento-gh-runner]
+    needs:
+      [
+        smoke-test-container-images,
+        build-and-push-container-images,
+        test-helm-charts,
+        release-rolling,
+      ]
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     environment: AZURE_DEMO
     env:
@@ -359,8 +364,8 @@ jobs:
         run: ssh "$TRENTO_USER@$TRENTO_SERVER_HOST" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-server.sh -r -p ~/.ssh/id_rsa
 
   deploy-agents:
-    runs-on: [ self-hosted, trento-gh-runner ]
-    needs: [ deploy-server ]
+    runs-on: [self-hosted, trento-gh-runner]
+    needs: [deploy-server]
     if: github.ref_name == 'main'
     environment: AZURE_DEMO
     env:
@@ -374,7 +379,7 @@ jobs:
         run: |
           set -ex
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
-          do
+          do            
             ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
@@ -386,36 +391,36 @@ jobs:
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
       env:
-        GITHUB_OAUTH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_OAUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: configure OSC
-    # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
-    # that is used to run osc commands
-      run: |
-        /scripts/init_osc_creds.sh
-        mkdir -p $HOME/.config/osc
-        cp /root/.config/osc/oscrc $HOME/.config/osc
-    - name: Prepare trento.changes file
-    # The .changes file is updated only in release creation. This current task should be improved
-    # in order to add the current rolling release notes
-      if: github.event_name == 'release'
-      run: |
-        osc checkout $OBS_PROJECT trento trento.changes
-        mv trento.changes $FOLDER
-        VERSION=$(./hack/get_version_from_git.sh)
-        TAG=$(echo $VERSION | cut -f1 -d+)
-        hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento.changes
-    - name: prepare _service file
-      run: |
-        VERSION=$(./hack/get_version_from_git.sh)
-        sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
-        sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
-        sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
-    - name: commit changes into OBS
-      run: cp $FOLDER/_service . && /scripts/upload.sh
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: configure OSC
+        # OSC credentials must be configured beforehand as the HOME variables cannot be changed from /github/home
+        # that is used to run osc commands
+        run: |
+          /scripts/init_osc_creds.sh
+          mkdir -p $HOME/.config/osc
+          cp /root/.config/osc/oscrc $HOME/.config/osc
+      - name: Prepare trento.changes file
+        # The .changes file is updated only in release creation. This current task should be improved
+        # in order to add the current rolling release notes
+        if: github.event_name == 'release'
+        run: |
+          osc checkout $OBS_PROJECT trento trento.changes
+          mv trento.changes $FOLDER
+          VERSION=$(./hack/get_version_from_git.sh)
+          TAG=$(echo $VERSION | cut -f1 -d+)
+          hack/gh_release_to_obs_changeset.py $REPOSITORY -a shap-staff@suse.de -t $TAG -f $FOLDER/trento.changes
+      - name: prepare _service file
+        run: |
+          VERSION=$(./hack/get_version_from_git.sh)
+          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+          sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+      - name: commit changes into OBS
+        run: cp $FOLDER/_service . && /scripts/upload.sh
 
   obs-submit:
     needs: obs-commit
@@ -424,19 +429,19 @@ jobs:
     container:
       image: ghcr.io/trento-project/continuous-delivery:master
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: configure OSC
-      run: |
-        /scripts/init_osc_creds.sh
-        mkdir -p $HOME/.config/osc
-        cp /root/.config/osc/oscrc $HOME/.config/osc
-    - name: prepare _service file
-      run: |
-        VERSION=$(./hack/get_version_from_git.sh)
-        sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
-        sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
-        sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
-    - name: submit package
-      run: cp $FOLDER/_service . && /scripts/submit.sh
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: configure OSC
+        run: |
+          /scripts/init_osc_creds.sh
+          mkdir -p $HOME/.config/osc
+          cp /root/.config/osc/oscrc $HOME/.config/osc
+      - name: prepare _service file
+        run: |
+          VERSION=$(./hack/get_version_from_git.sh)
+          sed -i 's~%%REVISION%%~${{ github.sha }}~' $FOLDER/_service && \
+          sed -i 's~%%REPOSITORY%%~${{ github.repository }}~' $FOLDER/_service && \
+          sed -i 's~%%VERSION%%~'"${VERSION}"'~' $FOLDER/_service
+      - name: submit package
+        run: cp $FOLDER/_service . && /scripts/submit.sh

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -379,7 +379,8 @@ jobs:
         run: |
           set -ex
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
-          do            
+          do
+            ssh "$TRENTO_USER@$target_host" "zypper in -y golang-github-prometheus-node_exporter" 
             ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done

--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The _Trento Server_ needs to reach the target infrastructure.
 The _Trento Agent_ component, on the other hand, needs to interact with a number of low-level system components
 which are part of the [SUSE Linux Enterprise Server for SAP Applications](https://www.suse.com/products/sles-for-sap/) Linux distribution.
 These could in theory also be installed and configured on other distributions providing the same functionalities, but this use case is not within the scope of the active development.
+
+In addition to that, the _Trento Agent_ also requires the [Prometheus node_exporter component](https://github.com/prometheus/node_exporter) to be running to collect host information for the monitoring functionality.
+
 The resource footprint of the _Trento Agent_ should not impact the performance of the host it runs on.
 
 ## Quick-Start installation
@@ -296,10 +299,27 @@ Trento Agents are responsible for discovering SAP systems, HA clusters and some 
 Cluster services, so running them in isolated environments (e.g. serverless,
 containers, etc.) makes little sense, as they won't be able as the discovery mechanisms will not be able to report any host information.
 
+> NOTE: Suggested installation instructions for SUSE-based distributions, adjust accordingly
+
+Install and start `node_exporter`:
+
+```shell
+zypper in -y golang-github-prometheus-node_exporter
+systemctl start prometheus-node_exporter
+```
+
 To start the trento agent:
 
 ```shell
 ./trento agent start
+```
+
+Alternatively, you can use the `trento-agent.service` from this repository and start it, which will start
+`node_exporter` automatically as a dependency:
+```shell
+cp packaging/systemd/trento-agent.service /etc/systemd/system
+systemctl daemon-reload
+systemctl start trento-agent.service
 ```
 
 > If the discovery loop is being executed too frequently, and this impacts the Web interface performance, the agent

--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -35,6 +35,7 @@ BuildRequires:  golang-packaging
 BuildRequires:  golang(API) = 1.16
 BuildRequires:  npm
 BuildRequires:  local-npm-registry
+Requires:       golang-github-prometheus-node_exporter
 Provides:       %{name} = %{version}-%{release}
 
 %{go_nostrip}

--- a/packaging/systemd/trento-agent.service
+++ b/packaging/systemd/trento-agent.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Trento agent service
+Requires=prometheus-node_exporter.service
+After=prometheus-node_exporter.service
 
 [Service]
 ExecStart=/usr/bin/trento agent start


### PR DESCRIPTION
This PR just adds `node_exporter` as a dependency in both the trento RPM spec and the agent systemd unit to ensure it's started in the proper order. 

I also applied tok the opportunity to format the ci-cd.yaml using a formatter.