### PR TITLE
Changing search value and result comparison for check 1.1.9.runtime

### DIFF
--- a/runner/ansible/roles/checks/1.1.9.runtime/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.9.runtime/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: "{{ name }}.check"
   shell: |
-    INTERFACE_COUNT=$(corosync-cmapctl | grep totem.interface\\..*\.ttl | wc -l)
-    [[ ${INTERFACE_COUNT} -ge "2" ]] && exit 0
+    INTERFACE_COUNT=$(corosync-cmapctl | grep totem.interface\\..*\.bindnetaddr | wc -l)
+    [[ ${INTERFACE_COUNT} -eq "2" ]] && exit 0
     exit 1
   check_mode: false
   register: config_updated


### PR DESCRIPTION
this PR is improving the mechanism for the Trento check 1.1.9.runtime
* changing the search string for corosync runtime check
* changing the result comparison to equal, as we are looking exactly for 2 rings
This PR is solving  #891 