### PR TITLE
Fix health summary api

### DIFF
--- a/web/models/health_summary.go
+++ b/web/models/health_summary.go
@@ -10,9 +10,10 @@ const (
 type HealthSummary []SAPSystemHealthSummary
 
 type SAPSystemHealthSummary struct {
-	ID             string `json:"id"`
-	SID            string `json:"sid"`
-	ClustersHealth string `json:"clusters_health"`
-	DatabaseHealth string `json:"database_health"`
-	HostsHealth    string `json:"hosts_health"`
+	ID              string `json:"id"`
+	SID             string `json:"sid"`
+	SAPSystemHealth string `json:"sapsystem_health"`
+	ClustersHealth  string `json:"clusters_health"`
+	DatabaseHealth  string `json:"database_health"`
+	HostsHealth     string `json:"hosts_health"`
 }

--- a/web/services/health_summary_service_test.go
+++ b/web/services/health_summary_service_test.go
@@ -23,9 +23,10 @@ func (suite *HealthSummaryServiceTestSuite) TestGetHealthSummary() {
 
 	sapSystemsService.On("GetAllApplications", mock.Anything, mock.Anything).Return(models.SAPSystemList{
 		{
-			ID:   "application_id",
-			SID:  "HA1",
-			Type: models.SAPSystemTypeApplication,
+			ID:     "application_id",
+			SID:    "HA1",
+			Type:   models.SAPSystemTypeApplication,
+			Health: models.SAPSystemHealthPassing,
 			Instances: []*models.SAPSystemInstance{
 				{
 					HostID:    "netweaver01",
@@ -52,10 +53,6 @@ func (suite *HealthSummaryServiceTestSuite) TestGetHealthSummary() {
 
 	clustersService.On("GetAll", mock.Anything, mock.Anything).Return(models.ClusterList{
 		{
-			ID:     "cluster_id",
-			Health: models.CheckPassing,
-		},
-		{
 			ID:     "hana_cluster",
 			Health: models.CheckCritical,
 		},
@@ -76,8 +73,9 @@ func (suite *HealthSummaryServiceTestSuite) TestGetHealthSummary() {
 
 	suite.EqualValues(models.HealthSummary{{
 		ID: "application_id", SID: "HA1",
-		ClustersHealth: "critical",
-		DatabaseHealth: "passing",
-		HostsHealth:    "warning",
+		SAPSystemHealth: models.HealthSummaryHealthPassing,
+		ClustersHealth:  models.HealthSummaryHealthCritical,
+		DatabaseHealth:  models.HealthSummaryHealthPassing,
+		HostsHealth:     models.HealthSummaryHealthWarning,
 	}}, healthSummary)
 }


### PR DESCRIPTION
This PR adds SAPSystemHealth to the health summary API and fixes the health summary service so that it uses only the HANA clusters to compute the cluster aggregate health