### PR TITLE
Add helm chart license

### DIFF
--- a/packaging/helm/trento-server/Chart.yaml
+++ b/packaging/helm/trento-server/Chart.yaml
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 #!BuildTag: trento/trento-server:0.4.4
 #!BuildTag: trento/trento-server:0.4.4-build%RELEASE%
 apiVersion: v2


### PR DESCRIPTION
Added the license on the Chart.yaml required by submission guidelines.

BTW: do we need to explicitly state the license in the sub charts?