### PR TITLE
Enable Grafana persistence

### DIFF
--- a/hack/helm/trento-dev/Chart.lock
+++ b/hack/helm/trento-dev/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: trento-server
   repository: file://../../../packaging/helm/trento-server
-  version: 0.3.8
-digest: sha256:296438dbc64a55fea561d037f5d6904a2599c88ff18ca2846bbccb2426bdfc6c
-generated: "2022-02-16T12:08:25.452419738+01:00"
+  version: 0.4.1
+digest: sha256:8db94b864c3e7eb9c0e1cb73762ae7dc1a586c388a3d59e27524e2801e36030e
+generated: "2022-02-22T12:29:53.450241777+01:00"

--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -6,7 +6,7 @@ description: The trento server chart contains all the components necessary to ru
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.4.0
+version: 0.4.1
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/values.yaml
+++ b/packaging/helm/trento-server/values.yaml
@@ -49,6 +49,8 @@ prometheus:
 
 grafana:
   enabled: true
+  persistence:
+    enabled: true
   admin:
     existingSecret: trento-server-grafana-secret
   grafana.ini:


### PR DESCRIPTION
This PR enables the Grafana persistence value in the helm chart, so that dashboards are persisted after rolling a pod