### PR TITLE
Change trento path in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,12 @@ ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-COPY --from=go-build /build/trento /app/trento
+COPY --from=go-build /build/trento /usr/bin/trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/trento"
-ENTRYPOINT ["/tini", "--", "/app/trento"]
+ENTRYPOINT ["/tini", "--", "/usr/bin/trento"]
 
 FROM gcr.io/distroless/base:debug AS trento-web
-COPY --from=go-build /build/trento /app/trento
+COPY --from=go-build /build/trento /usr/bin/trento
 LABEL org.opencontainers.image.source="https://github.com/trento-project/trento"
 EXPOSE 8080/tcp
-ENTRYPOINT ["/app/trento"]
+ENTRYPOINT ["/usr/bin/trento"]

--- a/hack/dump_scenario_from_k8s.sh
+++ b/hack/dump_scenario_from_k8s.sh
@@ -72,7 +72,7 @@ dump-scenario() {
         exit 1
     fi
 
-    kubectl exec -ti deploy/trento-server-web -- /app/trento ctl dump-scenario --name="$name" --path /scenarios
+    kubectl exec -ti deploy/trento-server-web -- /usr/bin/trento ctl dump-scenario --name="$name" --path /scenarios
     kubectl exec deploy/trento-server-web -- tar cf - scenarios | tar xf - -C "$path"
     kubectl exec deploy/trento-server-web -- rm -rf /scenarios
 }


### PR DESCRIPTION
This PR changes the path of the trento binary in the containers to the same used for premium `/usr/bin/path` so we can use the same dump script for both the flavors.