### PR TITLE
Exclude diagnostics service sap systems

### DIFF
--- a/agent/discovery/mocks/discovered_sap_system_mock.go
+++ b/agent/discovery/mocks/discovered_sap_system_mock.go
@@ -37,3 +37,18 @@ func NewDiscoveredSAPSystemApplicationMock() sapsystem.SAPSystemsList {
 
 	return s
 }
+
+func NewDiscoveredSAPSystemDiagnosticsMock() sapsystem.SAPSystemsList {
+	var s sapsystem.SAPSystemsList
+
+	jsonFile, err := os.Open("./test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json")
+	if err != nil {
+		panic(err)
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	json.Unmarshal(byteValue, &s)
+
+	return s
+}

--- a/internal/sapsystem/sapsystem_test.go
+++ b/internal/sapsystem/sapsystem_test.go
@@ -45,6 +45,11 @@ func fakeNewWebService(instNumber string) sapcontrol.WebService {
 				Propertytype: "string",
 				Value:        instance,
 			},
+			{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host",
+			},
 		},
 	}, nil)
 
@@ -112,7 +117,7 @@ func TestNewSAPSystem(t *testing.T) {
 
 	system, err := NewSAPSystem(appFS, "/usr/sap/DEV")
 
-	assert.Equal(t, Application, system.Type)
+	assert.Equal(t, Unknown, system.Type)
 	assert.Contains(t, system.Instances, "ASCS01")
 	assert.Contains(t, system.Instances, "ERS02")
 	assert.Equal(t, system.Profile, expectedProfile)
@@ -199,6 +204,27 @@ func TestSetSystemIdOther(t *testing.T) {
 	assert.Equal(t, "-", system.Id)
 }
 
+func TestSetSystemIdDiagnostics(t *testing.T) {
+	appFS := afero.NewMemMapFs()
+	appFS.MkdirAll("/etc", 0755)
+
+	machineIdContent := []byte(`dummy-machine-id`)
+
+	afero.WriteFile(
+		appFS, "/etc/machine-id",
+		machineIdContent, 0644)
+
+	system := &SAPSystem{
+		Type: DiagnosticsAgent,
+		SID:  "DAA",
+	}
+
+	system, err := setSystemId(appFS, system)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "d3d5dd5ec501127e0011a2531e3b11ff", system.Id)
+}
+
 func TestGetDatabases(t *testing.T) {
 	appFS := afero.NewMemMapFs()
 	appFS.MkdirAll("/usr/sap/DEV/SYS/global/hdb/mdc/", 0755)
@@ -266,9 +292,9 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 				Value:        "PRD",
 			},
 			{
-				Property:     "HANA Roles",
-				Propertytype: "type3",
-				Value:        "some hana value",
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host1",
 			},
 			{
 				Property:     "INSTANCE_NAME",
@@ -309,7 +335,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 				HttpPort:      50013,
 				HttpsPort:     50014,
 				StartPriority: "0.3",
-				Features:      "some features",
+				Features:      "HDB|HDB_WORKER",
 				Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 			},
 			{
@@ -318,7 +344,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 				HttpPort:      50113,
 				HttpsPort:     50114,
 				StartPriority: "0.3",
-				Features:      "some other features",
+				Features:      "HDB|HDB_WORKER",
 				Dispstatus:    sapcontrol.STATECOLOR_YELLOW,
 			},
 		},
@@ -381,10 +407,10 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					Propertytype: "string",
 					Value:        "HDB00",
 				},
-				"HANA Roles": &sapcontrol.InstanceProperty{
-					Property:     "HANA Roles",
-					Propertytype: "type3",
-					Value:        "some hana value",
+				"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+					Property:     "SAPLOCALHOST",
+					Propertytype: "string",
+					Value:        "host1",
 				},
 			},
 			Instances: map[string]*sapcontrol.SAPInstance{
@@ -394,7 +420,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					HttpPort:      50013,
 					HttpsPort:     50014,
 					StartPriority: "0.3",
-					Features:      "some features",
+					Features:      "HDB|HDB_WORKER",
 					Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 				},
 				"host2": &sapcontrol.SAPInstance{
@@ -403,7 +429,7 @@ func TestNewSAPInstanceDatabase(t *testing.T) {
 					HttpPort:      50113,
 					HttpsPort:     50114,
 					StartPriority: "0.3",
-					Features:      "some other features",
+					Features:      "HDB|HDB_WORKER",
 					Dispstatus:    sapcontrol.STATECOLOR_YELLOW,
 				},
 			},
@@ -519,6 +545,11 @@ func TestNewSAPInstanceApp(t *testing.T) {
 				Propertytype: "string",
 				Value:        "HDB00",
 			},
+			{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host1",
+			},
 		},
 	}, nil)
 
@@ -553,7 +584,7 @@ func TestNewSAPInstanceApp(t *testing.T) {
 				HttpPort:      50013,
 				HttpsPort:     50014,
 				StartPriority: "0.3",
-				Features:      "some features",
+				Features:      "MESSAGESERVER|ENQUE",
 				Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 			},
 			{
@@ -613,6 +644,11 @@ func TestNewSAPInstanceApp(t *testing.T) {
 					Propertytype: "string",
 					Value:        "HDB00",
 				},
+				"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+					Property:     "SAPLOCALHOST",
+					Propertytype: "string",
+					Value:        "host1",
+				},
 			},
 			Instances: map[string]*sapcontrol.SAPInstance{
 				"host1": &sapcontrol.SAPInstance{
@@ -621,7 +657,7 @@ func TestNewSAPInstanceApp(t *testing.T) {
 					HttpPort:      50013,
 					HttpsPort:     50014,
 					StartPriority: "0.3",
-					Features:      "some features",
+					Features:      "MESSAGESERVER|ENQUE",
 					Dispstatus:    sapcontrol.STATECOLOR_GREEN,
 				},
 				"host2": &sapcontrol.SAPInstance{
@@ -758,4 +794,128 @@ func TestFindInstances(t *testing.T) {
 		{"ERS10", "10"},
 	}
 	assert.ElementsMatch(t, expectedInstance, instances)
+}
+
+func TestDetectType_Database(t *testing.T) {
+	sapControl := &SAPControl{
+		Properties: map[string]*sapcontrol.InstanceProperty{
+			"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host2",
+			},
+		},
+		Instances: map[string]*sapcontrol.SAPInstance{
+			"host1": &sapcontrol.SAPInstance{
+				Hostname: "host1",
+				Features: "other",
+			},
+			"host2": &sapcontrol.SAPInstance{
+				Hostname: "host2",
+				Features: "HDB|HDB_WORKER",
+			},
+		},
+	}
+
+	instanceType, err := detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Database, instanceType)
+}
+
+func TestDetectType_Application(t *testing.T) {
+	sapControl := &SAPControl{
+		Properties: map[string]*sapcontrol.InstanceProperty{
+			"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host1",
+			},
+		},
+		Instances: map[string]*sapcontrol.SAPInstance{
+			"host1": &sapcontrol.SAPInstance{
+				Hostname: "host1",
+				Features: "MESSAGESERVER|ENQUE",
+			},
+		},
+	}
+
+	instanceType, err := detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Application, instanceType)
+
+	sapControl.Instances = map[string]*sapcontrol.SAPInstance{
+		"host1": &sapcontrol.SAPInstance{
+			Hostname: "host1",
+			Features: "ENQREP",
+		},
+	}
+
+	instanceType, err = detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Application, instanceType)
+
+	sapControl.Instances = map[string]*sapcontrol.SAPInstance{
+		"host1": &sapcontrol.SAPInstance{
+			Hostname: "host1",
+			Features: "ABAP|GATEWAY|ICMAN|IGS",
+		},
+	}
+
+	instanceType, err = detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Application, instanceType)
+}
+
+func TestDetectType_Diagnostics(t *testing.T) {
+	sapControl := &SAPControl{
+		Properties: map[string]*sapcontrol.InstanceProperty{
+			"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host1",
+			},
+		},
+		Instances: map[string]*sapcontrol.SAPInstance{
+			"host1": &sapcontrol.SAPInstance{
+				Hostname: "host1",
+				Features: "SMDAGENT",
+			},
+		},
+	}
+
+	instanceType, err := detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, DiagnosticsAgent, instanceType)
+}
+
+func TestDetectType_Unknown(t *testing.T) {
+	sapControl := &SAPControl{
+		Properties: map[string]*sapcontrol.InstanceProperty{
+			"SAPLOCALHOST": &sapcontrol.InstanceProperty{
+				Property:     "SAPLOCALHOST",
+				Propertytype: "string",
+				Value:        "host2",
+			},
+		},
+		Instances: map[string]*sapcontrol.SAPInstance{
+			"host1": &sapcontrol.SAPInstance{
+				Hostname: "host1",
+				Features: "other",
+			},
+			"host2": &sapcontrol.SAPInstance{
+				Hostname: "host2",
+				Features: "another",
+			},
+		},
+	}
+
+	instanceType, err := detectType(sapControl)
+
+	assert.NoError(t, err)
+	assert.Equal(t, Unknown, instanceType)
 }

--- a/test/e2e/cypress/fixtures/.photofinish.toml
+++ b/test/e2e/cypress/fixtures/.photofinish.toml
@@ -58,6 +58,10 @@ files = ["./sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system
 
 files = ["./sap-systems-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_sap_system_discovery_RED.json"]
 
+[sap-systems-overview-DAA]
+
+files = ["./sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json"]
+
 [cluster-4-SOK]
 
 files = ["./clusters-overview/13e8c25c-3180-5a9a-95c8-51ec38e50cfc_ha_cluster_discovery_4_SOK.json"]

--- a/test/e2e/cypress/fixtures/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/2ace860d-38e9-55f4-b051-faf4336e71d6_sap_system_discovery_DAA.json
@@ -1,0 +1,113 @@
+{
+  "agent_id": "2ace860d-38e9-55f4-b051-faf4336e71d6",
+  "discovery_type": "sap_system_discovery",
+  "payload": [
+    {
+      "Id": "a1e80e3e152a903662f7882fb3f8a851",
+      "SID": "DAA",
+      "Type": 3,
+      "Profile": {},
+      "Databases": null,
+      "Instances": {
+        "SMDA98": {
+          "Host": "vmhana01",
+          "Name": "SMDA98",
+          "Type": 3,
+          "SAPControl": {
+            "Instances": {
+              "vmhana01": {
+                "features": "SMDAGENT",
+                "hostname": "vmhana01",
+                "httpPort": 59813,
+                "dispstatus": "SAPControl-GREEN",
+                "instanceNr": 98,
+                "startPriority": "3"
+              }
+            },
+            "Processes": {
+              "jstart": {
+                "pid": 5197,
+                "name": "jstart",
+                "starttime": "2022 03 01 15:39:27",
+                "dispstatus": "SAPControl-GREEN",
+                "textstatus": "All processes running",
+                "description": "J2EE Server",
+                "elapsedtime": "17:06:31"
+              }
+            },
+            "Properties": {
+              "SAPSYSTEM": {
+                "value": "98",
+                "property": "SAPSYSTEM",
+                "propertytype": "Attribute"
+              },
+              "Webmethods": {
+                "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ABAPSetServerInactive,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile",
+                "property": "Webmethods",
+                "propertytype": "Attribute"
+              },
+              "Process List": {
+                "value": "GetProcessList",
+                "property": "Process List",
+                "propertytype": "NodeWebmethod"
+              },
+              "SAPLOCALHOST": {
+                "value": "vmhana01",
+                "property": "SAPLOCALHOST",
+                "propertytype": "Attribute"
+              },
+              "Access Points": {
+                "value": "GetAccessPointList",
+                "property": "Access Points",
+                "propertytype": "NodeWebmethod"
+              },
+              "INSTANCE_NAME": {
+                "value": "SMDA98",
+                "property": "INSTANCE_NAME",
+                "propertytype": "Attribute"
+              },
+              "SAPSYSTEMNAME": {
+                "value": "DAA",
+                "property": "SAPSYSTEMNAME",
+                "propertytype": "Attribute"
+              },
+              "StartPriority": {
+                "value": "3",
+                "property": "StartPriority",
+                "propertytype": "Attribute"
+              },
+              "J2EE GC History": {
+                "value": "J2EEGetVMGCHistory2,J2EEGetVMGCHistory",
+                "property": "J2EE GC History",
+                "propertytype": "NodeWebmethod"
+              },
+              "J2EE Heap Memory": {
+                "value": "J2EEGetVMHeapInfo",
+                "property": "J2EE Heap Memory",
+                "propertytype": "NodeWebmethod"
+              },
+              "J2EE Process Table": {
+                "value": "J2EEGetProcessList2,J2EEGetProcessList",
+                "property": "J2EE Process Table",
+                "propertytype": "NodeWebmethod"
+              },
+              "Protected Webmethods": {
+                "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
+                "property": "Protected Webmethods",
+                "propertytype": "Attribute"
+              },
+              "Parameter Documentation": {
+                "value": "http://vmhana01:59813/sapparamEN.html",
+                "property": "Parameter Documentation",
+                "propertytype": "NodeURL"
+              }
+            }
+          },
+          "HdbnsutilSRstate": null,
+          "HostConfiguration": null,
+          "SystemReplication": null
+        }
+      }
+    }
+  ]
+}

--- a/test/e2e/cypress/fixtures/sap-systems-overview/sap_systems_overview.feature
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/sap_systems_overview.feature
@@ -60,3 +60,9 @@ Feature: SAP Systems Overview
         And the page is refreshed
         Then the status of the 1st HANA instance in this SAP system is RED
         And the SAP system state is RED
+
+    Scenario: SAP diagnostic agent discoveries are not displayed
+        Given I navigate to the SAP Systems overview page
+        When a new SAP discovery with a SAP diagnostics agent is received
+        And the page is refreshed
+        Then the discovery with the SAP diagnostics agent is not displayed

--- a/test/e2e/cypress/integration/sap_systems_overview.js
+++ b/test/e2e/cypress/integration/sap_systems_overview.js
@@ -297,5 +297,12 @@ context('SAP Systems Overview', () => {
         cy.get('@instanceTableCell').eq(0).should('contain', 'error');
       });
     });
+    describe('SAP diagnostics agent', () => {
+      it(`should skip SAP diagnostics agent discovery visualization`, () => {
+        cy.loadScenario('sap-systems-overview-DAA');
+        cy.visit(`/sapsystems`);
+        cy.get('.eos-table').should('not.contain', 'DAA');
+      });
+    });
   });
 });

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
@@ -1,0 +1,109 @@
+[
+  {
+    "Id": "e06e328f8d6b0f46c1e66ffcd44d0dd7",
+    "SID": "DAA",
+    "Type": 3,
+    "Profile": {},
+    "Databases": null,
+    "Instances": {
+      "SMDA98": {
+        "Host": "vmhana01",
+        "Name": "SMDA98",
+        "Type": 3,
+        "SAPControl": {
+          "Instances": {
+            "vmhana01": {
+              "features": "SMDAGENT",
+              "hostname": "vmhana01",
+              "httpPort": 59813,
+              "dispstatus": "SAPControl-GREEN",
+              "instanceNr": 98,
+              "startPriority": "3"
+            }
+          },
+          "Processes": {
+            "jstart": {
+              "pid": 5197,
+              "name": "jstart",
+              "starttime": "2022 03 01 15:39:27",
+              "dispstatus": "SAPControl-GREEN",
+              "textstatus": "All processes running",
+              "description": "J2EE Server",
+              "elapsedtime": "17:06:31"
+            }
+          },
+          "Properties": {
+            "SAPSYSTEM": {
+              "value": "98",
+              "property": "SAPSYSTEM",
+              "propertytype": "Attribute"
+            },
+            "Webmethods": {
+              "value": "Start,InstanceStart,StartBypassHA,Bootstrap,Stop,InstanceStop,StopBypassHA,Shutdown,ParameterValue,GetProcessList,GetStartProfile,GetTraceFile,GetAlertTree,GetAlerts,RestartService,StopService,GetEnvironment,ListDeveloperTraces,ReadDeveloperTrace,RestartInstance,SendSignal,GetVersionInfo,GetQueueStatistic,GetInstanceProperties,OSExecute,ReadLogFile,AnalyseLogFiles,ListLogFiles,GetAccessPointList,GetSystemInstanceList,GetSystemUpdateList,StartSystem,StopSystem,RestartSystem,UpdateSystem,UpdateSCSInstance,CheckUpdateSystem,AccessCheck,GetProcessParameter,SetProcessParameter,SetProcessParameter2,CheckParameter,ShmDetach,GetNetworkId,GetSecNetworkId,RequestLogonFile,CreateSnapshot,ReadSnapshot,ListSnapshots,DeleteSnapshots,GetCallstack,ABAPReadSyslog,ABAPReadRawSyslog,ABAPGetWPTable,ABAPAcknowledgeAlerts,ABAPGetComponentList,ABAPCheckRFCDestinations,ABAPGetSystemWPTable,ABAPSetServerInactive,J2EEGetProcessList,J2EEGetProcessList2,J2EEControlProcess,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadCallStack,J2EEGetThreadTaskStack,J2EEGetSessionList,J2EEGetWebSessionList,J2EEGetWebSessionList2,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetApplicationAliasList,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetEJBSessionList,J2EEGetRemoteObjectList,J2EEGetClusterMsgList,J2EEGetSharedTableInfo,J2EEGetComponentList,J2EEControlComponents,ICMGetThreadList,ICMGetConnectionList,ICMGetCacheEntries,ICMGetProxyConnectionList,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,EnqGetLockTable,EnqRemoveLocks,EnqRemoveUserLocks,EnqGetStatistic,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,UpdateSystemPKI,UpdateInstancePSE,StorePSE,DeletePSE,CheckPSE,HACheckConfig,HACheckFailoverConfig,HAGetFailoverConfig,HAFailoverToNode,HASetMaintenanceMode,HACheckMaintenanceMode,ListConfigFiles,ReadConfigFile",
+              "property": "Webmethods",
+              "propertytype": "Attribute"
+            },
+            "Process List": {
+              "value": "GetProcessList",
+              "property": "Process List",
+              "propertytype": "NodeWebmethod"
+            },
+            "SAPLOCALHOST": {
+              "value": "vmhana01",
+              "property": "SAPLOCALHOST",
+              "propertytype": "Attribute"
+            },
+            "Access Points": {
+              "value": "GetAccessPointList",
+              "property": "Access Points",
+              "propertytype": "NodeWebmethod"
+            },
+            "INSTANCE_NAME": {
+              "value": "SMDA98",
+              "property": "INSTANCE_NAME",
+              "propertytype": "Attribute"
+            },
+            "SAPSYSTEMNAME": {
+              "value": "DAA",
+              "property": "SAPSYSTEMNAME",
+              "propertytype": "Attribute"
+            },
+            "StartPriority": {
+              "value": "3",
+              "property": "StartPriority",
+              "propertytype": "Attribute"
+            },
+            "J2EE GC History": {
+              "value": "J2EEGetVMGCHistory2,J2EEGetVMGCHistory",
+              "property": "J2EE GC History",
+              "propertytype": "NodeWebmethod"
+            },
+            "J2EE Heap Memory": {
+              "value": "J2EEGetVMHeapInfo",
+              "property": "J2EE Heap Memory",
+              "propertytype": "NodeWebmethod"
+            },
+            "J2EE Process Table": {
+              "value": "J2EEGetProcessList2,J2EEGetProcessList",
+              "property": "J2EE Process Table",
+              "propertytype": "NodeWebmethod"
+            },
+            "Protected Webmethods": {
+              "value": "ABAPAcknowledgeAlerts,ABAPCheckRFCDestinations,ABAPGetComponentList,ABAPGetSystemWPTable,ABAPGetWPTable,ABAPReadRawSyslog,ABAPReadSyslog,ABAPSetServerInactive,AnalyseLogFiles,Bootstrap,CheckParameter,CheckPSE,CheckUpdateSystem,ConfigureLogFileList,CreatePSECredential,CreateSnapshot,DeletePSE,DeleteSnapshots,EnqGetLockTable,EnqGetStatistic,EnqRemoveLocks,EnqRemoveUserLocks,GetAccessPointList,GetAlerts,GetAlertTree,GetCallstack,GetEnvironment,GetLogFileList,GetProcessParameter,GetQueueStatistic,GetStartProfile,GetSystemUpdateList,GetTraceFile,GetVersionInfo,GWCancelConnections,GWDeleteClients,GWDeleteConnections,GWGetConnectionList,GWGetClientList,HACheckConfig,HACheckFailoverConfig,HACheckMaintenanceMode,HAFailoverToNode,HAGetFailoverConfig,HASetMaintenanceMode,ICMGetCacheEntries,ICMGetConnectionList,ICMGetProxyConnectionList,ICMGetThreadList,InstanceStart,InstanceStop,J2EEControlCluster,J2EEControlComponents,J2EEControlProcess,J2EEDisableDbgSession,J2EEEnableDbgSession,J2EEGetApplicationAliasList,J2EEGetCacheStatistic,J2EEGetCacheStatistic2,J2EEGetClusterMsgList,J2EEGetComponentList,J2EEGetEJBSessionList,J2EEGetProcessList,J2EEGetProcessList2,J2EEGetRemoteObjectList,J2EEGetSessionList,J2EEGetSharedTableInfo,J2EEGetThreadCallStack,J2EEGetThreadList,J2EEGetThreadList2,J2EEGetThreadTaskStack,J2EEGetVMGCHistory,J2EEGetVMGCHistory2,J2EEGetVMHeapInfo,J2EEGetWebSessionList,J2EEGetWebSessionList2,ListConfigFiles,ListDeveloperTraces,ListLogFiles,ListSnapshots,OSExecute,ParameterValue,ReadConfigFile,ReadDeveloperTrace,ReadLogFile,ReadSnapshot,RestartInstance,RestartService,RestartSystem,SendSignal,SetProcessParameter,SetProcessParameter2,ShmDetach,Shutdown,Start,StartBypassHA,StartSystem,Stop,StopBypassHA,StopService,StopSystem,StorePSE,UpdateInstancePSE,UpdateSCSInstance,UpdateSystem,UpdateSystemPKI,WebDispGetServerList,WebDispGetGroupList,WebDispGetVirtHostList,WebDispGetUrlPrefixList,GetAgentConfig,GetListOfMaByCusGrp,GetMcInLocalMs,GetMtesByRequestTable,GetMtListByMtclass,InfoGetTree,MscCustomizeWrite,MscDeleteLines,MscReadCache,MsGetLocalMsInfo,MsGetMteclsInLocalMs,MtChangeStatus,MtCustomizeWrite,MtDbsetToWpsetByTid,MtDestroyMarkNTry,MteGetByToolRunstatus,MtGetAllToCust,MtGetAllToolsToSet,MtGetMteinfo,MtGetTidByName,MtRead,MtReset,PerfCustomizeWrite,PerfRead,PerfReadSmoothData,ReadDirectory,ReadFile,ReadProfileParameters,ReferenceRead,Register,RequestLogonFile,SnglmgsCustomizeWrite,SystemObjectSetValue,TextAttrRead,ToolGetEffective,ToolSet,ToolSetRuntimeStatus,TriggerDataCollection,Unregister,UtilAlChangeStatus,UtilMtGetAidByTid,UtilMtGetTreeLocal,UtilMtReadAll,UtilReadRawalertByAid,UtilSnglmsgReadRawdata",
+              "property": "Protected Webmethods",
+              "propertytype": "Attribute"
+            },
+            "Parameter Documentation": {
+              "value": "http://vmhana01:59813/sapparamEN.html",
+              "property": "Parameter Documentation",
+              "propertytype": "NodeURL"
+            }
+          }
+        },
+        "HdbnsutilSRstate": null,
+        "HostConfiguration": null,
+        "SystemReplication": null
+      }
+    }
+  }
+]

--- a/web/datapipeline/sap_systems_projector.go
+++ b/web/datapipeline/sap_systems_projector.go
@@ -52,6 +52,9 @@ func SAPSystemsProjector_SAPSystemsDiscoveryHandler(dataCollectedEvent *DataColl
 			if hdb, ok := s.Profile["dbs/hdb/dbname"]; ok {
 				dbName = hdb.(string)
 			}
+		case 3:
+			log.Infof("SAP diagnostics agent with %s identifier found. Skipping projection", s.SID)
+			continue
 		}
 
 		var instances []entities.SAPSystemInstance

--- a/web/datapipeline/sap_systems_projector_test.go
+++ b/web/datapipeline/sap_systems_projector_test.go
@@ -168,3 +168,20 @@ func (s *SAPSystemsProjectorTestSuite) Test_SAPSystemDiscoveryHandler_Applicatio
 	s.Equal(50213, projectedSAPSystemInstance.HttpPort)
 	s.Equal(50214, projectedSAPSystemInstance.HttpsPort)
 }
+
+func (s *SAPSystemsProjectorTestSuite) Test_SAPSystemDiscoveryHandler_Diagnostics() {
+	discoveredSAPSystemMock := mocks.NewDiscoveredSAPSystemDiagnosticsMock()
+
+	requestBody, _ := json.Marshal(discoveredSAPSystemMock)
+	SAPSystemsProjector_SAPSystemsDiscoveryHandler(&DataCollectedEvent{
+		ID:            1,
+		AgentID:       "agent_id",
+		DiscoveryType: SAPsystemDiscovery,
+		Payload:       requestBody,
+	}, s.tx)
+
+	var projectedSAPSystemInstance entities.SAPSystemInstance
+	result := s.tx.First(&projectedSAPSystemInstance)
+
+	s.Equal(int64(0), result.RowsAffected)
+}

--- a/web/templates/blocks/sap_instance.html.tmpl
+++ b/web/templates/blocks/sap_instance.html.tmpl
@@ -11,7 +11,7 @@
             </tr>
             </thead>
             <tbody>
-            {{- $SAPSystem := . }}
+            {{- range $Key, $SAPSystem := . }}
             {{- range .Instances }}
                 <tr>
                     <td>{{ $SAPSystem.ID }}</td>
@@ -20,6 +20,7 @@
                     <td>{{ .Features }}</td>
                     <td>{{ .InstanceNumber }}</td>
                 </tr>
+            {{- end  }}
             {{- else }}
                 {{ template "empty_table_body" 5}}
             {{- end }}

--- a/web/templates/host.html.tmpl
+++ b/web/templates/host.html.tmpl
@@ -132,9 +132,7 @@
         {{- if ne (len .Host.SAPSystems) 0 }}
             <p class='clearfix'></p>
             <h2>SAP instances</h2>
-            {{- range $Key, $SAPSystem := .Host.SAPSystems }}
-                    {{ template "sap_instance" $SAPSystem }}
-            {{- end }}
+            {{ template "sap_instance" .Host.SAPSystems }}
             <hr/>
         {{- end }}
         <p class='clearfix'></p>


### PR DESCRIPTION
Implement the SAP diagnostics agent (DAA usually) detection. When this instance is discovered, the projection is skipped, as we don't want to handle this instance type by now. We will see what to do in the future.

The diagnostics agent instance id is computed using the `/etc/machine-id` as this sap instance is host specific, it is not a distributed deployment. In this case, the agent id and system id will match. Let me know if you have some better suggestion.

The instance type detection has been changed to use the `Features` field with regexp, as this field gives exactly the type (some types are part of the application layer).

Besides that, I have added some test.

FYI: @abravosuse

PD: I have included a small change in the templating, to unify the SAP instances table headers usage. It is here: https://github.com/trento-project/trento/pull/849/commits/8c3b92253c37ac7675dcf82848a89cf06ab5b770
I could remove this commit in any case, but well, it doesn't almost affect. I found it ugly to see when 2 sap systems are discovered, but we won't have this situation often as we won't show diagnostics agents as SAP systems anymore