### PR TITLE
Split discovery intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ of existing clusters, rather than deploying new one.
 
 # Table of contents
 
+- [Trento](#trento)
+- [Table of contents](#table-of-contents)
 - [Features](#features)
 - [Introduction](#introduction)
 - [Installation](#installation)
@@ -35,18 +37,29 @@ of existing clusters, rather than deploying new one.
     - [Install K3S](#install-k3s)
     - [Install Helm and chart dependencies](#install-helm-and-chart-dependencies)
     - [Install the Trento Server Helm chart](#install-the-trento-server-helm-chart)
-    - [Other Helm chart usage examples:](#other-helm-chart-usage-examples-)
+    - [Other Helm chart usage examples:](#other-helm-chart-usage-examples)
   - [Manually running Trento](#manually-running-trento)
     - [Trento Agents](#trento-agents)
+      - [Publishing discovery data](#publishing-discovery-data)
+      - [Server](#server)
+      - [Agent](#agent)
     - [Trento Runner](#trento-runner)
       - [Starting the Trento Runner](#starting-the-trento-runner)
     - [Trento Web UI](#trento-web-ui)
 - [Configuration](#configuration)
+  - [Locations](#locations)
+  - [Formats](#formats)
+  - [Naming conventions](#naming-conventions)
+  - [Examples](#examples)
+  - [Environment Variables](#environment-variables)
 - [Development](#development)
   - [Helm development chart](#helm-development-chart)
   - [Build system](#build-system)
   - [Development dependencies](#development-dependencies)
   - [Docker](#docker)
+  - [End-to-end testing](#end-to-end-testing)
+    - [Adjusting environment variables to suit your own needs](#adjusting-environment-variables-to-suit-your-own-needs)
+    - [Further questions about E2E testing?](#further-questions-about-e2e-testing)
   - [Dump a scenario from a running cluster](#dump-a-scenario-from-a-running-cluster)
   - [SAPControl web service](#sapcontrol-web-service)
 - [Support](#support)
@@ -323,7 +336,7 @@ systemctl start trento-agent.service
 ```
 
 > If the discovery loop is being executed too frequently, and this impacts the Web interface performance, the agent
-> has the option to configure the discovery loop mechanism using the `--discovery-period` flag. Increasing this value improves the overall performance of the application
+> has the option to configure the discovery loop mechanism using the various `--<cloud,cluster,host,sapsystem>-discovery-period` flags. Increasing these value improves the overall performance of the application
 
 #### Publishing discovery data
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -46,10 +46,7 @@ func NewAgent(config *Config) (*Agent, error) {
 	var discoveries discovery.DiscoveryList
 
 	for _, initializer := range discoveryInitializers {
-		discoveries, err = discoveries.AddDiscovery(initializer, collectorClient, *config.DiscoveriesConfig)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not create a discovery")
-		}
+		discoveries = discoveries.AddDiscovery(initializer, collectorClient, *config.DiscoveriesConfig)
 	}
 
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -24,15 +24,19 @@ type Agent struct {
 	ctxCancel       context.CancelFunc
 }
 
+type DiscoveryPeriodConfig struct {
+	Cluster      time.Duration
+	SAPSystem    time.Duration
+	Cloud        time.Duration
+	Host         time.Duration
+	Subscription time.Duration
+}
+
 type Config struct {
-	InstanceName                string
-	SSHAddress                  string
-	ClusterDiscoveryPeriod      time.Duration
-	SAPSystemDiscoveryPeriod    time.Duration
-	CloudDiscoveryPeriod        time.Duration
-	HostDiscoveryPeriod         time.Duration
-	SubscriptionDiscoveryPeriod time.Duration
-	CollectorConfig             *collector.Config
+	InstanceName           string
+	SSHAddress             string
+	DiscoveryPeriodsConfig *DiscoveryPeriodConfig
+	CollectorConfig        *collector.Config
 }
 
 // NewAgent returns a new instance of Agent with the given configuration
@@ -49,11 +53,11 @@ func NewAgent(config *Config) (*Agent, error) {
 		ctx:             ctx,
 		ctxCancel:       ctxCancel,
 		discoveries: []discovery.Discovery{
-			discovery.NewClusterDiscovery(collectorClient, config.ClusterDiscoveryPeriod),
-			discovery.NewSAPSystemsDiscovery(collectorClient, config.SAPSystemDiscoveryPeriod),
-			discovery.NewCloudDiscovery(collectorClient, config.CloudDiscoveryPeriod),
-			discovery.NewHostDiscovery(config.SSHAddress, collectorClient, config.HostDiscoveryPeriod),
-			discovery.NewSubscriptionDiscovery(collectorClient, config.SubscriptionDiscoveryPeriod),
+			discovery.NewClusterDiscovery(collectorClient, config.DiscoveryPeriodsConfig.Cluster),
+			discovery.NewSAPSystemsDiscovery(collectorClient, config.DiscoveryPeriodsConfig.SAPSystem),
+			discovery.NewCloudDiscovery(collectorClient, config.DiscoveryPeriodsConfig.Cloud),
+			discovery.NewHostDiscovery(config.SSHAddress, collectorClient, config.DiscoveryPeriodsConfig.Host),
+			discovery.NewSubscriptionDiscovery(collectorClient, config.DiscoveryPeriodsConfig.Subscription),
 		},
 	}
 	return agent, nil

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -36,17 +36,12 @@ func NewAgent(config *Config) (*Agent, error) {
 		return nil, errors.Wrap(err, "could not create a collector client")
 	}
 
-	discoveryInitializers := []discovery.DiscoveryInitializer{
-		discovery.NewClusterDiscovery,
-		discovery.NewSAPSystemsDiscovery,
-		discovery.NewCloudDiscovery,
-		discovery.NewSubscriptionDiscovery,
-		discovery.NewHostDiscovery,
-	}
-	var discoveries discovery.DiscoveryList
-
-	for _, initializer := range discoveryInitializers {
-		discoveries = discoveries.AddDiscovery(initializer, collectorClient, *config.DiscoveriesConfig)
+	discoveries := []discovery.Discovery{
+		discovery.NewClusterDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewSAPSystemsDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewCloudDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewSubscriptionDiscovery(collectorClient, *config.DiscoveriesConfig),
+		discovery.NewHostDiscovery(collectorClient, *config.DiscoveriesConfig),
 	}
 
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -15,7 +14,6 @@ const CloudDiscoveryId string = "cloud_discovery"
 type CloudDiscovery struct {
 	id              string
 	collectorClient collector.Client
-	host            string
 	interval        time.Duration
 }
 
@@ -27,7 +25,6 @@ func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfi
 	d := CloudDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = CloudDiscoveryId
-	d.host, _ = os.Hostname()
 	d.interval = config.DiscoveriesPeriodsConfig.Cloud
 
 	return d, nil

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/agent/discovery/collector"
@@ -15,15 +16,19 @@ type CloudDiscovery struct {
 	discovery BaseDiscovery
 }
 
-func NewCloudDiscovery(collectorClient collector.Client) CloudDiscovery {
+func NewCloudDiscovery(collectorClient collector.Client, interval time.Duration) CloudDiscovery {
 	r := CloudDiscovery{}
 	r.id = CloudDiscoveryId
-	r.discovery = NewDiscovery(collectorClient)
+	r.discovery = NewDiscovery(collectorClient, interval)
 	return r
 }
 
 func (d CloudDiscovery) GetId() string {
 	return d.id
+}
+
+func (d CloudDiscovery) GetInterval() time.Duration {
+	return d.discovery.interval
 }
 
 func (d CloudDiscovery) Discover() (string, error) {

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -18,13 +18,13 @@ type CloudDiscovery struct {
 	interval        time.Duration
 }
 
-func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
+func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfig) Discovery {
 	d := CloudDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = CloudDiscoveryId
 	d.interval = config.DiscoveriesPeriodsConfig.Cloud
 
-	return d, nil
+	return d
 }
 
 func (d CloudDiscovery) GetId() string {

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -10,7 +10,7 @@ import (
 )
 
 const CloudDiscoveryId string = "cloud_discovery"
-const CloudDiscoveryMinInterval time.Duration = 1
+const CloudDiscoveryMinPeriod time.Duration = 1 * time.Second
 
 type CloudDiscovery struct {
 	id              string
@@ -19,10 +19,6 @@ type CloudDiscovery struct {
 }
 
 func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Cloud < CloudDiscoveryMinInterval {
-		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Cloud, CloudDiscoveryMinInterval)
-	}
-
 	d := CloudDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = CloudDiscoveryId

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -10,6 +10,7 @@ import (
 )
 
 const CloudDiscoveryId string = "cloud_discovery"
+const CloudDiscoveryMinInterval time.Duration = 1
 
 type CloudDiscovery struct {
 	id              string
@@ -18,8 +19,8 @@ type CloudDiscovery struct {
 }
 
 func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Cloud < 1 {
-		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Cloud)
+	if config.DiscoveriesPeriodsConfig.Cloud < CloudDiscoveryMinInterval {
+		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Cloud, CloudDiscoveryMinInterval)
 	}
 
 	d := CloudDiscovery{}

--- a/agent/discovery/cloud.go
+++ b/agent/discovery/cloud.go
@@ -24,13 +24,13 @@ func NewCloudDiscovery(collectorClient collector.Client, config DiscoveriesConfi
 		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Cloud)
 	}
 
-	r := CloudDiscovery{}
-	r.collectorClient = collectorClient
-	r.id = CloudDiscoveryId
-	r.host, _ = os.Hostname()
-	r.interval = config.DiscoveriesPeriodsConfig.Cloud
+	d := CloudDiscovery{}
+	d.collectorClient = collectorClient
+	d.id = CloudDiscoveryId
+	d.host, _ = os.Hostname()
+	d.interval = config.DiscoveriesPeriodsConfig.Cloud
 
-	return r, nil
+	return d, nil
 }
 
 func (d CloudDiscovery) GetId() string {

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/agent/discovery/collector"
@@ -16,15 +17,19 @@ type ClusterDiscovery struct {
 	discovery BaseDiscovery
 }
 
-func NewClusterDiscovery(collectorClient collector.Client) ClusterDiscovery {
+func NewClusterDiscovery(collectorClient collector.Client, interval time.Duration) ClusterDiscovery {
 	d := ClusterDiscovery{}
 	d.id = ClusterDiscoveryId
-	d.discovery = NewDiscovery(collectorClient)
+	d.discovery = NewDiscovery(collectorClient, interval)
 	return d
 }
 
 func (c ClusterDiscovery) GetId() string {
 	return c.id
+}
+
+func (d ClusterDiscovery) GetInterval() time.Duration {
+	return d.discovery.interval
 }
 
 // Execute one iteration of a discovery and publish the results to the collector

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -16,7 +15,6 @@ const ClusterDiscoveryId string = "ha_cluster_discovery"
 type ClusterDiscovery struct {
 	id              string
 	collectorClient collector.Client
-	host            string
 	interval        time.Duration
 }
 
@@ -28,7 +26,6 @@ func NewClusterDiscovery(collectorClient collector.Client, config DiscoveriesCon
 	d := ClusterDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = ClusterDiscoveryId
-	d.host, _ = os.Hostname()
 	d.interval = config.DiscoveriesPeriodsConfig.Cluster
 
 	return d, nil

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -19,13 +19,13 @@ type ClusterDiscovery struct {
 	interval        time.Duration
 }
 
-func NewClusterDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
+func NewClusterDiscovery(collectorClient collector.Client, config DiscoveriesConfig) Discovery {
 	d := ClusterDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = ClusterDiscoveryId
 	d.interval = config.DiscoveriesPeriodsConfig.Cluster
 
-	return d, nil
+	return d
 }
 
 func (c ClusterDiscovery) GetId() string {

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -10,6 +10,7 @@ import (
 )
 
 const ClusterDiscoveryId string = "ha_cluster_discovery"
+const ClusterDiscoveryMinInterval time.Duration = 1
 
 // This Discover handles any Pacemaker Cluster type
 type ClusterDiscovery struct {
@@ -19,8 +20,8 @@ type ClusterDiscovery struct {
 }
 
 func NewClusterDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Cluster < 1 {
-		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Cluster)
+	if config.DiscoveriesPeriodsConfig.Cluster < ClusterDiscoveryMinInterval {
+		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Cluster, ClusterDiscoveryMinInterval)
 	}
 
 	d := ClusterDiscovery{}

--- a/agent/discovery/cluster.go
+++ b/agent/discovery/cluster.go
@@ -10,7 +10,7 @@ import (
 )
 
 const ClusterDiscoveryId string = "ha_cluster_discovery"
-const ClusterDiscoveryMinInterval time.Duration = 1
+const ClusterDiscoveryMinPeriod time.Duration = 1 * time.Second
 
 // This Discover handles any Pacemaker Cluster type
 type ClusterDiscovery struct {
@@ -20,10 +20,6 @@ type ClusterDiscovery struct {
 }
 
 func NewClusterDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Cluster < ClusterDiscoveryMinInterval {
-		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Cluster, ClusterDiscoveryMinInterval)
-	}
-
 	d := ClusterDiscovery{}
 	d.collectorClient = collectorClient
 	d.id = ClusterDiscoveryId

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -28,12 +28,3 @@ type Discovery interface {
 	// Get interval
 	GetInterval() time.Duration
 }
-
-type DiscoveryList []Discovery
-type DiscoveryInitializer func(collector.Client, DiscoveriesConfig) Discovery
-
-func (d DiscoveryList) AddDiscovery(f DiscoveryInitializer, collectorClient collector.Client, config DiscoveriesConfig) DiscoveryList {
-	discovery := f(collectorClient, config)
-
-	return append(d, discovery)
-}

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -30,13 +30,10 @@ type Discovery interface {
 }
 
 type DiscoveryList []Discovery
-type DiscoveryInitializer func(collector.Client, DiscoveriesConfig) (Discovery, error)
+type DiscoveryInitializer func(collector.Client, DiscoveriesConfig) Discovery
 
-func (d DiscoveryList) AddDiscovery(f DiscoveryInitializer, collectorClient collector.Client, config DiscoveriesConfig) (DiscoveryList, error) {
-	discovery, err := f(collectorClient, config)
-	if err != nil {
-		return d, err
-	}
+func (d DiscoveryList) AddDiscovery(f DiscoveryInitializer, collectorClient collector.Client, config DiscoveriesConfig) DiscoveryList {
+	discovery := f(collectorClient, config)
 
-	return append(d, discovery), nil
+	return append(d, discovery)
 }

--- a/agent/discovery/discovery.go
+++ b/agent/discovery/discovery.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"os"
+	"time"
 
 	"github.com/trento-project/trento/agent/discovery/collector"
 )
@@ -11,12 +12,15 @@ type Discovery interface {
 	GetId() string
 	// Execute the discovery mechanism
 	Discover() (string, error)
+	// Get interval
+	GetInterval() time.Duration
 }
 
 type BaseDiscovery struct {
 	id              string
 	collectorClient collector.Client
 	host            string
+	interval        time.Duration
 }
 
 func (d BaseDiscovery) GetId() string {
@@ -29,11 +33,16 @@ func (d BaseDiscovery) Discover() (string, error) {
 	return "Basic discovery example", nil
 }
 
+func (d BaseDiscovery) GetInterval() time.Duration {
+	return d.interval
+}
+
 // NewDiscovery Return a new base discovery with the support for data collector endpoint
-func NewDiscovery(collectorClient collector.Client) BaseDiscovery {
+func NewDiscovery(collectorClient collector.Client, interval time.Duration) BaseDiscovery {
 	d := BaseDiscovery{}
 	d.id = ""
 	d.collectorClient = collectorClient
 	d.host, _ = os.Hostname()
+	d.interval = interval
 	return d
 }

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -17,6 +17,7 @@ import (
 )
 
 const HostDiscoveryId string = "host_discovery"
+const HostDiscoveryMinInterval time.Duration = 1
 
 type HostDiscovery struct {
 	id              string
@@ -27,8 +28,8 @@ type HostDiscovery struct {
 }
 
 func NewHostDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Host < 1 {
-		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Host)
+	if config.DiscoveriesPeriodsConfig.Host < HostDiscoveryMinInterval {
+		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Host, HostDiscoveryMinInterval)
 	}
 
 	d := HostDiscovery{}

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -27,14 +27,14 @@ type HostDiscovery struct {
 	interval        time.Duration
 }
 
-func NewHostDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
+func NewHostDiscovery(collectorClient collector.Client, config DiscoveriesConfig) Discovery {
 	d := HostDiscovery{}
 	d.id = HostDiscoveryId
 	d.collectorClient = collectorClient
 	d.host, _ = os.Hostname()
 	d.interval = config.DiscoveriesPeriodsConfig.Host
 	d.sshAddress = config.SSHAddress
-	return d, nil
+	return d
 }
 
 func (d HostDiscovery) GetId() string {

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -17,7 +17,7 @@ import (
 )
 
 const HostDiscoveryId string = "host_discovery"
-const HostDiscoveryMinInterval time.Duration = 1
+const HostDiscoveryMinPeriod time.Duration = 1 * time.Second
 
 type HostDiscovery struct {
 	id              string
@@ -28,10 +28,6 @@ type HostDiscovery struct {
 }
 
 func NewHostDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Host < HostDiscoveryMinInterval {
-		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Host, HostDiscoveryMinInterval)
-	}
-
 	d := HostDiscovery{}
 	d.id = HostDiscoveryId
 	d.collectorClient = collectorClient

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -40,8 +40,8 @@ func NewHostDiscovery(collectorClient collector.Client, config DiscoveriesConfig
 	return d, nil
 }
 
-func (h HostDiscovery) GetId() string {
-	return h.id
+func (d HostDiscovery) GetId() string {
+	return d.id
 }
 
 func (d HostDiscovery) GetInterval() time.Duration {
@@ -49,30 +49,30 @@ func (d HostDiscovery) GetInterval() time.Duration {
 }
 
 // Execute one iteration of a discovery and publish to the collector
-func (h HostDiscovery) Discover() (string, error) {
+func (d HostDiscovery) Discover() (string, error) {
 	ipAddresses, err := getHostIpAddresses()
 	if err != nil {
 		return "", err
 	}
 
 	host := hosts.DiscoveredHost{
-		SSHAddress:      h.sshAddress,
+		SSHAddress:      d.sshAddress,
 		OSVersion:       getOSVersion(),
 		HostIpAddresses: ipAddresses,
-		HostName:        h.host,
+		HostName:        d.host,
 		CPUCount:        getLogicalCPUs(),
 		SocketCount:     getCPUSocketCount(),
 		TotalMemoryMB:   getTotalMemoryMB(),
 		AgentVersion:    version.Version,
 	}
 
-	err = h.collectorClient.Publish(h.id, host)
+	err = d.collectorClient.Publish(d.id, host)
 	if err != nil {
 		log.Debugf("Error while sending host discovery to data collector: %s", err)
 		return "", err
 	}
 
-	return fmt.Sprintf("Host with name: %s successfully discovered", h.host), nil
+	return fmt.Sprintf("Host with name: %s successfully discovered", d.host), nil
 }
 
 func getHostIpAddresses() ([]string, error) {

--- a/agent/discovery/host.go
+++ b/agent/discovery/host.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strconv"
+	"time"
 
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/host"
@@ -22,16 +23,20 @@ type HostDiscovery struct {
 	discovery  BaseDiscovery
 }
 
-func NewHostDiscovery(sshAddress string, collectorClient collector.Client) HostDiscovery {
+func NewHostDiscovery(sshAddress string, collectorClient collector.Client, interval time.Duration) HostDiscovery {
 	d := HostDiscovery{}
 	d.id = HostDiscoveryId
 	d.sshAddress = sshAddress
-	d.discovery = NewDiscovery(collectorClient)
+	d.discovery = NewDiscovery(collectorClient, interval)
 	return d
 }
 
 func (h HostDiscovery) GetId() string {
 	return h.id
+}
+
+func (d HostDiscovery) GetInterval() time.Duration {
+	return d.discovery.interval
 }
 
 // Execute one iteration of a discovery and publish to the collector

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -12,15 +13,24 @@ import (
 const SAPDiscoveryId string = "sap_system_discovery"
 
 type SAPSystemsDiscovery struct {
-	id        string
-	discovery BaseDiscovery
+	id              string
+	collectorClient collector.Client
+	host            string
+	interval        time.Duration
 }
 
-func NewSAPSystemsDiscovery(collectorClient collector.Client, interval time.Duration) SAPSystemsDiscovery {
+func NewSAPSystemsDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
+	if config.DiscoveriesPeriodsConfig.SAPSystem < 1 {
+		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.SAPSystem)
+	}
+
 	r := SAPSystemsDiscovery{}
 	r.id = SAPDiscoveryId
-	r.discovery = NewDiscovery(collectorClient, interval)
-	return r
+	r.collectorClient = collectorClient
+	r.host, _ = os.Hostname()
+	r.interval = config.DiscoveriesPeriodsConfig.SAPSystem
+
+	return r, nil
 }
 
 func (d SAPSystemsDiscovery) GetId() string {
@@ -28,7 +38,7 @@ func (d SAPSystemsDiscovery) GetId() string {
 }
 
 func (d SAPSystemsDiscovery) GetInterval() time.Duration {
-	return d.discovery.interval
+	return d.interval
 }
 
 func (d SAPSystemsDiscovery) Discover() (string, error) {
@@ -38,7 +48,7 @@ func (d SAPSystemsDiscovery) Discover() (string, error) {
 		return "", err
 	}
 
-	err = d.discovery.collectorClient.Publish(d.id, systems)
+	err = d.collectorClient.Publish(d.id, systems)
 	if err != nil {
 		log.Debugf("Error while sending sapsystem discovery to data collector: %s", err)
 		return "", err

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -18,13 +18,13 @@ type SAPSystemsDiscovery struct {
 	interval        time.Duration
 }
 
-func NewSAPSystemsDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
+func NewSAPSystemsDiscovery(collectorClient collector.Client, config DiscoveriesConfig) Discovery {
 	d := SAPSystemsDiscovery{}
 	d.id = SAPDiscoveryId
 	d.collectorClient = collectorClient
 	d.interval = config.DiscoveriesPeriodsConfig.SAPSystem
 
-	return d, nil
+	return d
 }
 
 func (d SAPSystemsDiscovery) GetId() string {

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -24,13 +24,13 @@ func NewSAPSystemsDiscovery(collectorClient collector.Client, config Discoveries
 		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.SAPSystem)
 	}
 
-	r := SAPSystemsDiscovery{}
-	r.id = SAPDiscoveryId
-	r.collectorClient = collectorClient
-	r.host, _ = os.Hostname()
-	r.interval = config.DiscoveriesPeriodsConfig.SAPSystem
+	d := SAPSystemsDiscovery{}
+	d.id = SAPDiscoveryId
+	d.collectorClient = collectorClient
+	d.host, _ = os.Hostname()
+	d.interval = config.DiscoveriesPeriodsConfig.SAPSystem
 
-	return r, nil
+	return d, nil
 }
 
 func (d SAPSystemsDiscovery) GetId() string {

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -10,7 +10,7 @@ import (
 )
 
 const SAPDiscoveryId string = "sap_system_discovery"
-const SAPDiscoveryMinInterval time.Duration = 1
+const SAPDiscoveryMinPeriod time.Duration = 1 * time.Second
 
 type SAPSystemsDiscovery struct {
 	id              string
@@ -19,10 +19,6 @@ type SAPSystemsDiscovery struct {
 }
 
 func NewSAPSystemsDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.SAPSystem < SAPDiscoveryMinInterval {
-		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.SAPSystem, SAPDiscoveryMinInterval)
-	}
-
 	d := SAPSystemsDiscovery{}
 	d.id = SAPDiscoveryId
 	d.collectorClient = collectorClient

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -15,7 +14,6 @@ const SAPDiscoveryId string = "sap_system_discovery"
 type SAPSystemsDiscovery struct {
 	id              string
 	collectorClient collector.Client
-	host            string
 	interval        time.Duration
 }
 
@@ -27,7 +25,6 @@ func NewSAPSystemsDiscovery(collectorClient collector.Client, config Discoveries
 	d := SAPSystemsDiscovery{}
 	d.id = SAPDiscoveryId
 	d.collectorClient = collectorClient
-	d.host, _ = os.Hostname()
 	d.interval = config.DiscoveriesPeriodsConfig.SAPSystem
 
 	return d, nil

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -10,6 +10,7 @@ import (
 )
 
 const SAPDiscoveryId string = "sap_system_discovery"
+const SAPDiscoveryMinInterval time.Duration = 1
 
 type SAPSystemsDiscovery struct {
 	id              string
@@ -18,8 +19,8 @@ type SAPSystemsDiscovery struct {
 }
 
 func NewSAPSystemsDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.SAPSystem < 1 {
-		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.SAPSystem)
+	if config.DiscoveriesPeriodsConfig.SAPSystem < SAPDiscoveryMinInterval {
+		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.SAPSystem, SAPDiscoveryMinInterval)
 	}
 
 	d := SAPSystemsDiscovery{}

--- a/agent/discovery/sapsystem.go
+++ b/agent/discovery/sapsystem.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/agent/discovery/collector"
@@ -15,15 +16,19 @@ type SAPSystemsDiscovery struct {
 	discovery BaseDiscovery
 }
 
-func NewSAPSystemsDiscovery(collectorClient collector.Client) SAPSystemsDiscovery {
+func NewSAPSystemsDiscovery(collectorClient collector.Client, interval time.Duration) SAPSystemsDiscovery {
 	r := SAPSystemsDiscovery{}
 	r.id = SAPDiscoveryId
-	r.discovery = NewDiscovery(collectorClient)
+	r.discovery = NewDiscovery(collectorClient, interval)
 	return r
 }
 
 func (d SAPSystemsDiscovery) GetId() string {
 	return d.id
+}
+
+func (d SAPSystemsDiscovery) GetInterval() time.Duration {
+	return d.discovery.interval
 }
 
 func (d SAPSystemsDiscovery) Discover() (string, error) {

--- a/agent/discovery/subscription.go
+++ b/agent/discovery/subscription.go
@@ -11,6 +11,7 @@ import (
 )
 
 const SubscriptionDiscoveryId string = "subscription_discovery"
+const SubscriptionDiscoveryMinInterval time.Duration = 500
 
 type SubscriptionDiscovery struct {
 	id              string
@@ -20,8 +21,8 @@ type SubscriptionDiscovery struct {
 }
 
 func NewSubscriptionDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Subscription < 500 {
-		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Subscription)
+	if config.DiscoveriesPeriodsConfig.Subscription < SubscriptionDiscoveryMinInterval {
+		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Subscription, SubscriptionDiscoveryMinInterval)
 	}
 
 	r := SubscriptionDiscovery{}

--- a/agent/discovery/subscription.go
+++ b/agent/discovery/subscription.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/trento-project/trento/agent/discovery/collector"
@@ -15,15 +16,19 @@ type SubscriptionDiscovery struct {
 	discovery BaseDiscovery
 }
 
-func NewSubscriptionDiscovery(collectorClient collector.Client) SubscriptionDiscovery {
+func NewSubscriptionDiscovery(collectorClient collector.Client, interval time.Duration) SubscriptionDiscovery {
 	r := SubscriptionDiscovery{}
 	r.id = SubscriptionDiscoveryId
-	r.discovery = NewDiscovery(collectorClient)
+	r.discovery = NewDiscovery(collectorClient, interval)
 	return r
 }
 
 func (d SubscriptionDiscovery) GetId() string {
 	return d.id
+}
+
+func (d SubscriptionDiscovery) GetInterval() time.Duration {
+	return d.discovery.interval
 }
 
 func (d SubscriptionDiscovery) Discover() (string, error) {

--- a/agent/discovery/subscription.go
+++ b/agent/discovery/subscription.go
@@ -11,7 +11,7 @@ import (
 )
 
 const SubscriptionDiscoveryId string = "subscription_discovery"
-const SubscriptionDiscoveryMinInterval time.Duration = 500
+const SubscriptionDiscoveryMinPeriod time.Duration = 500 * time.Second
 
 type SubscriptionDiscovery struct {
 	id              string
@@ -21,10 +21,6 @@ type SubscriptionDiscovery struct {
 }
 
 func NewSubscriptionDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Subscription < SubscriptionDiscoveryMinInterval {
-		return nil, fmt.Errorf("invalid interval %s: should be at least %s", config.DiscoveriesPeriodsConfig.Subscription, SubscriptionDiscoveryMinInterval)
-	}
-
 	r := SubscriptionDiscovery{}
 	r.id = SubscriptionDiscoveryId
 	r.collectorClient = collectorClient

--- a/agent/discovery/subscription.go
+++ b/agent/discovery/subscription.go
@@ -11,7 +11,7 @@ import (
 )
 
 const SubscriptionDiscoveryId string = "subscription_discovery"
-const SubscriptionDiscoveryMinPeriod time.Duration = 500 * time.Second
+const SubscriptionDiscoveryMinPeriod time.Duration = 20 * time.Second
 
 type SubscriptionDiscovery struct {
 	id              string
@@ -20,14 +20,14 @@ type SubscriptionDiscovery struct {
 	interval        time.Duration
 }
 
-func NewSubscriptionDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	r := SubscriptionDiscovery{}
-	r.id = SubscriptionDiscoveryId
-	r.collectorClient = collectorClient
-	r.host, _ = os.Hostname()
-	r.interval = config.DiscoveriesPeriodsConfig.Subscription
+func NewSubscriptionDiscovery(collectorClient collector.Client, config DiscoveriesConfig) Discovery {
+	d := SubscriptionDiscovery{}
+	d.id = SubscriptionDiscoveryId
+	d.collectorClient = collectorClient
+	d.host, _ = os.Hostname()
+	d.interval = config.DiscoveriesPeriodsConfig.Subscription
 
-	return r, nil
+	return d
 }
 
 func (d SubscriptionDiscovery) GetId() string {

--- a/agent/discovery/subscription.go
+++ b/agent/discovery/subscription.go
@@ -20,7 +20,7 @@ type SubscriptionDiscovery struct {
 }
 
 func NewSubscriptionDiscovery(collectorClient collector.Client, config DiscoveriesConfig) (Discovery, error) {
-	if config.DiscoveriesPeriodsConfig.Subscription < 1 {
+	if config.DiscoveriesPeriodsConfig.Subscription < 500 {
 		return nil, fmt.Errorf("invalid interval %s", config.DiscoveriesPeriodsConfig.Subscription)
 	}
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 
@@ -18,11 +19,11 @@ import (
 func NewAgentCmd() *cobra.Command {
 	var sshAddress string
 
-	var clusterDiscoveryPeriod int
-	var sapSystemDiscoveryPeriod int
-	var cloudDiscoveryPeriod int
-	var hostDiscoveryPeriod int
-	var subscriptionDiscoveryPeriod int
+	var clusterDiscoveryPeriod time.Duration
+	var sapSystemDiscoveryPeriod time.Duration
+	var cloudDiscoveryPeriod time.Duration
+	var hostDiscoveryPeriod time.Duration
+	var subscriptionDiscoveryPeriod time.Duration
 
 	var collectorHost string
 	var collectorPort int
@@ -52,11 +53,11 @@ func NewAgentCmd() *cobra.Command {
 
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
-	startCmd.Flags().IntVarP(&clusterDiscoveryPeriod, "cluster-discovery-period", "", 10, "Cluster discovery mechanism loop period in seconds")
-	startCmd.Flags().IntVarP(&sapSystemDiscoveryPeriod, "sapsystem-discovery-period", "", 10, "SAP systems discovery mechanism loop period in seconds")
-	startCmd.Flags().IntVarP(&cloudDiscoveryPeriod, "cloud-discovery-period", "", 10, "Cloud discovery mechanism loop period in seconds")
-	startCmd.Flags().IntVarP(&hostDiscoveryPeriod, "host-discovery-period", "", 10, "Host discovery mechanism loop period in seconds")
-	startCmd.Flags().IntVarP(&subscriptionDiscoveryPeriod, "subscription-discovery-period", "", 900, "Subscription discovery mechanism loop period in seconds")
+	startCmd.Flags().DurationVarP(&clusterDiscoveryPeriod, "cluster-discovery-period", "", 10*time.Second, "Cluster discovery mechanism loop period in seconds")
+	startCmd.Flags().DurationVarP(&sapSystemDiscoveryPeriod, "sapsystem-discovery-period", "", 10*time.Second, "SAP systems discovery mechanism loop period in seconds")
+	startCmd.Flags().DurationVarP(&cloudDiscoveryPeriod, "cloud-discovery-period", "", 10*time.Second, "Cloud discovery mechanism loop period in seconds")
+	startCmd.Flags().DurationVarP(&hostDiscoveryPeriod, "host-discovery-period", "", 10*time.Second, "Host discovery mechanism loop period in seconds")
+	startCmd.Flags().DurationVarP(&subscriptionDiscoveryPeriod, "subscription-discovery-period", "", 900*time.Second, "Subscription discovery mechanism loop period in seconds")
 
 	startCmd.Flags().MarkHidden("subscription-discovery-period")
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -17,7 +17,11 @@ import (
 
 func NewAgentCmd() *cobra.Command {
 	var sshAddress string
-	var discoveryPeriod int
+
+	var clusterDiscoveryPeriod int
+	var sapSystemDiscoveryPeriod int
+	var cloudDiscoveryPeriod int
+	var hostDiscoveryPeriod int
 	var subscriptionDiscoveryPeriod int
 
 	var collectorHost string
@@ -48,8 +52,12 @@ func NewAgentCmd() *cobra.Command {
 
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
-	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 10, "Discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&clusterDiscoveryPeriod, "cluster-discovery-period", "", 10, "Cluster discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&sapSystemDiscoveryPeriod, "sapsystem-discovery-period", "", 10, "SAP systems discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&cloudDiscoveryPeriod, "cloud-discovery-period", "", 10, "Cloud discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&hostDiscoveryPeriod, "host-discovery-period", "", 10, "Host discovery mechanism loop period in seconds")
 	startCmd.Flags().IntVarP(&subscriptionDiscoveryPeriod, "subscription-discovery-period", "", 900, "Subscription discovery mechanism loop period in seconds")
+
 	startCmd.Flags().MarkHidden("subscription-discovery-period")
 
 	startCmd.Flags().StringVar(&collectorHost, "collector-host", "localhost", "Data Collector host")

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -18,6 +18,7 @@ import (
 func NewAgentCmd() *cobra.Command {
 	var sshAddress string
 	var discoveryPeriod int
+	var subscriptionDiscoveryPeriod int
 
 	var collectorHost string
 	var collectorPort int
@@ -48,6 +49,8 @@ func NewAgentCmd() *cobra.Command {
 	startCmd.Flags().StringVar(&sshAddress, "ssh-address", "", "The address to which the trento-agent should be reachable for ssh connection by the runner for check execution.")
 
 	startCmd.Flags().IntVarP(&discoveryPeriod, "discovery-period", "", 10, "Discovery mechanism loop period in seconds")
+	startCmd.Flags().IntVarP(&subscriptionDiscoveryPeriod, "subscription-discovery-period", "", 900, "Subscription discovery mechanism loop period in seconds")
+	startCmd.Flags().MarkHidden("subscription-discovery-period")
 
 	startCmd.Flags().StringVar(&collectorHost, "collector-host", "localhost", "Data Collector host")
 	startCmd.Flags().IntVar(&collectorPort, "collector-port", 8081, "Data Collector port")

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/trento-project/trento/agent"
+	"github.com/trento-project/trento/agent/discovery"
 	"github.com/trento-project/trento/agent/discovery/collector"
 )
 
@@ -44,23 +45,31 @@ func LoadConfig() (*agent.Config, error) {
 		return nil, errors.New("ssh-address is required, cannot start agent")
 	}
 
+	collectorConfig := &collector.Config{
+		CollectorHost: viper.GetString("collector-host"),
+		CollectorPort: viper.GetInt("collector-port"),
+		EnablemTLS:    enablemTLS,
+		Cert:          cert,
+		Key:           key,
+		CA:            ca,
+	}
+
+	discoveryPeriodsConfig := &discovery.DiscoveriesPeriodConfig{
+		Cluster:      time.Duration(viper.GetInt("cluster-discovery-period")) * time.Second,
+		SAPSystem:    time.Duration(viper.GetInt("sapsystem-discovery-period")) * time.Second,
+		Cloud:        time.Duration(viper.GetInt("cloud-discovery-period")) * time.Second,
+		Host:         time.Duration(viper.GetInt("host-discovery-period")) * time.Second,
+		Subscription: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
+	}
+
+	discoveriesConfig := &discovery.DiscoveriesConfig{
+		SSHAddress:               sshAddress,
+		CollectorConfig:          collectorConfig,
+		DiscoveriesPeriodsConfig: discoveryPeriodsConfig,
+	}
+
 	return &agent.Config{
-		CollectorConfig: &collector.Config{
-			CollectorHost: viper.GetString("collector-host"),
-			CollectorPort: viper.GetInt("collector-port"),
-			EnablemTLS:    enablemTLS,
-			Cert:          cert,
-			Key:           key,
-			CA:            ca,
-		},
-		InstanceName: hostname,
-		SSHAddress:   sshAddress,
-		DiscoveryPeriodsConfig: &agent.DiscoveryPeriodConfig{
-			Cluster:      time.Duration(viper.GetInt("cluster-discovery-period")) * time.Second,
-			SAPSystem:    time.Duration(viper.GetInt("sapsystem-discovery-period")) * time.Second,
-			Cloud:        time.Duration(viper.GetInt("cloud-discovery-period")) * time.Second,
-			Host:         time.Duration(viper.GetInt("host-discovery-period")) * time.Second,
-			Subscription: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
-		},
+		InstanceName:      hostname,
+		DiscoveriesConfig: discoveriesConfig,
 	}, nil
 }

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -53,12 +53,14 @@ func LoadConfig() (*agent.Config, error) {
 			Key:           key,
 			CA:            ca,
 		},
-		InstanceName:                hostname,
-		SSHAddress:                  sshAddress,
-		ClusterDiscoveryPeriod:      time.Duration(viper.GetInt("cluster-discovery-period")) * time.Second,
-		SAPSystemDiscoveryPeriod:    time.Duration(viper.GetInt("sapsystem-discovery-period")) * time.Second,
-		CloudDiscoveryPeriod:        time.Duration(viper.GetInt("cloud-discovery-period")) * time.Second,
-		HostDiscoveryPeriod:         time.Duration(viper.GetInt("host-discovery-period")) * time.Second,
-		SubscriptionDiscoveryPeriod: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
+		InstanceName: hostname,
+		SSHAddress:   sshAddress,
+		DiscoveryPeriodsConfig: &agent.DiscoveryPeriodConfig{
+			Cluster:      time.Duration(viper.GetInt("cluster-discovery-period")) * time.Second,
+			SAPSystem:    time.Duration(viper.GetInt("sapsystem-discovery-period")) * time.Second,
+			Cloud:        time.Duration(viper.GetInt("cloud-discovery-period")) * time.Second,
+			Host:         time.Duration(viper.GetInt("host-discovery-period")) * time.Second,
+			Subscription: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
+		},
 	}, nil
 }

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -53,8 +53,9 @@ func LoadConfig() (*agent.Config, error) {
 			Key:           key,
 			CA:            ca,
 		},
-		InstanceName:    hostname,
-		SSHAddress:      sshAddress,
-		DiscoveryPeriod: time.Duration(viper.GetInt("discovery-period")) * time.Second,
+		InstanceName:                hostname,
+		SSHAddress:                  sshAddress,
+		DiscoveryPeriod:             time.Duration(viper.GetInt("discovery-period")) * time.Second,
+		SubscriptionDiscoveryPeriod: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
 	}, nil
 }

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -55,7 +55,10 @@ func LoadConfig() (*agent.Config, error) {
 		},
 		InstanceName:                hostname,
 		SSHAddress:                  sshAddress,
-		DiscoveryPeriod:             time.Duration(viper.GetInt("discovery-period")) * time.Second,
+		ClusterDiscoveryPeriod:      time.Duration(viper.GetInt("cluster-discovery-period")) * time.Second,
+		SAPSystemDiscoveryPeriod:    time.Duration(viper.GetInt("sapsystem-discovery-period")) * time.Second,
+		CloudDiscoveryPeriod:        time.Duration(viper.GetInt("cloud-discovery-period")) * time.Second,
+		HostDiscoveryPeriod:         time.Duration(viper.GetInt("host-discovery-period")) * time.Second,
 		SubscriptionDiscoveryPeriod: time.Duration(viper.GetInt("subscription-discovery-period")) * time.Second,
 	}, nil
 }

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/suite"
 	"github.com/trento-project/trento/agent"
+	"github.com/trento-project/trento/agent/discovery"
 	"github.com/trento-project/trento/agent/discovery/collector"
 )
 
@@ -45,22 +46,23 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 
 	expectedConfig := &agent.Config{
 		InstanceName: "some-hostname",
-		SSHAddress:   "some-ssh-address",
-		DiscoveryPeriodsConfig: &agent.DiscoveryPeriodConfig{
-			Cluster:      10 * time.Second,
-			SAPSystem:    10 * time.Second,
-			Cloud:        10 * time.Second,
-			Host:         10 * time.Second,
-			Subscription: 900 * time.Second,
-		},
-
-		CollectorConfig: &collector.Config{
-			CollectorHost: "localhost",
-			CollectorPort: 1337,
-			EnablemTLS:    true,
-			Cert:          "some-cert",
-			Key:           "some-key",
-			CA:            "some-ca",
+		DiscoveriesConfig: &discovery.DiscoveriesConfig{
+			SSHAddress: "some-ssh-address",
+			DiscoveriesPeriodsConfig: &discovery.DiscoveriesPeriodConfig{
+				Cluster:      10 * time.Second,
+				SAPSystem:    10 * time.Second,
+				Cloud:        10 * time.Second,
+				Host:         10 * time.Second,
+				Subscription: 900 * time.Second,
+			},
+			CollectorConfig: &collector.Config{
+				CollectorHost: "localhost",
+				CollectorPort: 1337,
+				EnablemTLS:    true,
+				Cert:          "some-cert",
+				Key:           "some-key",
+				CA:            "some-ca",
+			},
 		},
 	}
 

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -46,7 +46,10 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 	expectedConfig := &agent.Config{
 		InstanceName:                "some-hostname",
 		SSHAddress:                  "some-ssh-address",
-		DiscoveryPeriod:             10 * time.Second,
+		ClusterDiscoveryPeriod:      10 * time.Second,
+		SAPSystemDiscoveryPeriod:    10 * time.Second,
+		CloudDiscoveryPeriod:        10 * time.Second,
+		HostDiscoveryPeriod:         10 * time.Second,
 		SubscriptionDiscoveryPeriod: 900 * time.Second,
 		CollectorConfig: &collector.Config{
 			CollectorHost: "localhost",

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -44,13 +44,16 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 	suite.cmd.Execute()
 
 	expectedConfig := &agent.Config{
-		InstanceName:                "some-hostname",
-		SSHAddress:                  "some-ssh-address",
-		ClusterDiscoveryPeriod:      10 * time.Second,
-		SAPSystemDiscoveryPeriod:    10 * time.Second,
-		CloudDiscoveryPeriod:        10 * time.Second,
-		HostDiscoveryPeriod:         10 * time.Second,
-		SubscriptionDiscoveryPeriod: 900 * time.Second,
+		InstanceName: "some-hostname",
+		SSHAddress:   "some-ssh-address",
+		DiscoveryPeriodsConfig: &agent.DiscoveryPeriodConfig{
+			Cluster:      10 * time.Second,
+			SAPSystem:    10 * time.Second,
+			Cloud:        10 * time.Second,
+			Host:         10 * time.Second,
+			Subscription: 900 * time.Second,
+		},
+
 		CollectorConfig: &collector.Config{
 			CollectorHost: "localhost",
 			CollectorPort: 1337,

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -44,9 +44,10 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 	suite.cmd.Execute()
 
 	expectedConfig := &agent.Config{
-		InstanceName:    "some-hostname",
-		SSHAddress:      "some-ssh-address",
-		DiscoveryPeriod: 10 * time.Second,
+		InstanceName:                "some-hostname",
+		SSHAddress:                  "some-ssh-address",
+		DiscoveryPeriod:             10 * time.Second,
+		SubscriptionDiscoveryPeriod: 900 * time.Second,
 		CollectorConfig: &collector.Config{
 			CollectorHost: "localhost",
 			CollectorPort: 1337,

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -67,8 +67,8 @@ func (suite *AgentCmdTestSuite) TearDownTest() {
 	}
 
 	config, err := LoadConfig()
-	config.InstanceName = "some-hostname"
 	suite.NoError(err)
+	config.InstanceName = "some-hostname"
 
 	suite.EqualValues(expectedConfig, config)
 }
@@ -77,7 +77,11 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 	suite.cmd.SetArgs([]string{
 		"start",
 		"--ssh-address=some-ssh-address",
-		"--discovery-period=10",
+		"--cloud-discovery-period=10s",
+		"--cluster-discovery-period=10s",
+		"--sapsystem-discovery-period=10s",
+		"--host-discovery-period=10s",
+		"--subscription-discovery-period=900s",
 		"--collector-host=localhost",
 		"--collector-port=1337",
 		"--enable-mtls",
@@ -89,7 +93,11 @@ func (suite *AgentCmdTestSuite) TestConfigFromFlags() {
 
 func (suite *AgentCmdTestSuite) TestConfigFromEnv() {
 	os.Setenv("TRENTO_SSH_ADDRESS", "some-ssh-address")
-	os.Setenv("TRENTO_DISCOVERY_PERIOD", "10")
+	os.Setenv("TRENTO_CLOUD_DISCOVERY_PERIOD", "10s")
+	os.Setenv("TRENTO_CLUSTER_DISCOVERY_PERIOD", "10s")
+	os.Setenv("TRENTO_SAPSYSTEM_DISCOVERY_PERIOD", "10s")
+	os.Setenv("TRENTO_HOST_DISCOVERY_PERIOD", "10s")
+	os.Setenv("TRENTO_SUBSCRIPTION_DISCOVERY_PERIOD", "900s")
 	os.Setenv("TRENTO_COLLECTOR_HOST", "localhost")
 	os.Setenv("TRENTO_COLLECTOR_PORT", "1337")
 	os.Setenv("TRENTO_ENABLE_MTLS", "true")

--- a/install-agent.sh
+++ b/install-agent.sh
@@ -21,7 +21,7 @@ Arguments:
   --ca              The path to the TLS CA file. Required if --enable-mtls is set.
   --rolling         Use the rolling version instead of the stable one.
   --use-tgz         Use the trento tar.gz file from GH releases rather than the RPM.
-  --interval        The polling interval in seconds for the discovery.
+  --interval        The polling interval in seconds for the discoveries.
   --help            Print this help.
 END
 }
@@ -124,7 +124,10 @@ enable-mtls: @ENABLE_MTLS@
 cert: @CERT@
 key: @KEY@
 ca: @CA@
-discovery-period: @INTERVAL@
+cloud-discovery-period: @INTERVAL@
+cluster-discovery-period: @INTERVAL@
+host-discovery-period: @INTERVAL@
+sapsystem-discovery-period: @INTERVAL@
 '
 
 . /etc/os-release

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -69,7 +69,8 @@
 ###############################################################################
 
 ## Subscription discovery period configures the tick interval for the
-## subscription discovery loop.
+## subscription discovery loop. Note that the minimal allowed value for this
+## variable is 500 seconds.
 ## Time unit is seconds
 ## Defaults to 900.
 

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -32,11 +32,48 @@
 
 ###############################################################################
 
-## Discovery period configures the tick interval for the discovery loops.
-## Time unit is minutes
-## Defaults to 2.
+## Cloud discovery period configures the tick interval for the cloud discovery
+## loop.
+## Time unit is seconds
+## Defaults to 10.
 
-# discovery-period: 2
+# cloud-discovery-period: 10
+
+###############################################################################
+
+## Cluster discovery period configures the tick interval for the cluster
+##  discovery loop.
+## Time unit is seconds
+## Defaults to 10.
+
+# cluster-discovery-period: 10
+
+###############################################################################
+
+## Host discovery period configures the tick interval for the host discovery
+## loop.
+## Time unit is seconds
+## Defaults to 10.
+
+# host-discovery-period: 10
+
+###############################################################################
+
+## SAP system discovery period configures the tick interval for the SAP system
+## discovery loop.
+## Time unit is seconds
+## Defaults to 10.
+
+# sapsystem-discovery-period: 10
+
+###############################################################################
+
+## Subscription discovery period configures the tick interval for the
+## subscription discovery loop.
+## Time unit is seconds
+## Defaults to 900.
+
+# subscription-discovery-period: 900
 
 ###############################################################################
 

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -68,16 +68,6 @@
 
 ###############################################################################
 
-## Subscription discovery period configures the tick interval for the
-## subscription discovery loop. Note that the minimal allowed value for this
-## variable is 500 seconds.
-## Time unit is seconds
-## Defaults to 900.
-
-# subscription-discovery-period: 900
-
-###############################################################################
-
 ## Application log level
 ## Allowed values: error, warn, info, debug
 ## defaults to info

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -1,9 +1,8 @@
 ssh-address: some-ssh-address
-cloud-discovery-period: 10
-cluster-discovery-period: 10
-host-discovery-period: 10
-sapsystem-discovery-period: 10
-subscription-discovery-period: 900
+cloud-discovery-period: 10s
+cluster-discovery-period: 10s
+host-discovery-period: 10s
+sapsystem-discovery-period: 10s
 collector-host: localhost
 collector-port: 1337
 enable-mtls: true

--- a/test/fixtures/config/agent.yaml
+++ b/test/fixtures/config/agent.yaml
@@ -1,5 +1,9 @@
 ssh-address: some-ssh-address
-discovery-period: 10
+cloud-discovery-period: 10
+cluster-discovery-period: 10
+host-discovery-period: 10
+sapsystem-discovery-period: 10
+subscription-discovery-period: 900
 collector-host: localhost
 collector-port: 1337
 enable-mtls: true


### PR DESCRIPTION
This PR superseedes #876 and in addition to just splitting the subscription discovery, it splits all the discoveries into separately configurable variables:
```
ClusterDiscoveryPeriod      time.Duration
SAPSystemDiscoveryPeriod    time.Duration
CloudDiscoveryPeriod        time.Duration
HostDiscoveryPeriod         time.Duration
SubscriptionDiscoveryPeriod time.Duration
```
Some notes:
 - The subscription discovery interval is kept as a hidden parameter
 - All others are visible in the `trento` CLI when using `--help`
 - We add the interval as part of the `BaseDiscovery` struct in the `interval` field and access them through the `GetInterval()` method
 
 @abravosuse min/max limits on the intervals have not been added as have a few questions:
  - Do we add the limits to all discoveries or just the subscription one?
  - What do you think about the default values? (10 for all execept subscription which is 900)
 
