### PR TITLE
Do not make assumptions about the shape of the payload of checks catalog

### DIFF
--- a/web/frontend/javascripts/cluster_check_settings.js
+++ b/web/frontend/javascripts/cluster_check_settings.js
@@ -37,9 +37,18 @@ const SettingsButton = () => {
 
   useEffect(() => {
     setLoading(true);
-    get('/api/checks/catalog').then(({ data }) => {
-      setChecksCatalog(data);
-    });
+    get('/api/checks/catalog')
+      .then(({ data }) => {
+        Boolean(data) ? setChecksCatalog(data) : setChecksCatalog([]);
+      })
+      .catch((error) => {
+        logError(error);
+        setChecksCatalog([]);
+        showErrorToast({
+          content: 'Error fetching checks catalog data.',
+        });
+      });
+
     get(`/api/checks/${clusterId}/settings`)
       .then(({ data }) => {
         const {

--- a/web/frontend/javascripts/cluster_check_settings.js
+++ b/web/frontend/javascripts/cluster_check_settings.js
@@ -39,7 +39,7 @@ const SettingsButton = () => {
     setLoading(true);
     get('/api/checks/catalog')
       .then(({ data }) => {
-        Boolean(data) ? setChecksCatalog(data) : setChecksCatalog([]);
+        data ? setChecksCatalog(data) : setChecksCatalog([]);
       })
       .catch((error) => {
         logError(error);


### PR DESCRIPTION
This prevents the checks selection from panicking in the frontend when the catalog is empty.