### PR TITLE
Associate attached database properly when the database name is resolved

### DIFF
--- a/internal/sapsystem/sapsystem_test.go
+++ b/internal/sapsystem/sapsystem_test.go
@@ -273,6 +273,19 @@ ERR:::
 	assert.ElementsMatch(t, expectedDbs, dbs)
 }
 
+func TestGetDBAddress(t *testing.T) {
+	s := &SAPSystem{Profile: SAPProfile{"SAPDBHOST": "localhost"}}
+	addr, err := getDBAddress(s)
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", addr)
+}
+
+func TestGetDBAddress_ResolveError(t *testing.T) {
+	s := &SAPSystem{Profile: SAPProfile{"SAPDBHOST": "other"}}
+	_, err := getDBAddress(s)
+	assert.EqualError(t, err, "could not resolve \"other\" hostname")
+}
+
 func TestNewSAPInstanceDatabase(t *testing.T) {
 	mockWebService := new(sapControlMocks.WebService)
 	mockCommand := new(sapSystemMocks.CustomCommand)

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/098fc159-3ed6-58e7-91be-38fda8a833ea_sap_system_discovery.json
@@ -6,8 +6,9 @@
       "Id": "d01fdc69aeba7bd5133b210eb2884853",
       "SID": "NWQ",
       "Type": 2,
+      "DBAddress": "10.90.1.13",
       "Profile": {
-        "SAPDBHOST": "10.90.1.13",
+        "SAPDBHOST": "ha-cluster.suse.de",
         "dbms/name": "HDQ",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/0fc07435-7ee2-54ca-b0de-fb27ffdc5deb_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "97a1e70aeff3c0685d65c4c3d32d533b",
       "SID": "NWP",
       "Type": 2,
+      "DBAddress": "10.80.1.13",
       "Profile": {
         "SAPDBHOST": "10.80.1.13",
         "dbms/name": "HDP",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/116d49bd-85e1-5e59-b820-83f66db8800c_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "97a1e70aeff3c0685d65c4c3d32d533b",
       "SID": "NWP",
       "Type": 2,
+      "DBAddress": "10.80.1.13",
       "Profile": {
         "SAPDBHOST": "10.80.1.13",
         "dbms/name": "HDP",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/25677e37-fd33-5005-896c-9275b1284534_sap_system_discovery.json
@@ -6,8 +6,9 @@
       "Id": "d01fdc69aeba7bd5133b210eb2884853",
       "SID": "NWQ",
       "Type": 2,
+      "DBAddress": "10.90.1.13",
       "Profile": {
-        "SAPDBHOST": "10.90.1.13",
+        "SAPDBHOST": "ha-cluster.suse.de",
         "dbms/name": "HDQ",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/3711ea88-9ccc-5b07-8f9d-042be449d72b_sap_system_discovery.json
@@ -6,8 +6,9 @@
       "Id": "d01fdc69aeba7bd5133b210eb2884853",
       "SID": "NWQ",
       "Type": 2,
+      "DBAddress": "10.90.1.13",
       "Profile": {
-        "SAPDBHOST": "10.90.1.13",
+        "SAPDBHOST": "ha-cluster.suse.de",
         "dbms/name": "HDQ",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/4b30a6af-4b52-5bda-bccb-f2248a12c992_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "97a1e70aeff3c0685d65c4c3d32d533b",
       "SID": "NWP",
       "Type": 2,
+      "DBAddress": "10.80.1.13",
       "Profile": {
         "SAPDBHOST": "10.80.1.13",
         "dbms/name": "HDP",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/81e9b629-c1e7-538f-bff1-47d3a6580522_sap_system_discovery.json
@@ -6,8 +6,9 @@
       "Id": "d01fdc69aeba7bd5133b210eb2884853",
       "SID": "NWQ",
       "Type": 2,
+      "DBAddress": "10.90.1.13",
       "Profile": {
-        "SAPDBHOST": "10.90.1.13",
+        "SAPDBHOST": "ha-cluster.suse.de",
         "dbms/name": "HDQ",
         "dbms/type": "hdb",
         "gw/acl_mode": "1",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/a3297d85-5e8b-5ac5-b8a3-55eebc2b8d12_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "97a1e70aeff3c0685d65c4c3d32d533b",
       "SID": "NWP",
       "Type": 2,
+      "DBAddress": "10.80.1.13",
       "Profile": {
         "SAPDBHOST": "10.80.1.13",
         "dbms/name": "HDP",

--- a/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
+++ b/test/e2e/cypress/fixtures/healthy-27-node-SAP-cluster/fb2c6b8a-9915-5969-a6b7-8b5a42de1971_sap_system_discovery.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
+++ b/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GRAY.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
+++ b/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_GREEN.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
+++ b/test/e2e/cypress/fixtures/sap-system-details/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_YELLOW.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-system-details/newagent_sap_system_discovery_new.json
+++ b/test/e2e/cypress/fixtures/sap-system-details/newagent_sap_system_discovery_new.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/1b0e9297-97dd-55d6-9874-8efde4d84c90_sap_system_discovery_RED.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-systems-overview/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery_GRAY.json
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/7269ee51-5007-5849-aaa7-7c4a98b0c9ce_sap_system_discovery_GRAY.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/9a3ec76a-dd4f-5013-9cf0-5eb4cf89898f_sap_system_discovery_YELLOW.json
@@ -6,6 +6,7 @@
       "Id": "a1e80e3e152a903662f7882fb3f8a851",
       "SID": "NWD",
       "Type": 2,
+      "DBAddress": "10.100.1.13",
       "Profile": {
         "SAPDBHOST": "10.100.1.13",
         "dbms/name": "HDD",

--- a/test/e2e/cypress/fixtures/sap-systems-overview/available_sap_systems.js
+++ b/test/e2e/cypress/fixtures/sap-systems-overview/available_sap_systems.js
@@ -189,7 +189,7 @@ export const availableSAPSystems = [
       sid: 'HDQ',
       id: '9953878f07bb54cac20d5d5d7ff08af2',
       tenant: 'HDQ',
-      dbAddress: '10.90.1.13',
+      dbAddress: 'ha-cluster.suse.de',
     },
     instances: [
       {

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_application.json
@@ -6,6 +6,7 @@
       "Id": "7b65dc281f9fae2c8e68e6cab669993e",
       "SID": "HA1",
       "Type": 2,
+      "DBAddress": "10.74.1.12",
       "Profile": {
         "SAPDBHOST": "10.74.1.12",
         "gw/acl_mode": "1",

--- a/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/expected_published_sap_system_discovery_database.json
@@ -6,6 +6,7 @@
       "Id": "e06e328f8d6b0f46c1e66ffcd44d0dd7",
       "SID": "PRD",
       "Type": 1,
+      "DBAddress": "",
       "Profile": {
         "SAPGLOBALHOST": "vmhana01",
         "SAPSYSTEMNAME": "PRD",

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_application.json
@@ -3,6 +3,7 @@
     "Id": "7b65dc281f9fae2c8e68e6cab669993e",
     "SID": "HA1",
     "Type": 2,
+    "DBAddress": "10.74.1.12",
     "Profile": {
       "SAPDBHOST": "10.74.1.12",
       "gw/acl_mode": "1",

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_database.json
@@ -3,6 +3,7 @@
     "Id": "e06e328f8d6b0f46c1e66ffcd44d0dd7",
     "SID": "PRD",
     "Type": 1,
+    "DBAddress": "",
     "Profile": {
       "SAPGLOBALHOST": "vmhana01",
       "SAPSYSTEMNAME": "PRD",

--- a/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
+++ b/test/fixtures/discovery/sap_system/sap_system_discovery_diagnostics.json
@@ -5,6 +5,7 @@
     "Type": 3,
     "Profile": {},
     "Databases": null,
+    "DBAddress": "",
     "Instances": {
       "SMDA98": {
         "Host": "vmhana01",

--- a/web/datapipeline/sap_systems_projector.go
+++ b/web/datapipeline/sap_systems_projector.go
@@ -36,7 +36,7 @@ func SAPSystemsProjector_SAPSystemsDiscoveryHandler(dataCollectedEvent *DataColl
 	}
 
 	for _, s := range discoveredSAPSystems {
-		var sapSystemType, dbHost, dbName string
+		var sapSystemType, dbHost, dbName, dbAddress string
 		var tenants []string
 
 		switch s.Type {
@@ -52,6 +52,7 @@ func SAPSystemsProjector_SAPSystemsDiscoveryHandler(dataCollectedEvent *DataColl
 			if hdb, ok := s.Profile["dbs/hdb/dbname"]; ok {
 				dbName = hdb.(string)
 			}
+			dbAddress = s.DBAddress
 		case 3:
 			log.Infof("SAP diagnostics agent with %s identifier found. Skipping projection", s.SID)
 			continue
@@ -60,13 +61,14 @@ func SAPSystemsProjector_SAPSystemsDiscoveryHandler(dataCollectedEvent *DataColl
 		var instances []entities.SAPSystemInstance
 		for _, i := range s.Instances {
 			instance := entities.SAPSystemInstance{
-				AgentID: dataCollectedEvent.AgentID,
-				ID:      s.Id,
-				SID:     s.SID,
-				Type:    sapSystemType,
-				Tenants: tenants,
-				DBHost:  dbHost,
-				DBName:  dbName,
+				AgentID:   dataCollectedEvent.AgentID,
+				ID:        s.Id,
+				SID:       s.SID,
+				Type:      sapSystemType,
+				Tenants:   tenants,
+				DBHost:    dbHost,
+				DBName:    dbName,
+				DBAddress: dbAddress,
 			}
 
 			var features string

--- a/web/datapipeline/sap_systems_projector.go
+++ b/web/datapipeline/sap_systems_projector.go
@@ -102,7 +102,7 @@ func SAPSystemsProjector_SAPSystemsDiscoveryHandler(dataCollectedEvent *DataColl
 			"id", "sid", "type", "features", "instance_number",
 			"system_replication", "system_replication_status",
 			"sap_hostname", "start_priority", "http_port", "https_port", "status",
-			"tenants", "db_host", "db_name")
+			"tenants", "db_host", "db_name", "db_address")
 		if err != nil {
 			return err
 		}

--- a/web/entities/sap_system.go
+++ b/web/entities/sap_system.go
@@ -25,6 +25,7 @@ type SAPSystemInstance struct {
 	SystemReplicationStatus string
 	DBHost                  string
 	DBName                  string
+	DBAddress               string
 	Tenants                 pq.StringArray `gorm:"type:text[]"`
 	Host                    *Host          `gorm:"foreignKey:AgentID"`
 	UpdatedAt               time.Time
@@ -52,12 +53,13 @@ func (s SAPSystemInstances) ToModel() []*models.SAPSystem {
 			}
 
 			sapSystem = &models.SAPSystem{
-				ID:     i.ID,
-				Type:   i.Type,
-				SID:    i.SID,
-				DBName: i.DBName,
-				DBHost: i.DBHost,
-				Tags:   tags,
+				ID:        i.ID,
+				Type:      i.Type,
+				SID:       i.SID,
+				DBName:    i.DBName,
+				DBHost:    i.DBHost,
+				DBAddress: i.DBAddress,
+				Tags:      tags,
 			}
 			set[i.ID] = sapSystem
 		}

--- a/web/models/sap_system.go
+++ b/web/models/sap_system.go
@@ -22,6 +22,7 @@ type SAPSystem struct {
 	AttachedDatabase *SAPSystem
 	DBName           string
 	DBHost           string
+	DBAddress        string
 	Health           string
 	Tags             []string
 	// TODO: this is frontend specific, should be removed

--- a/web/services/sap_systems_test.go
+++ b/web/services/sap_systems_test.go
@@ -24,6 +24,7 @@ func sapSystemsFixtures() entities.SAPSystemInstances {
 			Status:         string(sapcontrol.STATECOLOR_RED),
 			DBHost:         "dbhost_1",
 			DBName:         "tenant",
+			DBAddress:      "192.168.1.10",
 			Host: &entities.Host{
 				AgentID:     "1",
 				Name:        "apphost",
@@ -54,6 +55,7 @@ func sapSystemsFixtures() entities.SAPSystemInstances {
 				Name:        "dbhost_1",
 				ClusterID:   "cluster_id_2",
 				ClusterName: "dbcluster",
+				IPAddresses: pq.StringArray{"192.168.1.10"},
 			},
 			Tags: []*models.Tag{
 				{
@@ -126,12 +128,13 @@ func (suite *SAPSystemsServiceTestSuite) TestSAPSystemsService_GetAllApplication
 
 	suite.EqualValues(models.SAPSystemList{
 		{
-			ID:     "sap_system_1",
-			SID:    "HA1",
-			Type:   models.SAPSystemTypeApplication,
-			DBHost: "dbhost_1",
-			DBName: "tenant",
-			Health: models.SAPSystemHealthCritical,
+			ID:        "sap_system_1",
+			SID:       "HA1",
+			Type:      models.SAPSystemTypeApplication,
+			DBHost:    "dbhost_1",
+			DBName:    "tenant",
+			DBAddress: "192.168.1.10",
+			Health:    models.SAPSystemHealthCritical,
 			Instances: []*models.SAPSystemInstance{
 				{
 					Features:       "features",


### PR DESCRIPTION
If the database name is not an IP address directly, and it must be resolved, this cannot be done in the server side, as the resolution most probably is different.
In order to fix it, the Database IP address must be discovered and sent from the agent.

This PR includes this auto-detection and adds a new field, `DBAddress` in the payload.
Later on, the data projection is slightly changed to include this new field and use to associate App and database.