### PR TITLE
Fix grafana embedding

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -127,7 +127,7 @@ jobs:
           cypress_trento_binary: /tmp/trento
           cypress_photofinish_binary: /tmp/photofinish
         with:
-          start: /tmp/trento web serve --log-level=error --db-host=postgres --grafana-url=http://grafana:3000 --grafana-password=admin
+          start: /tmp/trento web serve --log-level=error --db-host=postgres --grafana-api-url=http://grafana:3000 --grafana-password=admin
           working-directory: test/e2e
           headless: true
           wait-on-timeout: 30

--- a/cmd/web/config.go
+++ b/cmd/web/config.go
@@ -43,9 +43,10 @@ func LoadConfig() (*web.Config, error) {
 		CA:            ca,
 		DBConfig:      dbCmd.LoadConfig(),
 		GrafanaConfig: &grafana.Config{
-			URL:      viper.GetString("grafana-url"),
-			User:     viper.GetString("grafana-user"),
-			Password: viper.GetString("grafana-password"),
+			PublicURL: viper.GetString("grafana-public-url"),
+			ApiURL:    viper.GetString("grafana-api-url"),
+			User:      viper.GetString("grafana-user"),
+			Password:  viper.GetString("grafana-password"),
 		},
 	}, nil
 }

--- a/cmd/web/config_test.go
+++ b/cmd/web/config_test.go
@@ -59,9 +59,10 @@ func (suite *WebCmdTestSuite) TearDownTest() {
 			DBName:   "trento",
 		},
 		GrafanaConfig: &grafana.Config{
-			URL:      "http://grafana:3000",
-			User:     "adminuser",
-			Password: "password",
+			PublicURL: "http://grafana:3000",
+			ApiURL:    "http://grafana:3000",
+			User:      "adminuser",
+			Password:  "password",
 		},
 	}
 	config, err := LoadConfig()
@@ -85,7 +86,8 @@ func (suite *WebCmdTestSuite) TestConfigFromFlags() {
 		"--db-user=postgres",
 		"--db-password=password",
 		"--db-name=trento",
-		"--grafana-url=http://grafana:3000",
+		"--grafana-api-url=http://grafana:3000",
+		"--grafana-public-url=http://grafana:3000",
 		"--grafana-user=adminuser",
 		"--grafana-password=password",
 	})
@@ -104,7 +106,8 @@ func (suite *WebCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_DB_USER", "postgres")
 	os.Setenv("TRENTO_DB_PASSWORD", "password")
 	os.Setenv("TRENTO_DB_NAME", "trento")
-	os.Setenv("TRENTO_GRAFANA_URL", "http://grafana:3000")
+	os.Setenv("TRENTO_GRAFANA_PUBLIC_URL", "http://grafana:3000")
+	os.Setenv("TRENTO_GRAFANA_API_URL", "http://grafana:3000")
 	os.Setenv("TRENTO_GRAFANA_USER", "adminuser")
 	os.Setenv("TRENTO_GRAFANA_PASSWORD", "password")
 }

--- a/cmd/web/web.go
+++ b/cmd/web/web.go
@@ -46,7 +46,8 @@ func addServeCmd(webCmd *cobra.Command) {
 	var key string
 	var ca string
 
-	var grafanaURL string
+	var grafanaPublicURL string
+	var grafanaApiURL string
 	var grafanaUser string
 	var grafanaPassword string
 
@@ -65,7 +66,8 @@ func addServeCmd(webCmd *cobra.Command) {
 	serveCmd.Flags().StringVar(&key, "key", "", "mTLS server key")
 	serveCmd.Flags().StringVar(&ca, "ca", "", "mTLS Certificate Authority")
 
-	serveCmd.Flags().StringVar(&grafanaURL, "grafana-url", "http://localhost:3000", "Grafana URL")
+	serveCmd.Flags().StringVar(&grafanaPublicURL, "grafana-public-url", "", "Browsable Grafana URL, if not provided, the API url will be used. This is the base url for iframes embedding.")
+	serveCmd.Flags().StringVar(&grafanaApiURL, "grafana-api-url", "http://localhost:3000", "Grafana API URL")
 	serveCmd.Flags().StringVar(&grafanaUser, "grafana-user", "admin", "Grafana user")
 	serveCmd.Flags().StringVar(&grafanaPassword, "grafana-password", "", "Grafana password")
 

--- a/internal/grafana/grafana.go
+++ b/internal/grafana/grafana.go
@@ -21,9 +21,17 @@ import (
 var nodeDashboard []byte
 
 type Config struct {
-	URL      string
-	User     string
-	Password string
+	PublicURL string
+	ApiURL    string
+	User      string
+	Password  string
+}
+
+func (config Config) BaseUrl() string {
+	if config.PublicURL != "" {
+		return config.PublicURL
+	}
+	return config.ApiURL
 }
 
 func InitGrafana(ctx context.Context, config *Config) error {
@@ -36,7 +44,7 @@ func InitGrafana(ctx context.Context, config *Config) error {
 				return err
 			}
 
-			dashboardsURL := fmt.Sprintf("%s/%s", config.URL, "api/dashboards/db")
+			dashboardsURL := fmt.Sprintf("%s/%s", config.ApiURL, "api/dashboards/db")
 			req, err := http.NewRequest("POST", dashboardsURL, bytes.NewBuffer(nodeDashboard))
 			if err != nil {
 				return err
@@ -78,7 +86,7 @@ func createToken(config *Config) (string, error) {
 		"secondsToLive": 60,
 	})
 
-	u, err := url.Parse(config.URL)
+	u, err := url.Parse(config.ApiURL)
 	if err != nil {
 		log.Fatal("Invalid Grafana URL provided")
 	}

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,12 +1,12 @@
-#!BuildTag: trento/trento-server:0.3.5
-#!BuildTag: trento/trento-server:0.3.5-build%RELEASE%
+#!BuildTag: trento/trento-server:0.3.9
+#!BuildTag: trento/trento-server:0.3.9-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.3.8
+version: 0.3.9
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/charts/trento-web/Chart.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1

--- a/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
+++ b/packaging/helm/trento-server/charts/trento-web/templates/deployment.yaml
@@ -54,7 +54,9 @@ spec:
               value: "{{ .Values.webService.port }}"
             - name: TRENTO_COLLECTOR_PORT
               value: "{{ .Values.collectorService.port }}"
-            - name: TRENTO_GRAFANA_URL
+            - name: TRENTO_GRAFANA_PUBLIC_URL
+              value: /grafana
+            - name: TRENTO_GRAFANA_API_URL
               value: "http://{{ .Release.Name }}-{{ .Values.global.grafana.name }}"
             - name: TRENTO_GRAFANA_PASSWORD
               value: {{ $grafanaSecret | b64dec }}

--- a/test/fixtures/config/web.yaml
+++ b/test/fixtures/config/web.yaml
@@ -10,6 +10,7 @@ db-port: 6543
 db-user: postgres
 db-password: password
 db-name: trento
-grafana-url: http://grafana:3000
+grafana-api-url: http://grafana:3000
+grafana-public-url: http://grafana:3000
 grafana-user: adminuser
 grafana-password: password

--- a/web/app.go
+++ b/web/app.go
@@ -186,7 +186,7 @@ func NewAppWithDeps(config *Config, deps Dependencies) (*App, error) {
 	webEngine.GET("/eula", EulaShowHandler())
 	webEngine.POST("/accept-eula", EulaAcceptHandler(deps.settingsService))
 	webEngine.GET("/hosts", NewHostListHandler(deps.hostsService))
-	webEngine.GET("/hosts/:id", NewHostHandler(deps.hostsService, deps.subscriptionsService, config.GrafanaConfig.URL))
+	webEngine.GET("/hosts/:id", NewHostHandler(deps.hostsService, deps.subscriptionsService, config.GrafanaConfig.BaseUrl()))
 	webEngine.GET("/catalog", NewChecksCatalogHandler(deps.checksService))
 	webEngine.GET("/clusters", NewClusterListHandler(deps.clustersService))
 	webEngine.GET("/clusters/:id", NewClusterHandler(deps.clustersService))

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -24,9 +24,10 @@ func setupTestConfig() *Config {
 		Host: "",
 		Port: 80,
 		GrafanaConfig: &grafana.Config{
-			URL:      "localhost",
-			User:     "admin",
-			Password: "admin",
+			PublicURL: "localhost",
+			ApiURL:    "localhost",
+			User:      "admin",
+			Password:  "admin",
 		},
 	}
 }


### PR DESCRIPTION
In order to embed grafana we need a url/path that the browser can reach.

This requires splitting `ApiUrl` for initialization from `URL` for embedding