### PR TITLE
check 1.1.9 (DA114A): to scan node-directives for both rings

### DIFF
--- a/runner/ansible/roles/checks/1.1.9/tasks/main.yml
+++ b/runner/ansible/roles/checks/1.1.9/tasks/main.yml
@@ -2,8 +2,31 @@
 
 - name: "{{ name }}.check"
   shell: |
-    INTERFACE_COUNT=$(cat /etc/corosync/corosync.conf | grep interface | wc -l)
-    [[ $INTERFACE_COUNT -ge "2" ]] && exit 0
+    RING_CHECK=$(
+        perl  -n -e '
+        my $cont;
+        while (<>) {
+            # filter out lines beginnig with hash sign (optionally after whitespace)
+            if (! /^\W*#/ ) {
+                $cont .= $_;
+            }
+        }
+        my $node=0;
+        # search for all (sub)directives node { ... }
+        while ($cont =~ m/\bnode\W*{[^}]*}/gs) {
+            $node++;
+            my $nodeStr=$&;
+            # filter for key value pairs for ring adresses for ring0 and ring1
+            if ($nodeStr =~ /(ring0_addr:\W*(.*))\W*(ring1_addr:\W*(.*))\W*/g) {
+                if ( $2 ne "" and $4 ne "" ) {
+                    # report a "2", if both attributes are set with values
+                    print "2"
+                }
+            }
+        }
+        printf "\n"' < /etc/corosync/corosync.conf
+    )
+    [[ "$RING_CHECK" == "22" ]] && exit 0
     exit 1
   check_mode: false
   register: config_updated


### PR DESCRIPTION
Instead of counting the string "interface"  the test needs to scan the corosync.conf file for the directices node { ... }. There must be exact 2 such node-directives for the current se case and each of the entries needs exact two ring-addresses to be configured. 
The perl-snipset outputs a "2" per found node-directive (if exactly 2 rings are found). So the correct result following the best practice is "22" (both name-directives have exact two ring-address definitions).