### PR TITLE
Add missing resp body close

### DIFF
--- a/agent/discovery/collector/client.go
+++ b/agent/discovery/collector/client.go
@@ -92,6 +92,7 @@ func (c *client) Publish(discoveryType string, payload interface{}) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusAccepted {
 		return fmt.Errorf(
@@ -108,6 +109,7 @@ func (c *client) Heartbeat() error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
 		return fmt.Errorf("server responded with status code %d while sending heartbeat", resp.StatusCode)

--- a/web/telemetry/publisher.go
+++ b/web/telemetry/publisher.go
@@ -32,6 +32,7 @@ func (tp *TelemetryPublisher) Publish(telemetryName string, installationID uuid.
 	if err != nil {
 		return errors.Wrapf(err, "An error occurred while publishing telemetry %s", telemetryName)
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusAccepted {
 		return errors.Errorf("Unexpected response code %d while publishing telemetry %s", resp.StatusCode, telemetryName)


### PR DESCRIPTION
Closes the response body when publishing data to prevent file descriptor leaks

https://pkg.go.dev/net/http