### PR TITLE
Add /usr/sbin to the PATH for the execution

### DIFF
--- a/runner/ansible/check.yml
+++ b/runner/ansible/check.yml
@@ -28,10 +28,14 @@
       delegate_to: localhost
 
     # Do not change the name. It is use in the trento callback call
-    - name: run_checks
-      include_role:
-        name: "{{ check_item.path }}"
-      loop: "{{ checks.files|sort(attribute='path') }}"
-      loop_control:
-        loop_var: check_item  # Do not change the name. It is use in the trento callback call
-      when: ((lookup("file", check_item.path+"/defaults/main.yml")|from_yaml).id|string)|default("") in cluster_selected_checks_list
+    - name: Run checks
+      block:
+      - name: run_checks
+        include_role:
+          name: "{{ check_item.path }}"
+        loop: "{{ checks.files|sort(attribute='path') }}"
+        loop_control:
+          loop_var: check_item  # Do not change the name. It is use in the trento callback call
+        when: ((lookup("file", check_item.path+"/defaults/main.yml")|from_yaml).id|string)|default("") in cluster_selected_checks_list
+      environment:
+        PATH: "/usr/sbin:{{ ansible_env.PATH }}"


### PR DESCRIPTION
Most of `crm` based tools are installed in `/usr/sbin` and it looks like not everyone has this directory in their PATH (or sudoers specification).
This change simply adds this directory to the execution PATH.

To reproduce the issue, change the next line in one of the hosts `/etc/sudoers` file:
```
Defaults secure_path="/usr/sbin:/usr/bin:/sbin:/bin"
```
And remove the `/usb/sbin` from there