### PR TITLE
Split subscription discovery to a 900 sec interval

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -18,6 +18,7 @@ import (
 func NewAgentCmd() *cobra.Command {
 	var sshAddress string
 	var discoveryPeriod int
+	var subscriptionDiscoveryPeriod int
 
 	var collectorHost string
 	var collectorPort int
@@ -48,6 +49,8 @@ func NewAgentCmd() *cobra.Command {
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
 	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 10, "Discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&subscriptionDiscoveryPeriod, "subscription-discovery-period", "", 900, "Subscription discovery mechanism loop period in seconds")
+	startCmd.Flags().MarkHidden("subscription-discovery-period")
 
 	startCmd.Flags().StringVar(&collectorHost, "collector-host", "localhost", "Data Collector host")
 	startCmd.Flags().IntVar(&collectorPort, "collector-port", 8081, "Data Collector port")

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -53,8 +53,9 @@ func LoadConfig() (*agent.Config, error) {
 			Key:           key,
 			CA:            ca,
 		},
-		InstanceName:    hostname,
-		SSHAddress:      sshAddress,
-		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Second,
+		InstanceName:                hostname,
+		SSHAddress:                  sshAddress,
+		DiscoveryPeriod:             time.Duration(viper.GetInt("discovery-period")) * time.Second,
+		SubscriptionDiscoveryPeriod: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
 	}, nil
 }

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -44,9 +44,10 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 	suite.cmd.Execute()
 
 	expectedConfig := &agent.Config{
-		InstanceName:    "some-hostname",
-		SSHAddress:      "some-ssh-address",
-		DiscoveryPeriod: 10 * time.Second,
+		InstanceName:                "some-hostname",
+		SSHAddress:                  "some-ssh-address",
+		DiscoveryPeriod:             10 * time.Second,
+		SubscriptionDiscoveryPeriod: 900 * time.Second,
 		CollectorConfig: &collector.Config{
 			CollectorHost: "localhost",
 			CollectorPort: 1337,


### PR DESCRIPTION
This PR's main goal is to reduce the possible load we are hitting our SCC service with. It attempts this by:
 - Splitting the subscription discovery from the rest of the discoveries so that we can set a separate interval
 - Increasing the default interval time to a tick per each 15 minutes.
 
In addition to this, we have added a hidden parameter in cobra to allow quickly adjusting this time interval. Feedback if this hidden param is a good idea or not is appreciated!