### PR TITLE
Add missing units in the agent installer config template

### DIFF
--- a/install-agent.sh
+++ b/install-agent.sh
@@ -124,10 +124,10 @@ enable-mtls: @ENABLE_MTLS@
 cert: @CERT@
 key: @KEY@
 ca: @CA@
-cloud-discovery-period: @INTERVAL@
-cluster-discovery-period: @INTERVAL@
-host-discovery-period: @INTERVAL@
-sapsystem-discovery-period: @INTERVAL@
+cloud-discovery-period: @INTERVAL@s
+cluster-discovery-period: @INTERVAL@s
+host-discovery-period: @INTERVAL@s
+sapsystem-discovery-period: @INTERVAL@s
 '
 
 . /etc/os-release

--- a/packaging/config/agent.yaml
+++ b/packaging/config/agent.yaml
@@ -37,7 +37,7 @@
 ## Time unit is seconds
 ## Defaults to 10.
 
-# cloud-discovery-period: 10
+# cloud-discovery-period: 10s
 
 ###############################################################################
 
@@ -46,7 +46,7 @@
 ## Time unit is seconds
 ## Defaults to 10.
 
-# cluster-discovery-period: 10
+# cluster-discovery-period: 10s
 
 ###############################################################################
 
@@ -55,7 +55,7 @@
 ## Time unit is seconds
 ## Defaults to 10.
 
-# host-discovery-period: 10
+# host-discovery-period: 10s
 
 ###############################################################################
 
@@ -64,7 +64,7 @@
 ## Time unit is seconds
 ## Defaults to 10.
 
-# sapsystem-discovery-period: 10
+# sapsystem-discovery-period: 10s
 
 ###############################################################################
 


### PR DESCRIPTION
This is a small leftover from https://github.com/trento-project/trento/pull/881 as the installer template misses the now required units (otherwise it defaults to nanoseconds which do not pass the validation)