### PR TITLE
Do not add bitnami charts repo from the installer if it's not needed

### DIFF
--- a/install-server.sh
+++ b/install-server.sh
@@ -192,6 +192,10 @@ install_helm() {
 }
 
 update_helm_dependencies() {
+    local download_chart=${DOWNLOAD_CHART:-true}
+    if [[ "$download_chart" != true ]]; then
+        return
+    fi
     echo "Updating Helm dependencies..."
     helm repo add bitnami https://charts.bitnami.com/bitnami >/dev/null
     helm repo update >/dev/null


### PR DESCRIPTION
This PR allows to skip the addition of the bitnami helm chart repo during the installation; useful for the `server-installer` subpackage in `trento-premium`; where we are using the TGZd `trento-premium-server` chart that already includes dependencies (such as bitnami's postgresql chart)

To be clear: Even though the repo was being added, it wasn't used as the script already skipped the download in such a case. In any case, it's cleaner like this so it's worth adding.