### PR TITLE
Allow adjustable polling rate in install-agent.sh

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -418,7 +418,7 @@ jobs:
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_REPO_OWNER: ${{ github.repository_owner }}
-      INTERVAL: ${{ secrets.TRENTO_DISCOVERY_INTERVAL }}
+      TRENTO_DISCOVERY_INTERVAL: ${{ secrets.TRENTO_DISCOVERY_INTERVAL }}
     steps:
       - uses: actions/checkout@v3
       - name: install and enable agents
@@ -427,7 +427,7 @@ jobs:
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
           do
             ssh "$TRENTO_USER@$target_host" "sudo zypper ref && sudo zypper in -y golang-github-prometheus-node_exporter"
-            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST" "--interval" "$INTERVAL"
+            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST" "--interval" "$TRENTO_DISCOVERY_INTERVAL"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -418,6 +418,7 @@ jobs:
       TRENTO_USER: ${{ secrets.TRENTO_USER }}
       TRENTO_SERVER_HOST: ${{ secrets.TRENTO_SERVER_HOST }}
       TRENTO_REPO_OWNER: ${{ github.repository_owner }}
+      INTERVAL: ${{ secrets.TRENTO_DISCOVERY_INTERVAL }}
     steps:
       - uses: actions/checkout@v3
       - name: install and enable agents
@@ -426,7 +427,7 @@ jobs:
           for target_host in ${TRENTO_AGENT_HOSTS//,/ }
           do
             ssh "$TRENTO_USER@$target_host" "sudo zypper ref && sudo zypper in -y golang-github-prometheus-node_exporter"
-            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST"
+            ssh "$TRENTO_USER@$target_host" "TRENTO_REPO_OWNER=$TRENTO_REPO_OWNER sudo --preserve-env=PATH,TRENTO_REPO_OWNER bash -s" -- < ./install-agent.sh "--rolling" "--use-tgz" "--ssh-address" "$target_host" "--server-ip" "$TRENTO_SERVER_HOST" "--interval" "$INTERVAL"
             ssh "$TRENTO_USER@$target_host" "sudo systemctl enable --now trento-agent.service"
           done
 

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -20,7 +20,8 @@ Arguments:
   --key             The path to the TLS key file. Required if --enable-mtls is set.
   --ca              The path to the TLS CA file. Required if --enable-mtls is set.
   --rolling         Use the rolling version instead of the stable one.
-  --use-tgz         Use the trento tar.gz file from GH releases rather than the RPM
+  --use-tgz         Use the trento tar.gz file from GH releases rather than the RPM.
+  --interval        The polling interval in seconds for the discovery.
   --help            Print this help.
 END
 }
@@ -46,6 +47,7 @@ ARGUMENT_LIST=(
     "ca:"
     "rolling"
     "use-tgz"
+    "interval:"
 )
 
 readonly TRENTO_VERSION=0.9.1
@@ -102,6 +104,11 @@ while [[ $# -gt 0 ]]; do
             shift 1
         ;;
 
+        --interval)
+            INTERVAL=$2
+            shift 2
+        ;;
+
         *)
             break
         ;;
@@ -117,6 +124,7 @@ enable-mtls: @ENABLE_MTLS@
 cert: @CERT@
 key: @KEY@
 ca: @CA@
+discovery-period: @INTERVAL@
 '
 
 . /etc/os-release
@@ -256,6 +264,7 @@ function install_trento_tgz() {
 
 function setup_trento() {
     local enable_mtls=${ENABLE_MTLS:-"false"}
+    local interval=${INTERVAL:-"10"}
 
     echo "* Generating trento-agent config..."
 
@@ -267,7 +276,8 @@ function setup_trento() {
         sed "s|@ENABLE_MTLS@|${enable_mtls}|g" |
         sed "s|@CERT@|${CERT}|g" |
         sed "s|@KEY@|${KEY}|g" |
-        sed "s|@CA@|${CA}|g" \
+        sed "s|@CA@|${CA}|g" |
+        sed "s|@INTERVAL@|${interval}|g" \
             > ${AGENT_CONFIG_FILE}
 }
 


### PR DESCRIPTION
This PR:
 - Adds a parameter in install-agent.sh to set the discovery interval for the agents
 - Makes use of that parameter from the `ci-cd.yaml` to set it to a new value more appropriate for our demo environment.
 
Notes:
 - The environment secret `TRENTO_DISCOVERY_INTERVAL` has already been added with a value of `90`.
 - I didn't want to adjust a new default value in the code as it might impact customers / partners that are already testing and would like to keep the 10s default.