### PR TITLE
Add persistence to postgresql deployment on helm

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,12 +1,12 @@
-#!BuildTag: trento/trento-server:0.4.3
-#!BuildTag: trento/trento-server:0.4.3-build%RELEASE%
+#!BuildTag: trento/trento-server:0.4.4
+#!BuildTag: trento/trento-server:0.4.4-build%RELEASE%
 apiVersion: v2
 name: trento-server
 description: The trento server chart contains all the components necessary to run a Trento server.
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates
-version: 0.4.3
+version: 0.4.4
 
 dependencies:
   - name: trento-web

--- a/packaging/helm/trento-server/templates/postgresql_pv.yaml
+++ b/packaging/helm/trento-server/templates/postgresql_pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Release.Name }}-postgresql-pv
+  namespace: {{ .Release.Namespace }}
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "{{ .Values.global.postgresql.persistence.mountPath }}"

--- a/packaging/helm/trento-server/templates/postgresql_pvc.yaml
+++ b/packaging/helm/trento-server/templates/postgresql_pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-postgresql-pv-claim
+  namespace: {{ .Release.Namespace }}
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/packaging/helm/trento-server/values.yaml
+++ b/packaging/helm/trento-server/values.yaml
@@ -7,6 +7,8 @@ global:
   postgresql:
     name: postgresql
     servicePort: 5432
+    persistence:
+      mountPath: /bitnami/postgresql
   grafana:
     name: grafana
   prometheus:
@@ -28,6 +30,12 @@ postgresql:
   postgresqlUsername: "postgres"
   postgresqlPassword: "postgres"
   postgresqlDatabase: "trento"
+  postgresqlDataDir: /bitnami/postgresql/trento
+  persistence:
+    existingClaim: "{{ .Release.Name }}-postgresql-pv-claim"
+    mountPath: /bitnami/postgresql
+  volumePermissions:
+    enabled: true
 
 prometheus:
   enabled: true


### PR DESCRIPTION
Add persistence to postgresql database, as by now, all the data is lost in machine reboot.

The implementation adds a permanent volume and permanent volume claim, together with some small changes in the values usage.

Unfortunately, I have not found the way to use the globals mountPath in the postgresql values (the value is duplicated) as the bitnami chart doesn't run template rendering