### PR TITLE
Implement cluster heatlh computation projection

### DIFF
--- a/test/e2e/cypress/fixtures/.photofinish.toml
+++ b/test/e2e/cypress/fixtures/.photofinish.toml
@@ -57,3 +57,19 @@ files = ["./sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system
 [sap-systems-overview-hana-RED]
 
 files = ["./sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json"]
+
+[cluster-4-SOK]
+
+files = ["./clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json"]
+
+[cluster-1-SOK]
+
+files = ["./clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SOK.json"]
+
+[cluster-4-SFAIL]
+
+files = ["./clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SFAIL.json"]
+
+[cluster-1-SFAIL]
+
+files = ["./clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json"]

--- a/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json
+++ b/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SFAIL.json
@@ -1,0 +1,789 @@
+{
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": true,
+    "Id": "04b8f8c21f9fd8991224478e8c4362f8",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhdbdev01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhdbdev02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster_1"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "SAPHanaSR-hana_hdd_site_srHook_WDF",
+              "Name": "hana_hdd_site_srHook_WDF",
+              "Value": "PRIM"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+                "Type": "SAPHanaTopology",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300",
+                    "Interval": "0"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_HDD_HDB10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_HDD_HDB10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-start-0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-stop-0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.100.1.13"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "24"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_HDD_HDB10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62510"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHana_HDD_HDB10",
+                "Type": "SAPHana",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700",
+                    "Interval": "60"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700",
+                    "Interval": "61"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-15",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "15",
+                  "Interval": "15"
+                }
+              ],
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": null
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "cc39771e-ea2f-4fb1-8968-a6176aee3d0a",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhdbdev01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhdbdev02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "hana_cluster_1",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmhdbdev01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 2
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmhdbdev02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Master",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": null,
+              "Role": "Stopped",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": false,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0
+            }
+          ],
+          "MultiState": true,
+          "FailureIgnored": false
+        },
+        {
+          "Id": "cln_SAPHanaTopology_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "1",
+                "Name": "vmhdbdev01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ],
+          "MultiState": false,
+          "FailureIgnored": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_HDD_HDB10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 7,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 25 15:37:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmhdbdev01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev01",
+            "ResourceHistory": [
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 1000000,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev01",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "1:P:master1::worker:"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "SFAIL"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev02",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "150"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SOK.json
+++ b/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_1_SOK.json
@@ -1,0 +1,789 @@
+{
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": true,
+    "Id": "04b8f8c21f9fd8991224478e8c4362f8",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhdbdev01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhdbdev02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster_1"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "SAPHanaSR-hana_hdd_site_srHook_WDF",
+              "Name": "hana_hdd_site_srHook_WDF",
+              "Value": "PRIM"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+                "Type": "SAPHanaTopology",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300",
+                    "Interval": "0"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_HDD_HDB10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_HDD_HDB10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-start-0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-stop-0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.100.1.13"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "24"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_HDD_HDB10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62510"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHana_HDD_HDB10",
+                "Type": "SAPHana",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700",
+                    "Interval": "60"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700",
+                    "Interval": "61"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-15",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "15",
+                  "Interval": "15"
+                }
+              ],
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": null
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "cc39771e-ea2f-4fb1-8968-a6176aee3d0a",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhdbdev01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhdbdev02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "hana_cluster_1",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmhdbdev01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 2
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmhdbdev02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Master",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": null,
+              "Role": "Stopped",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": false,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0
+            }
+          ],
+          "MultiState": true,
+          "FailureIgnored": false
+        },
+        {
+          "Id": "cln_SAPHanaTopology_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "1",
+                "Name": "vmhdbdev01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ],
+          "MultiState": false,
+          "FailureIgnored": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_HDD_HDB10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 7,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 25 15:37:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmhdbdev01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev01",
+            "ResourceHistory": [
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 1000000,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev01",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "1:P:master1::worker:"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "SOK"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev02",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "150"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SFAIL.json
+++ b/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SFAIL.json
@@ -1,0 +1,789 @@
+{
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": true,
+    "Id": "04b8f8c21f9fd8991224478e8c4362f8",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhdbdev01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhdbdev02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster_1"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "SAPHanaSR-hana_hdd_site_srHook_WDF",
+              "Name": "hana_hdd_site_srHook_WDF",
+              "Value": "PRIM"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+                "Type": "SAPHanaTopology",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300",
+                    "Interval": "0"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_HDD_HDB10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_HDD_HDB10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-start-0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-stop-0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.100.1.13"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "24"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_HDD_HDB10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62510"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHana_HDD_HDB10",
+                "Type": "SAPHana",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700",
+                    "Interval": "60"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700",
+                    "Interval": "61"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-15",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "15",
+                  "Interval": "15"
+                }
+              ],
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": null
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "cc39771e-ea2f-4fb1-8968-a6176aee3d0a",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhdbdev01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhdbdev02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "hana_cluster_1",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmhdbdev01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 2
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmhdbdev02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Master",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": null,
+              "Role": "Stopped",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": false,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0
+            }
+          ],
+          "MultiState": true,
+          "FailureIgnored": false
+        },
+        {
+          "Id": "cln_SAPHanaTopology_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "1",
+                "Name": "vmhdbdev01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ],
+          "MultiState": false,
+          "FailureIgnored": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_HDD_HDB10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 7,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 25 15:37:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmhdbdev01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev01",
+            "ResourceHistory": [
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 1000000,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev01",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1::worker:"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "SFAIL"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev02",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "150"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json
+++ b/test/e2e/cypress/fixtures/clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json
@@ -1,0 +1,789 @@
+{
+  "agent_id": "13e8c25c-3180-5a9a-95c8-51ec38e50cfc",
+  "discovery_type": "ha_cluster_discovery",
+  "payload": {
+    "DC": true,
+    "Id": "04b8f8c21f9fd8991224478e8c4362f8",
+    "Cib": {
+      "Configuration": {
+        "Nodes": [
+          {
+            "Id": "1",
+            "Uname": "vmhdbdev01",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-1-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Id": "nodes-1-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              }
+            ]
+          },
+          {
+            "Id": "2",
+            "Uname": "vmhdbdev02",
+            "InstanceAttributes": [
+              {
+                "Id": "nodes-2-lpa_hdd_lpt",
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_op_mode",
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_vhost",
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_remoteHost",
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_site",
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Id": "nodes-2-hana_hdd_srmode",
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              }
+            ]
+          }
+        ],
+        "CrmConfig": {
+          "ClusterProperties": [
+            {
+              "Id": "cib-bootstrap-options-have-watchdog",
+              "Name": "have-watchdog",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-dc-version",
+              "Name": "dc-version",
+              "Value": "2.0.5+20201202.ba59be712-4.13.1-2.0.5+20201202.ba59be712"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-infrastructure",
+              "Name": "cluster-infrastructure",
+              "Value": "corosync"
+            },
+            {
+              "Id": "cib-bootstrap-options-cluster-name",
+              "Name": "cluster-name",
+              "Value": "hana_cluster_1"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-enabled",
+              "Name": "stonith-enabled",
+              "Value": "true"
+            },
+            {
+              "Id": "cib-bootstrap-options-stonith-timeout",
+              "Name": "stonith-timeout",
+              "Value": "144s"
+            },
+            {
+              "Id": "cib-bootstrap-options-maintenance-mode",
+              "Name": "maintenance-mode",
+              "Value": "false"
+            },
+            {
+              "Id": "SAPHanaSR-hana_hdd_site_srHook_WDF",
+              "Name": "hana_hdd_site_srHook_WDF",
+              "Value": "PRIM"
+            }
+          ]
+        },
+        "Resources": {
+          "Clones": [
+            {
+              "Id": "cln_SAPHanaTopology_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+                "Type": "SAPHanaTopology",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-monitor-10",
+                    "Name": "monitor",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "300",
+                    "Interval": "0"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHanaTopology_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "cln_SAPHanaTopology_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Groups": [
+            {
+              "Id": "g_ip_HDD_HDB10",
+              "Primitives": [
+                {
+                  "Id": "rsc_ip_HDD_HDB10",
+                  "Type": "IPaddr2",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-start-0",
+                      "Name": "start",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-stop-0",
+                      "Name": "stop",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "0"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-ip",
+                      "Name": "ip",
+                      "Value": "10.100.1.13"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-cidr_netmask",
+                      "Name": "cidr_netmask",
+                      "Value": "24"
+                    },
+                    {
+                      "Id": "rsc_ip_HDD_HDB10-instance_attributes-nic",
+                      "Name": "nic",
+                      "Value": "eth0"
+                    }
+                  ]
+                },
+                {
+                  "Id": "rsc_socat_HDD_HDB10",
+                  "Type": "azure-lb",
+                  "Class": "ocf",
+                  "Provider": "heartbeat",
+                  "Operations": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-monitor-10",
+                      "Name": "monitor",
+                      "Role": "",
+                      "Timeout": "20",
+                      "Interval": "10"
+                    }
+                  ],
+                  "MetaAttributes": null,
+                  "InstanceAttributes": [
+                    {
+                      "Id": "rsc_socat_HDD_HDB10-instance_attributes-port",
+                      "Name": "port",
+                      "Value": "62510"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "Masters": [
+            {
+              "Id": "msl_SAPHana_HDD_HDB10",
+              "Primitive": {
+                "Id": "rsc_SAPHana_HDD_HDB10",
+                "Type": "SAPHana",
+                "Class": "ocf",
+                "Provider": "suse",
+                "Operations": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-start-0",
+                    "Name": "start",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-stop-0",
+                    "Name": "stop",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-promote-0",
+                    "Name": "promote",
+                    "Role": "",
+                    "Timeout": "3600",
+                    "Interval": "0"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-60",
+                    "Name": "monitor",
+                    "Role": "Master",
+                    "Timeout": "700",
+                    "Interval": "60"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-monitor-61",
+                    "Name": "monitor",
+                    "Role": "Slave",
+                    "Timeout": "700",
+                    "Interval": "61"
+                  }
+                ],
+                "MetaAttributes": null,
+                "InstanceAttributes": [
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-SID",
+                    "Name": "SID",
+                    "Value": "HDD"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-InstanceNumber",
+                    "Name": "InstanceNumber",
+                    "Value": "10"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-PREFER_SITE_TAKEOVER",
+                    "Name": "PREFER_SITE_TAKEOVER",
+                    "Value": "True"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-AUTOMATED_REGISTER",
+                    "Name": "AUTOMATED_REGISTER",
+                    "Value": "False"
+                  },
+                  {
+                    "Id": "rsc_SAPHana_HDD_HDB10-instance_attributes-DUPLICATE_PRIMARY_TIMEOUT",
+                    "Name": "DUPLICATE_PRIMARY_TIMEOUT",
+                    "Value": "7200"
+                  }
+                ]
+              },
+              "MetaAttributes": [
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-max",
+                  "Name": "clone-max",
+                  "Value": "2"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-clone-node-max",
+                  "Name": "clone-node-max",
+                  "Value": "1"
+                },
+                {
+                  "Id": "msl_SAPHana_HDD_HDB10-meta_attributes-interleave",
+                  "Name": "interleave",
+                  "Value": "true"
+                }
+              ]
+            }
+          ],
+          "Primitives": [
+            {
+              "Id": "stonith-sbd",
+              "Type": "external/sbd",
+              "Class": "stonith",
+              "Provider": "",
+              "Operations": [
+                {
+                  "Id": "stonith-sbd-monitor-15",
+                  "Name": "monitor",
+                  "Role": "",
+                  "Timeout": "15",
+                  "Interval": "15"
+                }
+              ],
+              "MetaAttributes": null,
+              "InstanceAttributes": [
+                {
+                  "Id": "stonith-sbd-instance_attributes-pcmk_delay_max",
+                  "Name": "pcmk_delay_max",
+                  "Value": "15"
+                }
+              ]
+            }
+          ]
+        },
+        "Constraints": {
+          "RscLocations": null
+        }
+      }
+    },
+    "SBD": {
+      "Config": {
+        "SBD_DEVICE": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+        "SBD_PACEMAKER": "yes",
+        "SBD_STARTMODE": "always",
+        "SBD_DELAY_START": "yes",
+        "SBD_WATCHDOG_DEV": "/dev/watchdog",
+        "SBD_TIMEOUT_ACTION": "flush,reboot",
+        "SBD_WATCHDOG_TIMEOUT": "5",
+        "SBD_MOVE_TO_ROOT_CGROUP": "auto",
+        "SBD_SYNC_RESOURCE_STARTUP": "no"
+      },
+      "Devices": [
+        {
+          "Dump": {
+            "Uuid": "cc39771e-ea2f-4fb1-8968-a6176aee3d0a",
+            "Slots": 255,
+            "Header": "2.1",
+            "SectorSize": 512,
+            "TimeoutLoop": 1,
+            "TimeoutMsgwait": 10,
+            "TimeoutAllocate": 2,
+            "TimeoutWatchdog": 5
+          },
+          "List": [
+            {
+              "Id": 0,
+              "Name": "vmhdbdev01",
+              "Status": "clear"
+            },
+            {
+              "Id": 1,
+              "Name": "vmhdbdev02",
+              "Status": "clear"
+            }
+          ],
+          "Device": "/dev/disk/by-id/scsi-1LIO-ORG_IBLOCK:182cb1b1-a815-4b82-b538-7a166b9bbb4a",
+          "Status": "healthy"
+        }
+      ]
+    },
+    "Name": "hana_cluster_1",
+    "Crmmon": {
+      "Nodes": [
+        {
+          "DC": true,
+          "Id": "1",
+          "Name": "vmhdbdev01",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 2
+        },
+        {
+          "DC": false,
+          "Id": "2",
+          "Name": "vmhdbdev02",
+          "Type": "member",
+          "Online": true,
+          "Pending": false,
+          "Standby": false,
+          "Unclean": false,
+          "Shutdown": false,
+          "ExpectedUp": true,
+          "Maintenance": false,
+          "StandbyOnFail": false,
+          "ResourcesRunning": 4
+        }
+      ],
+      "Clones": [
+        {
+          "Id": "msl_SAPHana_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Master",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHana_HDD_HDB10",
+              "Node": null,
+              "Role": "Stopped",
+              "Agent": "ocf::suse:SAPHana",
+              "Active": false,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 0
+            }
+          ],
+          "MultiState": true,
+          "FailureIgnored": false
+        },
+        {
+          "Id": "cln_SAPHanaTopology_HDD_HDB10",
+          "Failed": false,
+          "Unique": false,
+          "Managed": true,
+          "Resources": [
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_SAPHanaTopology_HDD_HDB10",
+              "Node": {
+                "Id": "1",
+                "Name": "vmhdbdev01",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::suse:SAPHanaTopology",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ],
+          "MultiState": false,
+          "FailureIgnored": false
+        }
+      ],
+      "Groups": [
+        {
+          "Id": "g_ip_HDD_HDB10",
+          "Resources": [
+            {
+              "Id": "rsc_ip_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:IPaddr2",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            },
+            {
+              "Id": "rsc_socat_HDD_HDB10",
+              "Node": {
+                "Id": "2",
+                "Name": "vmhdbdev02",
+                "Cached": true
+              },
+              "Role": "Started",
+              "Agent": "ocf::heartbeat:azure-lb",
+              "Active": true,
+              "Failed": false,
+              "Blocked": false,
+              "Managed": true,
+              "Orphaned": false,
+              "FailureIgnored": false,
+              "NodesRunningOn": 1
+            }
+          ]
+        }
+      ],
+      "Summary": {
+        "Nodes": {
+          "Number": 2
+        },
+        "Resources": {
+          "Number": 7,
+          "Blocked": 0,
+          "Disabled": 0
+        },
+        "LastChange": {
+          "Time": "Tue Jan 25 15:37:06 2022"
+        },
+        "ClusterOptions": {
+          "StonithEnabled": true
+        }
+      },
+      "Version": "2.0.5",
+      "Resources": [
+        {
+          "Id": "stonith-sbd",
+          "Node": {
+            "Id": "1",
+            "Name": "vmhdbdev01",
+            "Cached": true
+          },
+          "Role": "Started",
+          "Agent": "stonith:external/sbd",
+          "Active": true,
+          "Failed": false,
+          "Blocked": false,
+          "Managed": true,
+          "Orphaned": false,
+          "FailureIgnored": false,
+          "NodesRunningOn": 1
+        }
+      ],
+      "NodeHistory": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev02",
+            "ResourceHistory": [
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev01",
+            "ResourceHistory": [
+              {
+                "Name": "stonith-sbd",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_ip_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_socat_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHana_HDD_HDB10",
+                "FailCount": 1000000,
+                "MigrationThreshold": 5000
+              },
+              {
+                "Name": "rsc_SAPHanaTopology_HDD_HDB10",
+                "FailCount": 0,
+                "MigrationThreshold": 5000
+              }
+            ]
+          }
+        ]
+      },
+      "NodeAttributes": {
+        "Nodes": [
+          {
+            "Name": "vmhdbdev01",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "UNDEFINED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1::worker:"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "NBG"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "SOK"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "10"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "-9000"
+              }
+            ]
+          },
+          {
+            "Name": "vmhdbdev02",
+            "Attributes": [
+              {
+                "Name": "hana_hdd_clone_state",
+                "Value": "PROMOTED"
+              },
+              {
+                "Name": "hana_hdd_op_mode",
+                "Value": "logreplay"
+              },
+              {
+                "Name": "hana_hdd_remoteHost",
+                "Value": "vmhdbdev01"
+              },
+              {
+                "Name": "hana_hdd_roles",
+                "Value": "4:P:master1:master:worker:master"
+              },
+              {
+                "Name": "hana_hdd_site",
+                "Value": "WDF"
+              },
+              {
+                "Name": "hana_hdd_srmode",
+                "Value": "sync"
+              },
+              {
+                "Name": "hana_hdd_sync_state",
+                "Value": "PRIM"
+              },
+              {
+                "Name": "hana_hdd_version",
+                "Value": "2.00.057.00.1629894416"
+              },
+              {
+                "Name": "hana_hdd_vhost",
+                "Value": "vmhdbdev02"
+              },
+              {
+                "Name": "lpa_hdd_lpt",
+                "Value": "1643125026"
+              },
+              {
+                "Name": "master-rsc_SAPHana_HDD_HDB10",
+                "Value": "150"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/test/e2e/cypress/fixtures/clusters-overview/clusters_overview.feature
+++ b/test/e2e/cypress/fixtures/clusters-overview/clusters_overview.feature
@@ -17,6 +17,22 @@ Feature: Pacemaker Clusters Overview
         When I navigate to the Pacemaker Clusters Overview (/clusters)
         Then the displayed clusters should be the ones listed above
 
+    Scenario: Clusters health state matches the cluster health and checks results outcome
+        Given I am in the Pacemaker Clusters Overview
+        When the SR state is 4 and sync state is SOK and checks are passing
+        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Pasing status
+        When the SR state is 1 and sync state is SFAIL and checks are passing
+        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Critical status
+        When the SR state is 4 and sycn state is SOK and checs are in Warning
+        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Warning status
+        When the SR state is 4 and sycn state is SOK and checs are in Critical
+        Then the cluster with id '04b8f8c21f9fd8991224478e8c4362f8' is in Critical status
+
+    Scenario: Clusters that are not HANA type have unknown health state
+        Given I am in the Pacemaker Clusters Overview
+        When a non HANA cluster is discovered
+        Then the cluster is in Unknown status
+
     Scenario: Health Container information matches the status of the listed clusters
         Given I am in the Pacemaker Clusters Overview
         When the health container is ready

--- a/test/e2e/cypress/fixtures/sap-systems-overview/available_sap_systems.js
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/available_sap_systems.js
@@ -1,10 +1,12 @@
 const HANASystemReplicationModes = {
-  Primary: "HANA Primary",
-  Secondary: "HANA Secondary"
-}
+  Primary: 'HANA Primary',
+  Secondary: 'HANA Secondary',
+};
 
-export const isHanaSecondary = (instance) => instance.systemReplication == HANASystemReplicationModes.Secondary
-export const isHanaPrimary = (instance) => instance.systemReplication == HANASystemReplicationModes.Primary
+export const isHanaSecondary = (instance) =>
+  instance.systemReplication == HANASystemReplicationModes.Secondary;
+export const isHanaPrimary = (instance) =>
+  instance.systemReplication == HANASystemReplicationModes.Primary;
 
 export const availableSAPSystems = [
   {
@@ -243,7 +245,7 @@ export const availableSAPSystems = [
         health: 'check_circle',
         features: 'HDB|HDB_WORKER',
         instanceNumber: '10',
-        systemReplication:  HANASystemReplicationModes.Primary,
+        systemReplication: HANASystemReplicationModes.Primary,
         systemReplicationStatus: 'SOK',
         clusterName: 'hana_cluster',
         clusterID: '04b8f8c21f9fd8991224478e8c4362f8',

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -1,4 +1,8 @@
-import { availableSAPSystems, isHanaPrimary, isHanaSecondary } from '../fixtures/sap-systems-overview/available_sap_systems';
+import {
+  availableSAPSystems,
+  isHanaPrimary,
+  isHanaSecondary,
+} from '../fixtures/sap-systems-overview/available_sap_systems';
 
 context('SAP Systems Overview', () => {
   before(() => {
@@ -92,13 +96,19 @@ context('SAP Systems Overview', () => {
                   .should('contain', instances[index].systemReplication);
                 if (isHanaPrimary(instances[index])) {
                   cy.get('td')
-                  .eq(4)
-                  .should('not.contain', instances[index].systemReplicationStatus);
+                    .eq(4)
+                    .should(
+                      'not.contain',
+                      instances[index].systemReplicationStatus
+                    );
                 }
                 if (isHanaSecondary(instances[index])) {
                   cy.get('td')
-                  .eq(4)
-                  .should('contain', instances[index].systemReplicationStatus);
+                    .eq(4)
+                    .should(
+                      'contain',
+                      instances[index].systemReplicationStatus
+                    );
                 }
                 cy.get('td')
                   .eq(5)

--- a/test/e2e/cypress/support/commands.js
+++ b/test/e2e/cypress/support/commands.js
@@ -59,6 +59,17 @@ Cypress.Commands.add('resetDatabase', () => {
   );
 });
 
+Cypress.Commands.add('pruneChecksResults', () => {
+  cy.log('Resetting DB...');
+  cy.exec(
+    `${Cypress.env(
+      'trento_binary'
+    )} ctl prune-checks-results --db-host=${Cypress.env(
+      'db_host'
+    )} --db-port=${Cypress.env('db_port')}`
+  );
+});
+
 Cypress.Commands.add('loadScenario', (scenario) => {
   const [fixturesPath, photofinishBinary, collectorHost, collectorPort] = [
     Cypress.env('fixtures_path'),

--- a/web/app.go
+++ b/web/app.go
@@ -45,6 +45,7 @@ var DBTables = []interface{}{
 	&entities.Check{}, &datapipeline.DataCollectedEvent{}, &datapipeline.Subscription{},
 	&entities.HostTelemetry{}, &entities.Cluster{}, &entities.Host{}, &entities.HostHeartbeat{},
 	&entities.SlesSubscription{}, &entities.SAPSystemInstance{}, &entities.ChecksResult{},
+	&entities.HealthState{},
 }
 
 type App struct {

--- a/web/datapipeline/clusters_projector.go
+++ b/web/datapipeline/clusters_projector.go
@@ -17,6 +17,10 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+const (
+	partialSrHealth = "hana_sr_health"
+)
+
 func NewClustersProjector(db *gorm.DB) *projector {
 	clusterProjector := NewProjector("clusters", db)
 	clusterProjector.AddHandler(ClusterDiscovery, clustersProjector_ClusterDiscoveryHandler)
@@ -41,15 +45,26 @@ func clustersProjector_ClusterDiscoveryHandler(event *DataCollectedEvent, db *go
 		return nil
 	}
 
-	clusterListReadModel, err := transformClusterData(&cluster)
+	clusterReadModel, err := transformClusterData(&cluster)
 	if err != nil {
 		log.Errorf("can't transform data: %s", err)
 		return err
 	}
 
+	discoveredHealth, err := computeDiscoveredHealth(clusterReadModel)
+	if err != nil {
+		return err
+	}
+
+	err = ProjectHealth(db, clusterReadModel.ID, partialSrHealth, discoveredHealth)
+	if err != nil {
+		log.Errorf("can't project health: %s", err)
+		return err
+	}
+
 	return db.Clauses(clause.OnConflict{
 		UpdateAll: true,
-	}).Create(clusterListReadModel).Error
+	}).Create(clusterReadModel).Error
 }
 
 // transformClusterData transforms the cluster data into the read model
@@ -365,4 +380,38 @@ func parseSBDDevices(c *cluster.Cluster) []*entities.SBDDevice {
 	}
 
 	return sbdDevices
+}
+
+func computeDiscoveredHealth(c *entities.Cluster) (string, error) {
+	switch c.ClusterType {
+	case models.ClusterTypeHANAScaleUp, models.ClusterTypeHANAScaleOut:
+		return computeDiscoveredHANAHealth(c)
+	default:
+		return models.HealthSummaryHealthUnknown, nil
+	}
+}
+
+func computeDiscoveredHANAHealth(c *entities.Cluster) (string, error) {
+	var srHealth string
+	var clusterDetailHANA entities.HANAClusterDetails
+
+	err := json.Unmarshal(c.Details, &clusterDetailHANA)
+	if err != nil {
+		return "", err
+	}
+
+	srHealthState := clusterDetailHANA.SRHealthState
+	srSyncState := clusterDetailHANA.SecondarySyncState
+
+	// Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
+	// If data is not present for some reason the state goes to unknown
+	if srHealthState == models.HANASrHealth4 && srSyncState == models.HANASrSyncSOK {
+		srHealth = models.HealthSummaryHealthPassing
+	} else if srHealthState == "" || srSyncState == "" {
+		srHealth = models.HealthSummaryHealthUnknown
+	} else {
+		srHealth = models.HealthSummaryHealthCritical
+	}
+
+	return srHealth, nil
 }

--- a/web/datapipeline/clusters_projector.go
+++ b/web/datapipeline/clusters_projector.go
@@ -405,7 +405,7 @@ func computeDiscoveredHANAHealth(c *entities.Cluster) (string, error) {
 
 	// Passing state if SR Health state is 4 and Sync state is SOK, everything else is critical
 	// If data is not present for some reason the state goes to unknown
-	if srHealthState == models.HANASrHealth4 && srSyncState == models.HANASrSyncSOK {
+	if srHealthState == models.HANASrHealthOK && srSyncState == models.HANASrSyncSOK {
 		srHealth = models.HealthSummaryHealthPassing
 	} else if srHealthState == "" || srSyncState == "" {
 		srHealth = models.HealthSummaryHealthUnknown

--- a/web/datapipeline/clusters_projector_test.go
+++ b/web/datapipeline/clusters_projector_test.go
@@ -21,7 +21,7 @@ func TestClustersProjector_ClusterDiscoveryHandler(t *testing.T) {
 	tx := db.Begin()
 	defer tx.Rollback()
 
-	tx.AutoMigrate(&entities.Cluster{})
+	tx.AutoMigrate(&entities.Cluster{}, &entities.HealthState{})
 	tx.Create(&entities.Cluster{
 		Name:        "test_cluster",
 		ID:          "test_id",
@@ -45,12 +45,21 @@ func TestClustersProjector_ClusterDiscoveryHandler(t *testing.T) {
 	var cluster entities.Cluster
 	tx.First(&cluster)
 
+	var health entities.HealthState
+	tx.First(&health)
+
+	var partialHealth map[string]string
+	json.Unmarshal(health.PartialHealths, &partialHealth)
+
 	assert.Equal(t, "5dfbd28f35cbfb38969f9b99243ae8d4", cluster.ID)
 	assert.Equal(t, models.ClusterTypeHANAScaleUp, cluster.ClusterType)
 	assert.Equal(t, "PRD", cluster.SID)
 	assert.Equal(t, 8, cluster.ResourcesNumber)
 	assert.Equal(t, 2, cluster.HostsNumber)
 	assert.NotNil(t, cluster.Details)
+	assert.Equal(t, health.ID, cluster.ID)
+	assert.Equal(t, "critical", health.Health)
+	assert.Equal(t, map[string]string{"hana_sr_health": "critical"}, partialHealth)
 }
 
 func TestTransformClusterData_HANAScaleUp(t *testing.T) {

--- a/web/datapipeline/health_projector.go
+++ b/web/datapipeline/health_projector.go
@@ -1,0 +1,58 @@
+package datapipeline
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/trento-project/trento/web/entities"
+	"github.com/trento-project/trento/web/models"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+func ProjectHealth(db *gorm.DB, healthID, healthType, healthValue string) error {
+	var healthState entities.HealthState
+	var partialHealths map[string]string
+
+	err := db.Where("id = ?", healthID).First(&healthState).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			healthState.ID = healthID
+			partialHealths = make(map[string]string)
+		} else {
+			return err
+		}
+	} else {
+		err = json.Unmarshal(healthState.PartialHealths, &partialHealths)
+		if err != nil {
+			return err
+		}
+	}
+
+	partialHealths[healthType] = healthValue
+
+	partialHealthsJson, _ := json.Marshal(partialHealths)
+	healthState.Health = computeOverallHealth(partialHealths)
+	healthState.PartialHealths = (datatypes.JSON)(partialHealthsJson)
+
+	return db.Clauses(clause.OnConflict{
+		UpdateAll: true,
+	}).Create(healthState).Error
+}
+
+func computeOverallHealth(partialHealths map[string]string) string {
+	health := models.HealthSummaryHealthPassing
+	for _, pHealth := range partialHealths {
+		switch {
+		case pHealth == models.HealthSummaryHealthCritical:
+			health = models.HealthSummaryHealthCritical
+		case health != models.HealthSummaryHealthCritical && pHealth == models.HealthSummaryHealthWarning:
+			health = models.HealthSummaryHealthWarning
+		case health == models.HealthSummaryHealthPassing && pHealth == models.HealthSummaryHealthUnknown:
+			health = models.HealthSummaryHealthUnknown
+		}
+	}
+
+	return health
+}

--- a/web/datapipeline/health_projector_test.go
+++ b/web/datapipeline/health_projector_test.go
@@ -1,0 +1,151 @@
+package datapipeline
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	_ "github.com/trento-project/trento/test"
+	"github.com/trento-project/trento/test/helpers"
+	"github.com/trento-project/trento/web/entities"
+	"gorm.io/gorm"
+)
+
+type HealthProjectorTestSuite struct {
+	suite.Suite
+	db *gorm.DB
+	tx *gorm.DB
+}
+
+func TestHealthProjectorTestSuite(t *testing.T) {
+	suite.Run(t, new(HealthProjectorTestSuite))
+}
+
+func (suite *HealthProjectorTestSuite) SetupSuite() {
+	suite.db = helpers.SetupTestDatabase(suite.T())
+
+	suite.db.AutoMigrate(entities.HealthState{})
+}
+
+func (suite *HealthProjectorTestSuite) TearDownSuite() {
+	suite.db.Migrator().DropTable(entities.HealthState{})
+}
+
+func (suite *HealthProjectorTestSuite) SetupTest() {
+	suite.tx = suite.db.Begin()
+}
+
+func (suite *HealthProjectorTestSuite) TearDownTest() {
+	suite.tx.Rollback()
+}
+
+func (suite *HealthProjectorTestSuite) Test_ProjectHealth() {
+	err := ProjectHealth(suite.tx, "1", "my_health_value", "passing")
+	suite.NoError(err)
+
+	var health entities.HealthState
+	suite.tx.First(&health)
+
+	var partialHealth map[string]string
+	json.Unmarshal(health.PartialHealths, &partialHealth)
+
+	suite.Equal("1", health.ID)
+	suite.Equal("passing", health.Health)
+	suite.Equal(map[string]string{"my_health_value": "passing"}, partialHealth)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ProjectHealth_Update() {
+	partialHealths1, _ := json.Marshal(map[string]string{"my_health_value": "passing"})
+	suite.tx.Create(&entities.HealthState{
+		ID:             "1",
+		Health:         "passing",
+		PartialHealths: partialHealths1,
+	})
+
+	err := ProjectHealth(suite.tx, "1", "my_health_value", "critical")
+	suite.NoError(err)
+
+	var health entities.HealthState
+	suite.tx.First(&health)
+
+	var partialHealth map[string]string
+	json.Unmarshal(health.PartialHealths, &partialHealth)
+
+	suite.Equal("1", health.ID)
+	suite.Equal("critical", health.Health)
+	suite.Equal(map[string]string{"my_health_value": "critical"}, partialHealth)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ProjectHealth_New() {
+	partialHealths1, _ := json.Marshal(map[string]string{"my_health_value": "passing"})
+	suite.tx.Create(&entities.HealthState{
+		ID:             "1",
+		Health:         "passing",
+		PartialHealths: partialHealths1,
+	})
+
+	err := ProjectHealth(suite.tx, "1", "my_new_health", "warning")
+	suite.NoError(err)
+
+	var health entities.HealthState
+	suite.tx.First(&health)
+
+	var partialHealth map[string]string
+	json.Unmarshal(health.PartialHealths, &partialHealth)
+
+	suite.Equal("1", health.ID)
+	suite.Equal("warning", health.Health)
+	suite.Equal(
+		map[string]string{
+			"my_health_value": "passing",
+			"my_new_health":   "warning",
+		},
+		partialHealth,
+	)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ComputeOverallHealth_Passing() {
+	health := computeOverallHealth(
+		map[string]string{
+			"health":       "passing",
+			"other_health": "passing",
+		},
+	)
+	suite.Equal("passing", health)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ComputeOverallHealth_Unknown() {
+	health := computeOverallHealth(
+		map[string]string{
+			"health":         "passing",
+			"unknonw_health": "unknown",
+			"other_health":   "passing",
+		},
+	)
+	suite.Equal("unknown", health)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ComputeOverallHealth_Warning() {
+	health := computeOverallHealth(
+		map[string]string{
+			"health":         "passing",
+			"warning_health": "warning",
+			"unknonw_health": "unknown",
+			"other_health":   "passing",
+		},
+	)
+	suite.Equal("warning", health)
+}
+
+func (suite *HealthProjectorTestSuite) Test_ComputeOverallHealth_Critical() {
+	health := computeOverallHealth(
+		map[string]string{
+			"health":          "passing",
+			"critical_health": "critical",
+			"warning_health":  "warning",
+			"unknonw_health":  "unknown",
+			"other_health":    "passing",
+		},
+	)
+	suite.Equal("critical", health)
+}

--- a/web/entities/cluster.go
+++ b/web/entities/cluster.go
@@ -14,6 +14,7 @@ type Cluster struct {
 	SID             string `gorm:"column:sid"`
 	ResourcesNumber int
 	HostsNumber     int
+	Health          *HealthState  `gorm:"foreignkey:id"`
 	Tags            []*models.Tag `gorm:"polymorphic:Resource;polymorphicValue:clusters"`
 	UpdatedAt       time.Time
 	Hosts           []*Host        `gorm:"foreignkey:cluster_id"`
@@ -61,6 +62,11 @@ func (c *Cluster) ToModel() *models.Cluster {
 		tags = append(tags, tag.Value)
 	}
 
+	health := models.HealthSummaryHealthUnknown
+	if c.Health != nil {
+		health = c.Health.Health
+	}
+
 	return &models.Cluster{
 		ID:              c.ID,
 		Name:            c.Name,
@@ -68,6 +74,7 @@ func (c *Cluster) ToModel() *models.Cluster {
 		SID:             c.SID,
 		ResourcesNumber: c.ResourcesNumber,
 		HostsNumber:     c.HostsNumber,
+		Health:          health,
 		Tags:            tags,
 	}
 }

--- a/web/entities/health_state.go
+++ b/web/entities/health_state.go
@@ -1,0 +1,18 @@
+package entities
+
+import (
+	"gorm.io/datatypes"
+)
+
+type HealthState struct {
+	ID             string `gorm:"primaryKey"`
+	Health         string
+	PartialHealths datatypes.JSON
+}
+
+// PartialHealths is something like
+// {"config_checks": "passing", "hana_sr_health": "passing"}
+
+// The Health and PartialHealths are changed upon events:
+// config_checks when we receive new check results
+// hana_sr_health when we discover new cluster data

--- a/web/models/cluster.go
+++ b/web/models/cluster.go
@@ -10,8 +10,13 @@ const (
 	HANAStatusSecondary     = "Secondary"
 	HANAStatusFailed        = "Failed"
 	HANAStatusUnknown       = "Unknown"
-	HANASrHealth4           = "4"
-	HANASrSyncSOK           = "SOK"
+	// More information about HANASrHealthOK and HANASrSyncSOK:
+	// https://help.sap.com/viewer/4e9b18c116aa42fc84c7dbfd02111aba/2.0.05/en-US/d112a740dfb34dbda309d89e675dd99f.html
+	// https://github.com/SUSE/SAPHanaSR/blob/master/ra/SAPHana#L188
+	// https://help.sap.com/viewer/4e9b18c116aa42fc84c7dbfd02111aba/2.0.05/en-US/f6b1bd1020984ee69e902b21b702c096.html
+	// https://github.com/SUSE/SAPHanaSR/blob/master/ra/SAPHana#L1171
+	HANASrHealthOK = "4"
+	HANASrSyncSOK  = "SOK"
 )
 
 type Cluster struct {

--- a/web/models/cluster.go
+++ b/web/models/cluster.go
@@ -10,6 +10,8 @@ const (
 	HANAStatusSecondary     = "Secondary"
 	HANAStatusFailed        = "Failed"
 	HANAStatusUnknown       = "Unknown"
+	HANASrHealth4           = "4"
+	HANASrSyncSOK           = "SOK"
 )
 
 type Cluster struct {

--- a/web/services/clusters_test.go
+++ b/web/services/clusters_test.go
@@ -27,12 +27,18 @@ func TestClustersServiceTestSuite(t *testing.T) {
 func (suite *ClustersServiceTestSuite) SetupSuite() {
 	suite.db = helpers.SetupTestDatabase(suite.T())
 
-	suite.db.AutoMigrate(entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{}, entities.ChecksResult{})
+	suite.db.AutoMigrate(
+		entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{},
+		models.ConnectionSettings{}, entities.ChecksResult{}, entities.HealthState{},
+	)
 	loadClustersFixtures(suite.db)
 }
 
 func (suite *ClustersServiceTestSuite) TearDownSuite() {
-	suite.db.Migrator().DropTable(entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{}, models.ConnectionSettings{}, entities.ChecksResult{})
+	suite.db.Migrator().DropTable(
+		entities.Cluster{}, entities.Host{}, models.Tag{}, models.SelectedChecks{},
+		models.ConnectionSettings{}, entities.ChecksResult{}, entities.HealthState{},
+	)
 }
 
 func (suite *ClustersServiceTestSuite) SetupTest() {
@@ -136,6 +142,27 @@ func loadClustersFixtures(db *gorm.DB) {
 				CloudData:     cloudData,
 			},
 		},
+	})
+
+	partialHealths1, _ := json.Marshal(map[string]string{"hana_sr_health": "passing"})
+	db.Create(&entities.HealthState{
+		ID:             "1",
+		Health:         "passing",
+		PartialHealths: partialHealths1,
+	})
+
+	partialHealths2, _ := json.Marshal(map[string]string{"hana_sr_health": "warning"})
+	db.Create(&entities.HealthState{
+		ID:             "2",
+		Health:         "warning",
+		PartialHealths: partialHealths2,
+	})
+
+	partialHealths3, _ := json.Marshal(map[string]string{"hana_sr_health": "critical"})
+	db.Create(&entities.HealthState{
+		ID:             "3",
+		Health:         "critical",
+		PartialHealths: partialHealths3,
 	})
 }
 


### PR DESCRIPTION
Hey folks! This is the improvement for the cluster health computation. It is based on projections in the discovery side and the checks results event. Hopefully it makes the work.
I have written some E2E tests and all goes green (they are not uploaded yet).

Some more details:
The partial healths fields is a map which stores all the partial healths of a resource, cluster in our case (but easy extendable for other resources like sap systems, hosts, etc). So the partial health is updated in the different events (now, when a new cluster discovery is done and the cluster checks results are executed). The 2 healths are stored, and the overall health computed.

I have a doubt with the new table though (`health_states`). I thinking if we should truncate the values of this table on web service boot up. This would have 2 benefits:
- If for some reason we need the change the partial healths labels (`hana_sr_health` and `config_checks` by now), we would get rid off them, and we wouldn't have zombie entries.
- We wouldn't have "old" health states. Maybe it is safe to restore the health to nothing on boot up, to not show old values, as it might be misleading.