### PR TITLE
Remove mention of Blue Horizon from landing page

### DIFF
--- a/packaging/suse/trento.spec
+++ b/packaging/suse/trento.spec
@@ -44,9 +44,8 @@ An open cloud-native web console improving on the life of SAP Applications admin
 
 Trento is a city on the Adige River in Trentino-Alto Adige/Suedtirol in Italy. [...] It is one of the nation's wealthiest and most prosperous cities, [...] often ranking highly among Italian cities for quality of life, standard of living, and business and job opportunities. (source)
 
-This project is a reboot of the "SUSE Console for SAP Applications", also known as the Blue Horizon for SAP prototype, which is focused on automated infrastructure deployment and provisioning for SAP Applications.
-
-As opposed to that first iteration, this new one will focus more on operations of existing clusters, rather than deploying new one.
+This project focuses on operations of existing clusters of SAP
+applications.
 
 %prep
 %setup -q            # unpack project sources

--- a/test/e2e/cypress/integration/home.js
+++ b/test/e2e/cypress/integration/home.js
@@ -4,15 +4,6 @@ context('Homepage', () => {
   });
 
   describe('The main links in the homepage should work (means the links are the expected ones)', () => {
-    it('should provide correct link to Blue Horizon for SAP', () => {
-      cy.get('#tn-blue-horizon-link')
-        .should('have.attr', 'target', 'blank')
-        .and(
-          'have.attr',
-          'href',
-          'https://github.com/SUSE/blue-horizon-for-sap'
-        );
-    });
     it('should provide correct link to the Hosts page', () => {
       cy.get('#tn-hosts-link').should('have.attr', 'href', '/hosts');
     });

--- a/web/middlewares_test.go
+++ b/web/middlewares_test.go
@@ -46,7 +46,7 @@ func TestEulaMiddlewareLettingThrough(t *testing.T) {
 	app.webEngine.ServeHTTP(resp, req)
 
 	assert.Equal(t, 200, resp.Code)
-	assert.Contains(t, resp.Body.String(), "Blue Horizon for SAP")
+	assert.Contains(t, resp.Body.String(), "In the hosts overview, the user can")
 }
 
 func TestEulaMiddlewareError(t *testing.T) {

--- a/web/templates/home.html.tmpl
+++ b/web/templates/home.html.tmpl
@@ -7,11 +7,6 @@
     </div>
     <hr/>
     <section>
-        <div class='mb-5'>
-            This project is a reboot of the "SUSE Console for SAP Applications", also known
-            as the <a id='tn-blue-horizon-link' target='blank' href='https://github.com/SUSE/blue-horizon-for-sap'>Blue Horizon for SAP</a>
-            prototype, which is focused on automated infrastructure deployment and provisioning for SAP Applications
-        </div>
         <div class='card-deck'>
             <div class='card'>
                 <h5 class='card-header'>Hosts</h5>


### PR DESCRIPTION
Information about Blue Horizon is not relevant for most customers, only
for the few that looked at it.
Remove it.